### PR TITLE
casting reshape index to tf.int64

### DIFF
--- a/src/qibo/base/cache.py
+++ b/src/qibo/base/cache.py
@@ -59,6 +59,9 @@ class BaseCache:
             self._calculate_density_matrix_controlled()
         return self._right0
 
+    def cast_shapes(self, cast_func):
+        pass
+
     def _calculate_density_matrix(self):
         """Calculates `left` and `right` elements."""
         raise NotImplementedError
@@ -171,6 +174,12 @@ class MatmulEinsumCache(BaseCache):
                                    self.transposed_shape,
                                    self.nqubits * (2,)),
                         "conjugate": False}
+
+    def cast_shapes(self, cast_func):
+        for attr in ["_vector", "_left", "_right", "_left0", "_right0"]:
+            d = getattr(self, attr)
+            if d is not None:
+                d["shapes"] = tuple(cast_func(s) for s in d["shapes"])
 
     def _calculate_density_matrix(self):
         self._left = {"ids": self.ids + [len(self.ids)],

--- a/src/qibo/tensorflow/einsum.py
+++ b/src/qibo/tensorflow/einsum.py
@@ -103,16 +103,13 @@ class MatmulEinsum:
   def __call__(self, cache: Dict, state: tf.Tensor,
                gate: tf.Tensor) -> tf.Tensor:
       shapes = cache["shapes"]
-      shape0 = tf.cast(shapes[0], dtype=tf.int64)
-      shape1 = tf.cast(shapes[1], dtype=tf.int64)
-      shape2 = tf.cast(shapes[2], dtype=tf.int64)
 
-      state = tf.reshape(state, shape0)
+      state = tf.reshape(state, shapes[0])
       state = tf.transpose(state, cache["ids"])
       if cache["conjugate"]:
-          state = tf.reshape(tf.math.conj(state), shape1)
+          state = tf.reshape(tf.math.conj(state), shapes[1])
       else:
-          state = tf.reshape(state, shape1)
+          state = tf.reshape(state, shapes[1])
 
       n = len(tuple(gate.shape))
       if n > 2:
@@ -121,7 +118,7 @@ class MatmulEinsum:
       else:
           state = tf.matmul(gate, state)
 
-      state = tf.reshape(state, shape2)
+      state = tf.reshape(state, shapes[2])
       state = tf.transpose(state, cache["inverse_ids"])
       state = tf.reshape(state, shapes[3])
       return state

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -62,6 +62,7 @@ class TensorflowGate(base_gates.Gate):
             self.calculation_cache = self.einsum.create_cache(targets, nactive, ncontrol=len(self.control_qubits))
         else:
             self.calculation_cache = self.einsum.create_cache(self.qubits, n)
+        self.calculation_cache.cast_shapes(lambda x: tf.cast(x, dtype=DTYPEINT))
 
     def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
                  ) -> tf.Tensor:


### PR DESCRIPTION
Fixes negative index when running more than 32 qubits.