### PR TITLE
updating optimization level to 3

### DIFF
--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -20,9 +20,9 @@ SOURCES = $(filter-out $(CUDASRC), $(SRCS))
 TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
-CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
+CFLAGS = ${TF_CFLAGS} -fPIC -O3 -std=c++11
 CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
-CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
+CFLAGS_NVCC = ${TF_CFLAGS} -O3 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 
 LDFLAGS = -shared ${TF_LFLAGS}
 LDFLAGS_CUDA = $(LDFLAGS) -L$(CUDA_PATH)/lib64 -lcudart


### PR DESCRIPTION
Tests are passing with optimization level 3, so we may prefer to use this option by default.
@stavros11 could you please give a quick look at the benchmark results using this PR?
If the numbers improve then we can merge this PR.