### PR TITLE
Change "name" to "dataset" in reuploading example

### DIFF
--- a/examples/reuploading_classifier/README.md
+++ b/examples/reuploading_classifier/README.md
@@ -39,7 +39,7 @@ In this example there are only three files
 - `main.py` is the file calling all other functions. The action of every line of code is commented in the source code.
 
 The parameters to be fixed for a run of the experiment are
-- name: problem to solve, to choose between `['circle', '3_circles', 'square', '4_squares', 'crown', 'tricrown', 'wavy_lines']`
+- dataset: problem to solve, to choose between `['circle', '3_circles', 'square', '4_squares', 'crown', 'tricrown', 'wavy_lines']`
 - layers: layers of the classifier
 
 Every time the `main.py` is run, it checks whether there is a solution to that particular problem. If it has been

--- a/examples/reuploading_classifier/main.py
+++ b/examples/reuploading_classifier/main.py
@@ -6,32 +6,32 @@ import pickle
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--name", default='tricrown',
+parser.add_argument("--dataset", default='tricrown',
                     help="Name of the example", type=str)
 parser.add_argument("--layers", default=10, help="Number of layers.", type=int)
 
 
-def main(name, layers):
+def main(dataset, layers):
     """Perform classification for a given problem and number of layers.
 
     Args:
-        name (str): Name of the problem to create the dataset, to choose between
+        dataset (str): Problem to create the dataset, to choose between
             ['circle', '3_circles', 'square', '4_squares', 'crown', 'tricrown', 'wavy_lines']
         layers (int): Number of layers to use in the classifier
     """
-    ql = single_qubit_classifier(name, layers)  # Define classifier
+    ql = single_qubit_classifier(dataset, layers)  # Define classifier
     with open('saved_parameters.pkl', 'rb') as f:
         # Load previous results. Have we ever run these problem?
         data = pickle.load(f)
     try:
-        parameters = data[name][layers]
+        parameters = data[dataset][layers]
         print('Problem solved before, obtaining parameters from file...')
         print('-'*60)
     except:
         print('Problem never solved, finding optimal parameters...')
         result, parameters = ql.minimize(
             method='l-bfgs-b', options={'disp': True})
-        data[name][layers] = parameters
+        data[dataset][layers] = parameters
         with open('saved_parameters.pkl', 'wb') as f:
             pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
 


### PR DESCRIPTION
Fixes #172. It seems that using `name` as a variable name causes some issues on a very specific Python / library configuration that is quite hard to reproduce. It is probably safer to use a different name to avoid problems with other users.

@GoGoKo699, please make sure that this version works for you.