### PR TITLE
Fix `set_device` test for GPU

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -41,7 +41,7 @@ jobs:
       run: |
         pytest --cov=qibo --cov-report=xml --pyargs qibo
     - name: Test examples
-      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.8'
+      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'
       run: |
         pytest examples/
     - name: Upload coverage to Codecov

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -157,7 +157,7 @@ Installing with pip
 
 The installation using ``pip`` is the recommended approach to install
 ``qibotf``. We provide precompiled packages for linux x86/64 and macosx 10.15 or
-greater for Python 3.6, 3.7 and 3.8.
+greater for Python 3.6, 3.7, 3.8 and 3.9.
 
 In order to install the package use the following command:
 
@@ -197,7 +197,7 @@ then proceed with the installation of requirements with:
 
       pip install -r requirements.txt
 
-Make sure your system has a GNU ``g++ >= 6`` compiler. If you are working on
+Make sure your system has a GNU ``g++ >= 4`` compiler. If you are working on
 macosx make sure the command ``c++`` is ``clang >= 11`` and install the libomp
 library with ``brew install libomp`` command.
 
@@ -218,11 +218,11 @@ path.
 
       3. make sure the NVCC compiler is available from ``CUDA_PATH/bin/nvcc``, otherwise the compilation may fail. You can locate it with ``whereis nvcc`` and eventually link/copy to your ``CUDA_PATH/bin`` folder.
 
-      For example, TensorFlow 2.4 supports CUDA 11. After installing
-      TensorFlow proceed with the NVCC 11 installation. On linux the
-      installation path usually is ``/usr/local/cuda-11/``.
+      For example, TensorFlow 2.5.0 supports CUDA 11.2. After installing
+      TensorFlow proceed with the NVCC 11.2 installation. On linux the
+      installation path usually is ``/usr/local/cuda-11.2/``.
 
-      Before installing Qibo do ``export CUDA_PATH=/usr/local/cuda-11``.
+      Before installing Qibo do ``export CUDA_PATH=/usr/local/cuda-11.2``.
 
       Note that Qibo will not enable GPU support if points 1 and 2 are not
       performed.

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -188,10 +188,14 @@ def parallel_parametrized_execution(circuit, parameters, initial_state=None, pro
 
 def _check_parallel_configuration(processes):
     """Check if configuration is suitable for efficient parallel execution."""
-    import psutil
-    from qibo import get_device
+    import os, psutil
+    from qibo import get_device, get_backend
     from qibo.config import raise_error, get_threads, log
     device = get_device()
+    if os.name == "nt":  # pragma: no cover
+        raise_error(RuntimeError, "Parallel evaluations not supported on Windows.")
+    if get_backend() == "tensorflow":  # pragma: no cover
+        raise_error(RuntimeError, "tensorflow backend does not support parallel evaluations.")
     if device is not None and "GPU" in device:  # pragma: no cover
         raise_error(RuntimeError, "Parallel evaluations cannot be used with GPU.")
     if ((processes is not None and processes * get_threads() > psutil.cpu_count()) or

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -84,7 +84,7 @@ def test_set_precision_errors(backend):
 
 
 def test_set_device(backend):
-    original_device = backends.get_device()
+    original_devices = {bk: bk.default_device for bk in K.constructed_backends.values()}
     if backends.get_backend() == "numpy":
         with pytest.warns(RuntimeWarning):
             backends.set_device("/CPU:0")
@@ -99,8 +99,8 @@ def test_set_device(backend):
             backends.set_device("/gpu:10")
         with pytest.raises(ValueError):
             backends.set_device("/GPU:10")
-    if original_device:
-        backends.set_device(original_device)
+    for bk, device in original_devices.items():
+        bk.set_device(device)
 
 
 def test_set_shot_batch_size():

--- a/src/qibo/tests/test_models_variational.py
+++ b/src/qibo/tests/test_models_variational.py
@@ -94,6 +94,8 @@ def test_vqe(backend, method, options, compile, filename):
 
     if method == 'parallel_L-BFGS-B':
         device = qibo.get_device()
+        if qibo.get_backend() == "tensorflow":
+            pytest.skip("unsupported backend")
         if device is not None and "GPU" in device: # pragma: no cover
             pytest.skip("unsupported configuration")
         import os

--- a/src/qibo/tests/test_parallel.py
+++ b/src/qibo/tests/test_parallel.py
@@ -12,7 +12,7 @@ from qibo.parallel import parallel_parametrized_execution, parallel_execution
 
 def test_parallel_circuit_evaluation(backend):
     """Evaluate circuit for multiple input states."""
-    if 'GPU' in qibo.get_device() or os.name == 'nt': # pragma: no cover
+    if 'GPU' in qibo.get_device() or os.name == 'nt' or qibo.get_backend() == "tensorflow": # pragma: no cover
         pytest.skip("unsupported configuration")
     original_threads = qibo.get_threads()
     qibo.set_threads(1)
@@ -34,7 +34,7 @@ def test_parallel_circuit_evaluation(backend):
 
 def test_parallel_parametrized_circuit(backend):
     """Evaluate circuit for multiple parameters."""
-    if 'GPU' in qibo.get_device() or os.name == 'nt': # pragma: no cover
+    if 'GPU' in qibo.get_device() or os.name == 'nt' or qibo.get_backend() == "tensorflow": # pragma: no cover
         pytest.skip("unsupported configuration")
     original_threads = qibo.get_threads()
     qibo.set_threads(1)


### PR DESCRIPTION
Fixes #415. It seems that the issue comes from a `set_device` test that does not reset the device properly back to GPU when it runs for the numpy backend. All tests now work both on CPU and GPU for me. @scarrazza please confirm that it is okay for you too.