### PR TITLE
removing --pre flag

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -18,12 +18,7 @@ jobs:
     - name: Update pip
       run: |
         python -m pip install --upgrade pip
-    - name: Install package python 3.8
-      if: matrix.python-version == '3.8'
-      run: |
-        pip install .[docs] --pre
-    - name: Install package python < 3.8
-      if: matrix.python-version != '3.8'
+    - name: Install package
       run: |
         pip install .[docs]
     - name: Lint with pylint


### PR DESCRIPTION
Given that tf2.2 is out we can remove and simply the workflow.