### PR TITLE
[WIP] Benchmarks based on pytest-benchmarks

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -32,11 +32,11 @@ jobs:
         pylint src -E -d E1123,E1120
     - name: Test with pytest core
       run: |
-        pytest --cov=qibo --cov-report=xml --pyargs qibo
+        pytest --cov=qibo --cov-report=xml --pyargs qibo --ignore examples/benchmarks
     - name: Test examples
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.8'
       run: |
-        pytest examples/
+        pytest examples/ --ignore examples/benchmarks
     - name: Upload coverage to Codecov
       if: startsWith(matrix.os, 'ubuntu')
       uses: codecov/codecov-action@v1

--- a/examples/benchmarks/conftest.py
+++ b/examples/benchmarks/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+BACKENDS = ["custom"]
+
+PRECISIONS = ["single", "double"]
+
+NSHOTS = [int(1e3), int(1e5)]
+
+# Set these according to machine specs
+# or use parser?
+NQUBITS = [10, 15]
+NQUBITS_DISTRIBUTED = [(n, None) for n in NQUBITS]
+# list of (nqubits, accelerators)
+NQUBITS_DISTRIBUTED.extend([(20, {"/GPU:0": 1, "/GPU:1": 1})])
+
+
+def pytest_generate_tests(metafunc):
+    if "accelerators" in metafunc.fixturenames:
+        assert "nqubits" in metafunc.fixturenames
+        metafunc.parametrize("nqubits,accelerators", NQUBITS_DISTRIBUTED)
+    else:
+        if "nqubits" in metafunc.fixturenames:
+            metafunc.parametrize("nqubits", NQUBITS)
+
+    if "backend" in metafunc.fixturenames:
+        metafunc.parametrize("backend", BACKENDS)
+    if "precision" in metafunc.fixturenames:
+        metafunc.parametrize("precision", PRECISIONS)
+    if "nshots" in metafunc.fixturenames:
+        metafunc.parametrize("nshots", NSHOTS)

--- a/examples/benchmarks/test_benchmark.py
+++ b/examples/benchmarks/test_benchmark.py
@@ -1,0 +1,26 @@
+import pytest
+import qibo
+from qibo import models, gates
+
+
+def test_qft_create(benchmark, nqubits, accelerators, backend, precision):
+    qibo.set_backend(backend)
+    qibo.set_precision(precision)
+    circuit = benchmark(models.QFT, nqubits, accelerators)
+
+
+def test_qft_execute(benchmark, nqubits, accelerators, backend, precision):
+    qibo.set_backend(backend)
+    qibo.set_precision(precision)
+    circuit = models.QFT(nqubits, accelerators)
+    result = benchmark(circuit)
+
+
+def test_frequency_sampling(benchmark, nqubits, nshots, backend, precision):
+    qibo.set_backend(backend)
+    qibo.set_precision(precision)
+    circuit = models.Circuit(nqubits)
+    circuit.add((gates.H(i) for i in range(nqubits)))
+    circuit.add(gates.M(*range(nqubits)))
+    result = circuit(nshots=nshots)
+    result = benchmark(result.frequencies)


### PR DESCRIPTION
Adds some basic functionality to perform benchmarks using the [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/en/latest/index.html) library. Currently only QFT and measurement frequency benchmarks are included, however we can easily extend this with other circuits.

The benchmark configurations should be set according to the used machine in `conftest.py`, by modifying the `NQUBITS` and `NQUBITS_DISTRIBUTED` lists. The benchmarks can be executed using:
```console
pytest examples/benchmarks --benchmark-save=benchmark_name
```



