### PR TITLE
Fix multi-threading for one-qubit gates

### DIFF
--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -174,13 +174,13 @@ struct BaseTwoQubitGateFunctor<CPUDevice, T> {
 
     auto thread_pool =
         context->device()->tensorflow_cpu_worker_threads()->workers;
-    const int ncores = (int) thread_pool->NumThreads() / 2;
+    const int ncores = (int) thread_pool->NumThreads();
     int64 nreps;
     if (ncores > 1) {
       nreps = (int64) nstates / ncores;
     }
     else {
-      nreps = nstates;
+      nreps = 1;
     }
     const ThreadPool::SchedulingParams p(
         ThreadPool::SchedulingStrategy::kFixedBlockSize, absl::nullopt,


### PR DESCRIPTION
This implements an alternative approach to the one-qubit kernel that is similar to the two qubit one. Single-thread performance drops slightly but multi-threading is much more stable and the issues from #106 are fixed.

Personally I prefer this version because it performs better on multiple cores which is the case for most modern devices. It is only worse when one does `taskset -c 0` but I don't see any reason one would do that in actual applications (unless computational resources are limited). @scarrazza please check if this version makes porting to GPU any easier regarding the blocking.

Gate times comparison on single-thread:
| | 27 | 28 | 29 | 
-- | -- | -- | -- |
H master | 13.81504035 | 29.06866026 | 60.8791225 |  
H this | 15.23683453 | 32.05380964 | 67.40500569 |  
Z master | 3.693949461 | 7.666159153 | 15.75709271 |  
Z this | 5.120784998 | 10.5700171 | 21.89049649 |  
CZPow master | 3.201692343 | 6.567142487 | 13.50676394 |  
CZPow this | 4.30229497 | 8.94386816 | 18.4590919 |  
CNOT master | 2.99245739 | 6.197901964 | 12.74487662 |  
CNOT this | 3.976273775 | 8.206417084 | 16.95376229 |  

Gate times comparison on 36 threads:
| | 27 | 28 | 29 | 30 
-- | -- | -- | -- | -- |
H master | 2.48870945 | 4.234880924 | 19.64204836 | 39.52432489
H this | 1.351120472 | 2.76094532 | 5.816787004 | 11.93648005
Z master | 1.6392138 | 2.437001228 | 16.69101334 | 33.31007671
Z this | 0.8173494339 | 1.661530256 | 3.406300783 | 6.940683126
CZPow master | 1.371021032 | 1.945347309 | 3.134688854 | 17.61731458
CZPow this | 0.5762004852 | 1.118975878 | 2.250274658 | 4.575408936
CNOT master | 1.513159752 | 2.27933979 | 3.87240386 | 19.06164122
CNOT this | 0.7744123936 | 1.586816072 | 3.242152929 | 6.657937765

Variational circuit from #106 using 36 threads:
| | 27 | 28 | 29 | 30 
-- | -- | -- | -- | -- |
master (all gates) | 6.250109434 | 10.25957799 | 42.19182372 | 102.6262238
this (all gates) | 3.190833807 | 6.611063242 | 13.26968336 | 27.88768148
master (gate union) | 1.816077948 | 3.328910828 | 12.65422797 | 24.35796618
this (gate union) | 1.493907213 | 3.008334637 | 5.823143959 | 11.49829507