### PR TITLE
adding eigenvector method to Hamiltonian class

### DIFF
--- a/src/qibo/hamiltonians.py
+++ b/src/qibo/hamiltonians.py
@@ -135,7 +135,7 @@ class Hamiltonian(object):
                     r._eigenvectors = self._eigenvectors
                 elif o.real == 0:
                     r._eigenvectors = K.eye(
-                        self._eigenvectors.shape, dtype=self.hamiltonian.dtype)
+                        self._eigenvectors.shape[0], dtype=self.hamiltonian.dtype)
             return r
         else:
             raise NotImplementedError(f'Hamiltonian multiplication to {type(o)} '

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -117,3 +117,9 @@ def test_hamiltonian_eigenvectors(dtype):
     V3 = H3.eigenvectors().numpy()
     U3 = H3._eigenvalues.numpy()
     np.testing.assert_allclose(H3.hamiltonian, V3 @ np.diag(U3) @ V3.T)
+
+    c3 = dtype(0)
+    H4 = c3 * H1
+    V4 = H4._eigenvectors.numpy()
+    U4 = H4._eigenvalues.numpy()
+    np.testing.assert_allclose(H4.hamiltonian, V4 @ np.diag(U4) @ V4.T)


### PR DESCRIPTION
Closes #182 . For now the eigenvector method should be re-called when multiplying the hamiltonian by a negative scalar.