### PR TITLE
Fix setup.py in order to force tf >= 2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["numpy", "tensorflow", "scipy", "cma"],
+    install_requires=["numpy", "tensorflow>=2.1.0", "scipy", "cma"],
     extras_require={
         "docs": ["sphinx_rtd_theme", "recommonmark", "sphinxcontrib-bibtex"]
     },


### PR DESCRIPTION
This addresses a installation problem pointed out by @GoGoKo699 when the tf version is lower than 2.1.0, in particular this error:
```
File "/home/guo/文档/TII/qibo/src/qibo/config.py", line 34, in <module>
    _available_cpus = tf.config.list_logical_devices("CPU")
AttributeError: module 'tensorflow._api.v2.config' has no attribute 'list_logical_devices'
```

Now setup.py should upgrade tensorflow to at least 2.1.0.