### PR TITLE
Repeated target or control qubit checks

### DIFF
--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -116,11 +116,12 @@ class DeviceQueues:
         """
         calc_gate = copy.copy(gate)
         # Recompute the target/control indices considering only local qubits.
-        calc_gate.target_qubits = tuple(q - self.reduction_number(q)
-                                        for q in calc_gate.target_qubits)
-        calc_gate.control_qubits = tuple(q - self.reduction_number(q)
-                                         for q in calc_gate.control_qubits
-                                         if q not in self.global_qubits_set)
+        new_target_qubits = tuple(q - self.reduction_number(q)
+                                  for q in calc_gate.target_qubits)
+        new_control_qubits = tuple(q - self.reduction_number(q)
+                                   for q in calc_gate.control_qubits
+                                   if q not in self.global_qubits_set)
+        calc_gate.set_targets_and_controls(new_target_qubits, new_control_qubits)
         calc_gate.original_gate = gate
         return calc_gate
 
@@ -193,10 +194,11 @@ class DeviceQueues:
 
         # Modify gates to take into account the swaps
         for gate in new_remaining_queue:
-            gate.target_qubits = tuple(qubit_map[q] if q in qubit_map else q
+            new_target_qubits = tuple(qubit_map[q] if q in qubit_map else q
                                        for q in gate.target_qubits)
-            gate.control_qubits = tuple(qubit_map[q] if q in qubit_map else q
+            new_control_qubits = tuple(qubit_map[q] if q in qubit_map else q
                                         for q in gate.control_qubits)
+            gate.set_targets_and_controls(new_target_qubits, new_control_qubits)
 
         return self._transform(queue, new_remaining_queue, counter)
 

--- a/src/qibo/tests/test_base.py
+++ b/src/qibo/tests/test_base.py
@@ -228,6 +228,10 @@ def test_gate_with_repeated_qubits():
         gate = SWAP(0, 0)
     with pytest.raises(ValueError):
         gate = H(0).controlled_by(1, 2, 3, 1)
+    with pytest.raises(ValueError):
+        gate = CNOT(1, 1)
+    with pytest.raises(ValueError):
+        gate = Y(1).controlled_by(0, 1, 2)
 
 
 def test_gates_commute():


### PR DESCRIPTION
Closes #144. Added checks that target and control qubits are not repeated and that there is no overlap between target and control qubits for the same gate. If the user tries to add an invalid gate a `ValueError` will be raised to prevent dying kernels.