### PR TITLE
Fix re-execution of circuit with density matrices

### DIFF
--- a/src/qibo/tensorflow/circuit.py
+++ b/src/qibo/tensorflow/circuit.py
@@ -85,6 +85,7 @@ class TensorflowCircuit(circuit.BaseCircuit):
     def _execute(self, initial_state: Optional[InitStateType] = None,
                  nshots: Optional[int] = None) -> OutputType:
         """Performs ``circuit.execute`` on specified device."""
+        self.using_density_matrix = False
         state = self._cast_initial_state(initial_state)
 
         if self.using_tfgates:

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -282,6 +282,22 @@ def test_circuit_switch_to_density_matrix(backend):
 
 
 @pytest.mark.parametrize("backend", _EINSUM_BACKENDS)
+def test_circuit_reexecution(backend):
+    """Test re-executing a circuit with `gates.NoiseChnanel`."""
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    c = models.Circuit(2)
+    c.add(gates.H(0))
+    c.add(gates.H(1))
+    c.add(gates.NoiseChannel(0, px=0.5))
+    c.add(gates.NoiseChannel(1, pz=0.3))
+    final_rho = c().numpy()
+    final_rho2 = c().numpy()
+    np.testing.assert_allclose(final_rho, final_rho2)
+    qibo.set_backend(original_backend)
+
+
+@pytest.mark.parametrize("backend", _EINSUM_BACKENDS)
 def test_general_channel(backend):
     """Test `gates.GeneralChannel`."""
     original_backend = qibo.get_backend()


### PR DESCRIPTION
Fixes #196. There was a bug in Qibo when re-executing a circuit that starts from state vector but switches to density matrices when noise gates are found. This bug should be fixed and tested by this PR.

The 3_tangle example started crashing because of this bug when we implemented the `set_parameters` method. Before implementing this method the circuit was being re-constructed in each repetition so it wasn't affected by the bug. After `set_parameters` the same circuit was being re-used every time and that's why the problem appeared.

I will add some tests that check that all advanced examples work, either in this or in a different PR.