### PR TITLE
Measurement CPU fall back to avoid Aborted error

### DIFF
--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -228,7 +228,7 @@ class M(TensorflowGate, base_gates.M):
                                          dtype=DTYPES.get('DTYPEINT'))[0]
 
         device = DEVICES['DEFAULT']
-        if np.log2(nshots) + self.nqubits > 31: # pragma: no cover
+        if np.log2(nshots) + len(self.target_qubits) > 31: # pragma: no cover
             # Use CPU to avoid "aborted" error
             device = self._get_cpu()
 


### PR DESCRIPTION
Temporary fix for the aborted problem that appears in GPUs with 32GB memory and is described in #174. Measurements will fall back to CPU whenever the dimension of the `logits` tensor that is used in `tf.random.categorical` is larger than the supported by int32. I tested on DGX and it seems to work.