### PR TITLE
Fix for custom operators and autograph

### DIFF
--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
@@ -27,14 +27,22 @@ class InitialStateOp : public OpKernel {
 
   void Compute(OpKernelContext *context) override {
     // grabe the input tensor
-    Tensor input_tensor = context->input(0);
+    const Tensor& input_tensor = context->input(0);
+
+    // Create an output tensor
+    Tensor* output_tensor = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(0, input_tensor.shape(),
+                                                     &output_tensor));
+
+    // fill output
+    const auto N = input_tensor.flat<T>().size();
+    for (auto i = 0; i < N; i++)
+      output_tensor->flat<T>().data()[i] = input_tensor.flat<T>().data()[i];
 
     // call the implementation
     InitialStateFunctor<Device, T>()(
       context->eigen_device<Device>(),
-      input_tensor.flat<T>().data());
-
-    context->set_output(0, input_tensor);
+      output_tensor->flat<T>().data());
   }
 };
 

--- a/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
@@ -1,5 +1,5 @@
 #include "tensorflow/core/framework/op.h"
-#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/common_shape_fns.h"
 
 using namespace tensorflow;
 
@@ -7,10 +7,7 @@ REGISTER_OP("InitialState")
     .Attr("T: {complex64, complex128}")
     .Input("in: T")
     .Output("out: T")
-    .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
-      c->set_output(0, c->input(0));
-      return Status::OK();
-    });
+    .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
 #define REGISTER_GATE_OP(NAME)                                                \
   REGISTER_OP(NAME)                                                           \
@@ -21,10 +18,7 @@ REGISTER_OP("InitialState")
       .Attr("nqubits: int")                                                   \
       .Attr("target: int")                                                    \
       .Output("out: T")                                                       \
-      .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {    \
-        c->set_output(0, c->input(0));                                        \
-        return Status::OK();                                                  \
-      });
+      .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
 #define REGISTER_GATE_NOMATRIX_OP(NAME)                                       \
   REGISTER_OP(NAME)                                                           \
@@ -34,10 +28,7 @@ REGISTER_OP("InitialState")
       .Attr("nqubits: int")                                                   \
       .Attr("target: int")                                                    \
       .Output("out: T")                                                       \
-      .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {    \
-        c->set_output(0, c->input(0));                                        \
-        return Status::OK();                                                  \
-      });
+      .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
 REGISTER_GATE_OP("ApplyGate")
 REGISTER_GATE_OP("ApplyZPow")
@@ -53,7 +44,4 @@ REGISTER_OP("ApplySwap")
     .Attr("target1: int")
     .Attr("target2: int")
     .Output("out: T")
-    .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
-      c->set_output(0, c->input(0));
-      return Status::OK();
-    });
+    .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);


### PR DESCRIPTION
@stavros11 the main problem of the custom operators in #95 is that we are doing in place updates, thus the graphs are executed in parallel and take as input the values pointed by the array at the return value.

The solution to this problem is presented here, where we create an output object.
The tests are passing, however I am pretty sure we will see performance deterioration.

Could you please run your benchmark? If this approach is too slow, we may consider forcing disabling `tf.function` everywhere.