### PR TITLE
Hamiltonian expectation using terms

### DIFF
--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -676,7 +676,7 @@ to the state vector. For more information on how solvers work we refer to the
 :ref:`How to simulate time evolution? <timeevol-example>` section.
 When a :class:`qibo.abstractions.hamiltonians.Hamiltonian` is used then solvers will
 exponentiate it using its full matrix. Alternatively, if a
-:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` is used then solvers
+:class:`qibo.core.hamiltonians.TrotterHamiltonian` is used then solvers
 will fall back to traditional Qibo circuits that perform Trotter steps. For
 more information on how the Trotter decomposition is implemented in Qibo we
 refer to the :ref:`Using Trotter decomposition <trotterdecomp-example>` example.
@@ -1141,7 +1141,7 @@ functionality to perform this transformation automatically, if the underlying
 Hamiltonian object is defined as a sum of commuting parts that consist of terms
 that can be exponentiated efficiently.
 Such Hamiltonian can be implemented in Qibo using
-:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`.
+:class:`qibo.core.hamiltonians.TrotterHamiltonian`.
 The implementation of Trotter decmoposition is based in Sec.
 4.1 of `arXiv:1901.05824 <https://arxiv.org/abs/1901.05824>`_.
 Below is an example of how to use this object in practice:
@@ -1163,7 +1163,7 @@ exponentials of the Trotter decomposition and can be executed on any state.
 
 Note that in the transverse field Ising model (TFIM) that was used in this
 example is among the pre-coded Hamiltonians in Qibo and could be created as
-a :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` simply using the
+a :class:`qibo.core.hamiltonians.TrotterHamiltonian` simply using the
 ``trotter`` flag. Defining custom Hamiltonians can be more complicated, however
 Qibo simplifies this process by providing the option to define Hamiltonians
 symbolically through the use of ``sympy``. For more information on this we
@@ -1171,11 +1171,11 @@ refer to the
 :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
 example.
 
-A :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` can also be used to
+A :class:`qibo.core.hamiltonians.TrotterHamiltonian` can also be used to
 simulate time evolution. This can be done by passing the Hamiltonian to a
 :class:`qibo.evolution.StateEvolution` model and using the exponential solver.
 Qibo automatically finds that this Hamiltonian is a
-:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` object
+:class:`qibo.core.hamiltonians.TrotterHamiltonian` object
 and uses the Trotter decomposition to perform the evolution.
 For example:
 
@@ -1281,7 +1281,7 @@ used for simulating adiabatic evolution. The solver can be specified during the
 initialization of the :class:`qibo.models.AdiabaticEvolution` model and a
 Trotter decomposition may be used with the exponential solver. The Trotter
 decomposition will be used automatically if ``h0`` and ``h1`` are defined
-using as :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` objects. For
+using as :class:`qibo.core.hamiltonians.TrotterHamiltonian` objects. For
 pre-coded Hamiltonians this can be done simply as:
 
 .. code-block::  python
@@ -1302,16 +1302,16 @@ devices by passing an ``accelerators`` dictionary in the creation of the
 :class:`qibo.evolution.AdiabaticEvolution` model.
 
 Note that ``h0`` and ``h1`` should have the same type, either both
-:class:`qibo.abstractions.hamiltonians.Hamiltonian` or both
-:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`.
-When :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` is used, then ``h0`` and
+:class:`qibo.core.hamiltonians.Hamiltonian` or both
+:class:`qibo.core.hamiltonians.TrotterHamiltonian`.
+When :class:`qibo.core.hamiltonians.TrotterHamiltonian` is used, then ``h0`` and
 ``h1`` should also have the same part structure, otherwise it will not be
 possible to add them in order to create the total Hamiltonian. For more
 information on this we refer to
-:meth:`qibo.abstractions.hamiltonians.TrotterHamiltonian.is_compatible`.
+:meth:`qibo.core.hamiltonians.TrotterHamiltonian.is_compatible`.
 If the given Hamiltonians do not have the same part structure and ``h0``
 consists of one-body terms only then Qibo will use an automatic algorithm
-(:meth:`qibo.abstractions.hamiltonians.TrotterHamiltonian.make_compatible`)
+(:meth:`qibo.core.hamiltonians.TrotterHamiltonian.make_compatible`)
 to rearrange the terms of ``h0`` so that it matches the part structure of ``h1``.
 It is important to note that in some applications making ``h0`` and ``h1``
 compatible manually may take better advantage of caching and lead to better
@@ -1359,8 +1359,8 @@ How to define custom Hamiltonians using symbols?
 ------------------------------------------------
 
 In order to use the VQE, QAOA and time evolution models in Qibo the user has to
-define Hamiltonians based on :class:`qibo.abstractions.hamiltonians.Hamiltonian`, or
-:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` when the Trotter
+define Hamiltonians based on :class:`qibo.abstractions.hamiltonians.AbstractHamiltonian`, or
+:class:`qibo.core.hamiltonians.TrotterHamiltonian` when the Trotter
 decomposition is to be used. Qibo provides pre-coded Hamiltonians for some
 common physics models, such as the transverse field Ising model (TFIM) and the
 Heisenberg model (see :ref:`Hamiltonians <Hamiltonians>` for a complete list
@@ -1395,54 +1395,47 @@ corresponding 16x16 matrix:
 Although it is possible to generalize the above construction to arbitrary number
 of qubits this procedure may be more complex for other Hamiltonians. Moreover
 constructing the full matrix does not scale well with increasing the number of
-qubits. This makes the use of :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`
-preferrable as the qubit number increases, as these Hamiltonians are not based
-in the full matrix representation. On the other hand a
-:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` is more complicated to
-construct for an arbitrary Hamiltonian.
+qubits. This makes the use of :class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian`
+preferrable as the qubit number increases, as this Hamiltonians is not based
+in the full matrix representation.
 
 To simplify the construction of Hamiltonians, Qibo provides the
-:meth:`qibo.abstractions.hamiltonians.Hamiltonian.from_symbolic` and
-:meth:`qibo.abstractions.hamiltonians.TrotterHamiltonian.from_symbolic` methods which
-allow the user to construct Hamiltonian objects by writing their symbolic
-form using ``sympy`` symbols. For example, the TFIM on four qubits could be
-constructed as:
+:class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian` object which
+allows the user to construct Hamiltonian objects by writing their symbolic
+form using ``sympy`` symbols. Moreover Qibo provides quantum-computation specific
+symbols (:class:`qibo.symbols.Symbol`) such as the Pauli operators.
+For example, the TFIM on four qubits could be constructed as:
 
 .. code-block::  python
 
-    import sympy
     import numpy as np
-    from qibo import hamiltonians, matrices
+    from qibo import hamiltonians
+    from qibo.symbols import X, Z
 
-    # Define symbols for X and Z operators
-    Z = sympy.symbols("Z0 Z1 Z2 Z3")
-    X = sympy.symbols("X0 X1 X2 X3")
-
-    # Define Hamiltonian using these symbols
+    # Define Hamiltonian using Qibo symbols
     # ZZ terms
-    symbolic_ham = sum(Z[i] * Z[i + 1] for i in range(3))
+    symbolic_ham = sum(Z(i) * Z(i + 1) for i in range(3))
     # periodic boundary condition term
-    symbolic_ham += Z[0] * Z[-1]
+    symbolic_ham += Z(0) * Z(3)
     # X terms
-    symbolic_ham += sum(X)
+    symbolic_ham += sum(X(i) for in range(4))
 
-    # Define a map from symbols to actual matrices
-    symbol_map = {s: (i, matrices.X) for i, s in enumerate(X)}
-    symbol_map.update({s: (i, matrices.Z) for i, s in enumerate(Z)})
+    # Define a Hamiltonian using the above form
+    ham = hamiltonians.SymbolicHamiltonian(symbolic_ham)
+    # This Hamiltonian is memory efficient as it does not construct the full matrix
 
-    # Define a dense Hamiltonian
-    ham = hamiltonians.Hamiltonian.from_symbolic(symbolic_ham, symbol_map)
-    # This Hamiltonian automatically constructs the full matrix which can be
-    # accessed as ``ham.matrix``.
-
-    # Define a more memory-friendly Trotter Hamiltonian
-    trotter_ham = hamiltonians.TrotterHamiltonian.from_symbolic(symbolic_ham, symbol_map)
+    # The corresponding dense Hamiltonian which contains the full matrix can
+    # be constructed easily as
+    dense_ham = ham.dense
+    # and the matrix is accessed as ``dense_ham.matrix`` or ``ham.matrix``.
 
 
 Defining Hamiltonians from symbols is usually a simple process as the symbolic
 form is very close to the form of the Hamiltonian on paper. Note that in the
-case of :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`, Qibo handles
+case of :class:`qibo.core.hamiltonians.TrotterHamiltonian`, Qibo handles
 automatically the Trotter decomposition by splitting to the appropriate terms.
+In order to construct ``TrotterHamiltonian`` from symbols one can use the
+:meth:`qibo.core.hamiltonians.TrotterHamiltonian.from_symbolic` method.
 
 As noted in the :ref:`How to simulate adiabatic time evolution? <adevol-example>`,
 when using Trotter decomposition to simulate adiabatic evolution, then ``h0``
@@ -1451,7 +1444,7 @@ This is usually not true when constructing Hamiltonians using symbols.
 However, if the constructed Hamiltonians are not compatible but ``h0`` consists
 of one-body terms only (which is the case in most adiabatic evolution
 applications) then Qibo will use an automatic algorithm
-(:meth:`qibo.abstractions.hamiltonians.TrotterHamiltonian.make_compatible`) to make it
+(:meth:`qibo.core.hamiltonians.TrotterHamiltonian.make_compatible`) to make it
 compatible to ``h1``. We note that in some applications, making the Hamiltonians
 compatible  manually instead of relying on the automatic functionality,
 may take better advantage of caching compared and lead to better execution

--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -466,6 +466,7 @@ Thermal relaxation channel
 
 _______________________
 
+
 .. _Hamiltonians:
 
 Hamiltonians
@@ -576,6 +577,34 @@ Max Cut
 ^^^^^^^
 
 .. autoclass:: qibo.hamiltonians.MaxCut
+    :members:
+    :member-order: bysource
+
+_______________________
+
+
+.. _Symbols:
+
+Symbols
+-------
+
+Qibo provides a basic set of symbols which inherit the ``sympy.Symbol`` object
+and can be used to construct :class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian`
+objects as described in the previous section.
+
+.. autoclass:: qibo.symbols.Symbol
+    :members:
+    :member-order: bysource
+
+.. autoclass:: qibo.symbols.X
+    :members:
+    :member-order: bysource
+
+.. autoclass:: qibo.symbols.Y
+    :members:
+    :member-order: bysource
+
+.. autoclass:: qibo.symbols.Z
     :members:
     :member-order: bysource
 

--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -473,17 +473,46 @@ Hamiltonians
 
 The main abstract Hamiltonian object of Qibo is:
 
-.. autoclass:: qibo.abstractions.hamiltonians.Hamiltonian
+.. autoclass:: qibo.abstractions.hamiltonians.AbstractHamiltonian
     :members:
     :member-order: bysource
 
-In addition to the abstract model, Qibo provides the following pre-coded
-Hamiltonians:
 
-.. note::
-    Note that all pre-coded Hamiltonians can be created as either
-    :class:`qibo.abstractions.hamiltonians.Hamiltonian` or
-    :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` using the ``trotter`` flag.
+Matrix Hamiltonian
+^^^^^^^^^^^^^^^^^^
+
+The first implementation of Hamiltonians uses the full matrix representation
+of the Hamiltonian operator in the computational basis. This matrix has size
+``(2 ** nqubits, 2 ** nqubits)`` and therefore its construction is feasible
+only when number of qubits is small.
+
+.. autoclass:: qibo.abstractions.hamiltonians.MatrixHamiltonian
+    :members:
+    :member-order: bysource
+
+.. autoclass:: qibo.core.hamiltonians.Hamiltonian
+    :members:
+    :member-order: bysource
+
+
+Symbolic Hamiltonian
+^^^^^^^^^^^^^^^^^^^^
+
+Qibo allows the user to define Hamiltonians using ``sympy`` symbols. In this
+case the full Hamiltonian matrix is not constructed unless it is required
+for specific operations, making the implementation more efficient for larger
+qubit numbers. For more information on constructing Hamiltonians using symbols
+we refer to the
+:ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>` example.
+
+.. autoclass:: qibo.abstractions.hamiltonians.SymbolicHamiltonian
+    :members:
+    :member-order: bysource
+
+.. autoclass:: qibo.core.hamiltonians.SymbolicHamiltonian
+    :members:
+    :member-order: bysource
+
 
 Trotter Hamiltonian
 ^^^^^^^^^^^^^^^^^^^
@@ -494,9 +523,19 @@ Trotter decomposition. The Hamiltonians represented by this object are sums of
 commuting terms, following the description of Sec. 4.1 of
 `arXiv:1901.05824 <https://arxiv.org/abs/1901.05824>`_.
 
-.. autoclass:: qibo.abstractions.hamiltonians.TrotterHamiltonian
+.. autoclass:: qibo.core.hamiltonians.TrotterHamiltonian
     :members:
     :member-order: bysource
+
+
+In addition to the above abstract models, Qibo provides the following pre-coded
+Hamiltonians:
+
+.. note::
+    Note that all pre-coded Hamiltonians can be created as either
+    :class:`qibo.abstractions.hamiltonians.Hamiltonian` or
+    :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` using the ``trotter`` flag.
+
 
 Heisenberg XXZ
 ^^^^^^^^^^^^^^

--- a/examples/adiabatic3sat/main.py
+++ b/examples/adiabatic3sat/main.py
@@ -44,8 +44,8 @@ def main(nqubits, instance, T, dt, solver, plot, trotter, params,
         H1 = hamiltonians.TrotterHamiltonian.from_symbolic(sh1, smap1)
     else:
         print('Using the full Hamiltonian evolution\n')
-        H0 = hamiltonians.Hamiltonian.from_symbolic(sh0, smap0)
-        H1 = hamiltonians.Hamiltonian.from_symbolic(sh1, smap1)
+        H0 = hamiltonians.Hamiltonian.from_symbolic(sh0, smap0).dense
+        H1 = hamiltonians.Hamiltonian.from_symbolic(sh1, smap1).dense
 
     print('-'*20+'\n')
     if plot and nqubits >= 14:

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.6-dev"
+__version__ = "0.1.6rc0"
 from qibo.config import set_threads, get_threads, set_batch_size, get_batch_size
 from qibo.backends import set_precision, set_backend, set_device
 from qibo.backends import get_backend, get_precision, get_device

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.6rc0"
+__version__ = "0.1.6.dev1"
 from qibo.config import set_threads, get_threads, set_batch_size, get_batch_size
 from qibo.backends import set_precision, set_backend, set_device
 from qibo.backends import get_backend, get_precision, get_device

--- a/src/qibo/abstractions/abstract_gates.py
+++ b/src/qibo/abstractions/abstract_gates.py
@@ -513,6 +513,15 @@ class BaseBackendGate(Gate, ABC):
         """Applies the gate on a density matrix."""
         raise_error(NotImplementedError)
 
+    @abstractmethod
+    def density_matrix_half_call(self, state): # pragma: no cover
+        """Half application of gate to density matrix.
+
+        Useful for :class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian`
+        multiplication to density matrices.
+        """
+        raise_error(NotImplementedError)
+
     def __call__(self, state):
         """Applies the gate on a state.
 

--- a/src/qibo/abstractions/abstract_gates.py
+++ b/src/qibo/abstractions/abstract_gates.py
@@ -517,8 +517,20 @@ class BaseBackendGate(Gate, ABC):
     def density_matrix_half_call(self, state): # pragma: no cover
         """Half application of gate to density matrix.
 
-        Useful for :class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian`
-        multiplication to density matrices.
+        For an arbitrary unitary gate U the
+        :meth:`qibo.abstractions.abstract_gates.BaseBackendGate.density_matrix_call`
+        calculates
+
+        .. math::
+            U\\rho U^\\dagger
+
+        while this method calculates only
+
+        .. math::
+            U\\rho
+
+        This is useful for :class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian`
+        multiplication to density matrices. 
         """
         raise_error(NotImplementedError)
 

--- a/src/qibo/abstractions/hamiltonians.py
+++ b/src/qibo/abstractions/hamiltonians.py
@@ -37,9 +37,6 @@ class Hamiltonian(ABC):
         self._eigenvectors = None
         self._exp = {"a": None, "result": None}
 
-        self.terms = None
-        self._gates = None
-
     @classmethod
     @abstractmethod
     def from_symbolic(cls, symbolic_hamiltonian, symbol_map, numpy=False): # pragma: no cover
@@ -68,10 +65,6 @@ class Hamiltonian(ABC):
         if self._matrix is None:
             self._matrix = self.calculate_dense_matrix()
         return self._matrix
-
-    @abstractmethod
-    def calculate_dense_matrix(self): # pragma: no cover
-        raise_error(NotImplementedError)
 
     @abstractmethod
     def eigenvalues(self): # pragma: no cover
@@ -471,8 +464,7 @@ class TrotterHamiltonian(Hamiltonian):
                 self.expgate_sets[term].add(gate)
                 self._circuit.add(gate)
 
-    def terms(self): # pylint: disable=E0202
-        # TODO: Fix pylint here (`self.terms` of `Hamiltonian` hides this method)
+    def terms(self):
         if self._terms is None:
             self._terms = [gates.Unitary(term.matrix, *targets)
                            for targets, term in self]

--- a/src/qibo/abstractions/hamiltonians.py
+++ b/src/qibo/abstractions/hamiltonians.py
@@ -181,3 +181,18 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
     def exp(self, a):
         return self.dense.exp(a)
+
+
+class TrotterHamiltonian(SymbolicHamiltonian):
+
+    @abstractmethod
+    def is_compatible(self, o): # pragma: no cover
+        raise_error(NotImplementedError)
+
+    @abstractmethod
+    def make_compatible(self, o): # pragma: no cover
+        raise_error(NotImplementedError)
+
+    @abstractmethod
+    def circuit(self, dt, accelerators=None, memory_device="/CPU:0"): # pragma: no cover
+        raise_error(NotImplementedError)

--- a/src/qibo/abstractions/hamiltonians.py
+++ b/src/qibo/abstractions/hamiltonians.py
@@ -3,6 +3,7 @@ from qibo.config import log, raise_error
 
 
 class AbstractHamiltonian(ABC):
+    """Qibo abstraction for Hamiltonian objects."""
 
     def __init__(self):
         self._nqubits = None
@@ -98,13 +99,12 @@ class AbstractHamiltonian(ABC):
 
 
 class MatrixHamiltonian(AbstractHamiltonian):
-    """Abstract Hamiltonian operator using full matrix representation.
+    """Abstract Hamiltonian based on full matrix representation.
 
     Args:
         nqubits (int): number of quantum bits.
         matrix (np.ndarray): Matrix representation of the Hamiltonian in the
-            computational basis as an array of shape
-            ``(2 ** nqubits, 2 ** nqubits)``.
+            computational basis as an array of shape ``(2 ** nqubits, 2 ** nqubits)``.
         numpy (bool): If ``True`` the Hamiltonian is created using numpy as the
             calculation backend, otherwise the selected backend is used.
             Default option is ``numpy = False``.
@@ -120,6 +120,7 @@ class MatrixHamiltonian(AbstractHamiltonian):
 
     @property
     def matrix(self):
+        """Returns the full ``(2 ** nqubits, 2 ** nqubits)`` matrix representation."""
         return self._matrix
 
     @matrix.setter
@@ -133,6 +134,14 @@ class MatrixHamiltonian(AbstractHamiltonian):
 
 
 class SymbolicHamiltonian(AbstractHamiltonian):
+    """Abstract Hamiltonian based on symbolic representation.
+
+    Unlike :class:`qibo.abstractions.hamiltonians.MatrixHamiltonian` this
+    object does not create the full ``(2 ** nqubits, 2 ** nqubits)``
+    Hamiltonian matrix leading to more efficient calculations.
+    Note that the matrix is required and will be created automatically if
+    specific methods, such as ``.eigenvectors()`` or ``.exp()`` are called.
+    """
 
     def __init__(self):
         super().__init__()
@@ -140,6 +149,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
     @property
     def dense(self):
+        """Creates the equivalent :class:`qibo.abstractions.hamiltonians.MatrixHamiltonian`."""
         if self._dense is None:
             log.warn("Calculating the dense form of a symbolic Hamiltonian. "
                      "This operation is memory inefficient.")
@@ -160,6 +170,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
     @property
     def matrix(self):
+        """Returns the full ``(2 ** nqubits, 2 ** nqubits)`` matrix representation."""
         return self.dense.matrix
 
     def eigenvalues(self):

--- a/src/qibo/abstractions/hamiltonians.py
+++ b/src/qibo/abstractions/hamiltonians.py
@@ -111,6 +111,7 @@ class MatrixHamiltonian(AbstractHamiltonian):
     """
 
     def __init__(self, nqubits, matrix=None):
+        super().__init__()
         self.nqubits = nqubits
         self.matrix = matrix
         self._eigenvalues = None
@@ -134,6 +135,7 @@ class MatrixHamiltonian(AbstractHamiltonian):
 class SymbolicHamiltonian(AbstractHamiltonian):
 
     def __init__(self):
+        super().__init__()
         self._dense = None
 
     @property

--- a/src/qibo/abstractions/hamiltonians.py
+++ b/src/qibo/abstractions/hamiltonians.py
@@ -1,6 +1,4 @@
-import itertools
 from abc import ABC, abstractmethod
-from qibo import gates
 from qibo.config import log, raise_error
 
 
@@ -119,29 +117,6 @@ class MatrixHamiltonian(AbstractHamiltonian):
         self._eigenvectors = None
         self._exp = {"a": None, "result": None}
 
-    @classmethod
-    @abstractmethod
-    def from_symbolic(cls, symbolic_hamiltonian, symbol_map, numpy=False): # pragma: no cover
-        """Creates a ``Hamiltonian`` from a symbolic Hamiltonian.
-
-        We refer to the :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
-        example for more details.
-
-        Args:
-            symbolic_hamiltonian (sympy.Expr): The full Hamiltonian written
-                with symbols.
-            symbol_map (dict): Dictionary that maps each symbol that appears in
-                the Hamiltonian to a pair of (target, matrix).
-            numpy (bool): If ``True`` the Hamiltonian is created using numpy as
-                the calculation backend, otherwise the selected backend is used.
-                Default option is ``numpy = False``.
-
-        Returns:
-            A :class:`qibo.abstractions.hamiltonians.Hamiltonian` object that
-            implements the given symbolic Hamiltonian.
-        """
-        raise_error(NotImplementedError)
-
     @property
     def matrix(self):
         return self._matrix
@@ -156,444 +131,40 @@ class MatrixHamiltonian(AbstractHamiltonian):
         self._matrix = m
 
 
-class TrotterHamiltonian(AbstractHamiltonian):
-    """Hamiltonian operator used for Trotterized time evolution.
+class SymbolicHamiltonian(AbstractHamiltonian):
 
-    The Hamiltonian represented by this class has the form of Eq. (57) in
-    `arXiv:1901.05824 <https://arxiv.org/abs/1901.05824>`_.
-
-    Args:
-        *parts (dict): Dictionary whose values are
-            :class:`qibo.abstractions.hamiltonians.Hamiltonian` objects representing
-            the h operators of Eq. (58) in the reference. The keys of the
-            dictionary are tuples of qubit ids (int) that represent the targets
-            of each h term.
-        ground_state (Callable): Optional callable with no arguments that
-            returns the ground state of this ``TrotterHamiltonian``. Specifying
-            this method is useful if the ``TrotterHamiltonian`` is used as
-            the easy Hamiltonian of the adiabatic evolution and its ground
-            state is used as the initial condition.
-
-    Example:
-        ::
-
-            from qibo import matrices, hamiltonians
-            # Create h term for critical TFIM Hamiltonian
-            matrix = -np.kron(matrices.Z, matrices.Z) - np.kron(matrices.X, matrices.I)
-            term = hamiltonians.Hamiltonian(2, matrix)
-            # TFIM with periodic boundary conditions is translationally
-            # invariant and therefore the same term can be used for all qubits
-            # Create even and odd Hamiltonian parts (Eq. (43) in arXiv:1901.05824)
-            even_part = {(0, 1): term, (2, 3): term}
-            odd_part = {(1, 2): term, (3, 0): term}
-            # Create a ``TrotterHamiltonian`` object using these parts
-            h = hamiltonians.TrotterHamiltonian(even_part, odd_part)
-
-            # Alternatively the precoded TFIM model may be used with the
-            # ``trotter`` flag set to ``True``
-            h = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
-    """
-
-    def __init__(self, *parts, ground_state=None):
-        self.dtype = None
-        self.term_class = None
-        # maps each distinct ``Hamiltonian`` term to the set of gates that
-        # are associated with it
-        self.expgate_sets = {}
-        self.term_sets = {}
-        self.targets_map = {}
-        for part in parts:
-            if not isinstance(part, dict):
-                raise_error(TypeError, "``TrotterHamiltonian`` part should be "
-                                       "dictionary but is {}."
-                                       "".format(type(part)))
-            for targets, term in part.items():
-                if not issubclass(type(term), AbstractHamiltonian):
-                    raise_error(TypeError, "Invalid term type {}."
-                                           "".format(type(term)))
-                if len(targets) != term.nqubits:
-                    raise_error(ValueError, "Term targets {} but supports {} "
-                                            "qubits."
-                                            "".format(targets, term.nqubits))
-
-                if targets in self.targets_map:
-                    raise_error(ValueError, "Targets {} are given in more than "
-                                            "one term.".format(targets))
-                self.targets_map[targets] = term
-                if term in self.term_sets:
-                    self.term_sets[term].add(targets)
-                else:
-                    self.term_sets[term] = {targets}
-                    self.expgate_sets[term] = set()
-
-                if self.term_class is None:
-                    self.term_class = term.__class__
-                elif term.__class__ != self.term_class:
-                    raise_error(TypeError,
-                                "Terms of different types {} and {} were "
-                                "given.".format(term, self.term_class))
-                if self.dtype is None:
-                    self.dtype = term.matrix.dtype
-                elif term.matrix.dtype != self.dtype: # pragma: no cover
-                    raise_error(TypeError,
-                                "Terms of different types {} and {} were "
-                                "given.".format(term.matrix.dtype, self.dtype))
-        self.parts = parts
-        self.nqubits = len({t for targets in self.targets_map.keys()
-                            for t in targets})
-        self.nterms = sum(len(part) for part in self.parts)
-        # Function that creates the ground state of this Hamiltonian
-        # can be ``None``
-        self.ground_state_func = ground_state
-        # Circuit that implements on Trotter dt step
-        self._circuit = None
-        # List of gates that implement each Hamiltonian term. Useful for
-        # calculating expectation
-        self._terms = None
-        # Define dense Hamiltonian attributes
-        self._matrix = None
+    def __init__(self):
         self._dense = None
-        self._eigenvalues = None
-        self._eigenvectors = None
-        self._exp = {"a": None, "result": None}
-
-    @classmethod
-    def from_dictionary(cls, terms, ground_state=None):
-        parts = cls._split_terms(terms)
-        return cls(*parts, ground_state=ground_state)
-
-    @classmethod
-    @abstractmethod
-    def from_symbolic(cls, symbolic_hamiltonian, symbol_map, ground_state=None): # pragma: no cover
-        """Creates a ``TrotterHamiltonian`` from a symbolic Hamiltonian.
-
-        We refer to the :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
-        example for more details.
-
-        Args:
-            symbolic_hamiltonian (sympy.Expr): The full Hamiltonian written
-                with symbols.
-            symbol_map (dict): Dictionary that maps each symbol that appears in
-                the Hamiltonian to a pair of (target, matrix).
-            ground_state (Callable): Optional callable with no arguments that
-                returns the ground state of this ``TrotterHamiltonian``.
-                See :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` for more
-                details.
-
-        Returns:
-            A :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` object that
-            implements the given symbolic Hamiltonian.
-        """
-        raise_error(NotImplementedError)
-
-    @staticmethod
-    @abstractmethod
-    def construct_terms(terms): # pragma: no cover
-        """Helper method for `from_symbolic`.
-
-        Constructs the term dictionary by using the same
-        :class:`qibo.abstractions.hamiltonians.Hamiltonian` object for terms that
-        have equal matrix representation. This is done for efficiency during
-        the exponentiation of terms.
-
-        Args:
-            terms (dict): Dictionary that maps tuples of targets to the matrix
-                          that acts on these on targets.
-
-        Returns:
-            terms (dict): Dictionary that maps tuples of targets to the
-                          Hamiltonian term that acts on these on targets.
-        """
-        raise_error(NotImplementedError)
-
-    @staticmethod
-    def _split_terms(terms):
-        """Splits a dictionary of terms to multiple parts.
-
-        Each qubit should not appear in more that one terms in each
-        part to ensure commutation relations in the definition of
-        :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`.
-
-        Args:
-            terms (dict): Dictionary that maps tuples of targets to the matrix
-                          that acts on these on targets.
-
-        Returns:
-            List of dictionary parts to be used for the creation of a
-            ``TrotterHamiltonian``. The parts are such that no qubit appears
-            twice in each part.
-        """
-        groups, singles = [set()], [set()]
-        for targets in terms.keys():
-            flag = True
-            t = set(targets)
-            for g, s in zip(groups, singles):
-                if not t & s:
-                    s |= t
-                    g.add(targets)
-                    flag = False
-                    break
-            if flag:
-                groups.append({targets})
-                singles.append(t)
-        return [{k: terms[k] for k in g} for g in groups]
-
-    def is_compatible(self, o):
-        """Checks if a ``TrotterHamiltonian`` has the same part structure.
-
-        By part structure we mean that the target keys of the dictionaries
-        contained in the ``self.parts`` list are the same for both Hamiltonians.
-        Two :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` objects can be
-        added only when they are compatible (have the same part structure).
-        When using Trotter decomposition to simulate adiabatic evolution then
-        ``h0`` and ``h1`` should be compatible.
-
-        Args:
-            o: The Hamiltonian to check compatibility with.
-
-        Returns:
-            ``True`` if ``o`` has the same structure as ``self`` otherwise
-            ``False``.
-        """
-        if isinstance(o, self.__class__):
-            if len(self.parts) != len(o.parts):
-                return False
-            for part1, part2 in zip(self.parts, o.parts):
-                if set(part1.keys()) != set(part2.keys()):
-                    return False
-            return True
-        return False
-
-    @abstractmethod
-    def make_compatible(self, o): # pragma: no cover
-        """Makes given ``TrotterHamiltonian`` compatible to the current one.
-
-        See :meth:`qibo.abstractions.hamiltonians.TrotterHamiltonian.is_compatible` for
-        more details on how compatibility is defined in this context.
-        The current method will be used automatically by
-        :class:`qibo.evolution.AdiabaticEvolution` to make the ``h0`` and ``h1``
-        Hamiltonians compatible if they are not.
-        We note that in some applications making the Hamiltonians compatible
-        manually instead of relying in this method may take better advantage of
-        caching and lead to better execution performance.
-
-        Args:
-            o: The ``TrotterHamiltonian`` to make compatible to the current.
-               Should be non-interacting (contain only one-qubit terms).
-
-        Returns:
-            A new :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` object
-            that is equivalent to ``o`` but has the same part structure as
-            ``self``.
-        """
-        raise_error(NotImplementedError)
 
     @property
     def dense(self):
-        """Creates an equivalent Hamiltonian model that holds the full matrix.
-
-        Returns:
-            A :class:`qibo.abstractions.hamiltonians.Hamiltonian` object that is
-            equivalent to this local Hamiltonian.
-        """
         if self._dense is None:
-            from qibo import hamiltonians
-            matrix = self.calculate_dense_matrix() # pylint: disable=E1111
-            self.dense = hamiltonians.Hamiltonian(self.nqubits, matrix)
+            log.warn("Calculating the dense form of a symbolic Hamiltonian. "
+                     "This operation is memory inefficient.")
+            self.dense = self.calculate_dense()
         return self._dense
 
     @dense.setter
     def dense(self, hamiltonian):
+        assert isinstance(hamiltonian, MatrixHamiltonian)
         self._dense = hamiltonian
         self._eigenvalues = hamiltonian._eigenvalues
         self._eigenvectors = hamiltonian._eigenvectors
         self._exp = hamiltonian._exp
+
+    @abstractmethod
+    def calculate_dense(self): # pragma: no cover
+        raise_error(NotImplementedError)
 
     @property
     def matrix(self):
         return self.dense.matrix
 
     def eigenvalues(self):
-        """Computes the eigenvalues for the Hamiltonian."""
         return self.dense.eigenvalues()
 
     def eigenvectors(self):
-        """Computes a tensor with the eigenvectors for the Hamiltonian."""
         return self.dense.eigenvectors()
 
-    def ground_state(self):
-        """Computes the ground state of the Hamiltonian.
-
-        If this method is needed it should be implemented efficiently for the
-        particular Hamiltonian by passing the ``ground_state`` argument during
-        initialization. If this argument is not passed then this method will
-        diagonalize the full (dense) Hamiltonian matrix which is computationally
-        and memory intensive.
-        """
-        if self.ground_state_func is None:
-            log.info("Ground state function not available for ``TrotterHamiltonian``."
-                     "Using dense Hamiltonian eigenvectors.")
-            return self.eigenvectors()[:, 0]
-        return self.ground_state_func()
-
     def exp(self, a):
-        """Computes a tensor corresponding to exp(-1j * a * H).
-
-        Args:
-            a (complex): Complex number to multiply Hamiltonian before
-                exponentiation.
-        """
         return self.dense.exp(a)
-
-    def expectation(self, state, normalize=False): # pragma: no cover
-        """Computes the real expectation value for a given state.
-
-        Args:
-            state (array): the expectation state.
-            normalize (bool): If ``True`` the expectation value is divided
-                with the state's norm squared.
-
-        Returns:
-            Real number corresponding to the expectation value.
-        """
-        # abstract method
-        raise_error(NotImplementedError)
-
-    def __iter__(self):
-        """Helper iteration method to loop over the Hamiltonian terms."""
-        for part in self.parts:
-            for targets, term in part.items():
-                yield targets, term
-
-    def _create_circuit(self, dt, accelerators=None, memory_device="/CPU:0"):
-        """Creates circuit that implements the Trotterized evolution."""
-        from qibo.models import Circuit
-        self._circuit = Circuit(self.nqubits, accelerators=accelerators,
-                                memory_device=memory_device)
-        self._circuit.check_initial_state_shape = False
-        self._circuit.dt = None
-        for part in itertools.chain(self.parts, self.parts[::-1]):
-            for targets, term in part.items():
-                gate = gates.Unitary(term.exp(dt / 2.0), *targets)
-                self.expgate_sets[term].add(gate)
-                self._circuit.add(gate)
-
-    def terms(self):
-        if self._terms is None:
-            self._terms = [gates.Unitary(term.matrix, *targets)
-                           for targets, term in self]
-        return self._terms
-
-    def circuit(self, dt, accelerators=None, memory_device="/CPU:0"):
-        """Circuit implementing second order Trotter time step.
-
-        Args:
-            dt (float): Time step to use for Trotterization.
-
-        Returns:
-            :class:`qibo.abstractions.circuit.AbstractCircuit` that implements a single
-            time step of the second order Trotterized evolution.
-        """
-        if self._circuit is None:
-            self._create_circuit(dt, accelerators, memory_device)
-        elif dt != self._circuit.dt:
-            self._circuit.dt = dt
-            self._circuit.set_parameters({
-                gate: term.exp(dt / 2.0)
-                for term, expgates in self.expgate_sets.items()
-                for gate in expgates})
-        return self._circuit
-
-    def _scalar_op(self, op, o):
-        """Helper method for implementing operations with scalars.
-
-        Args:
-            op (str): String that defines the operation, such as '__add__' or
-                '__mul__'.
-            o: Scalar to perform operation for.
-        """
-        new_parts = []
-        new_terms = {term: getattr(term, op)(o) for term in self.expgate_sets.keys()}
-        new_parts = ({targets: new_terms[term]
-                      for targets, term in part.items()}
-                     for part in self.parts)
-        new = self.__class__(*new_parts)
-        if self._dense is not None:
-            new.dense = getattr(self.dense, op)(o)
-        if self._circuit is not None:
-            new._circuit = self._circuit
-            new._circuit.dt = None
-            new.expgate_sets = {new_terms[term]: gate_set
-                              for term, gate_set in self.expgate_sets.items()}
-        return new
-
-    def _hamiltonian_op(self, op, o):
-        """Helper method for implementing operations between local Hamiltonians.
-
-        Args:
-            op (str): String that defines the operation, such as '__add__'.
-            o (:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`): Other local
-                Hamiltonian to perform the operation.
-        """
-        if len(self.parts) != len(o.parts):
-            raise_error(ValueError, "Cannot add local Hamiltonians if their "
-                                    "parts are not compatible.")
-
-        new_terms = {}
-        def new_parts():
-            for part1, part2 in zip(self.parts, o.parts):
-                if set(part1.keys()) != set(part2.keys()):
-                    raise_error(ValueError, "Cannot add local Hamiltonians "
-                                            "if their parts are not "
-                                            "compatible.")
-                new_part = {}
-                for targets in part1.keys():
-                    term_tuple = (part1[targets], part2[targets])
-                    if term_tuple not in new_terms:
-                        new_terms[term_tuple] = getattr(part1[targets], op)(
-                            part2[targets])
-                    new_part[targets] = new_terms[term_tuple]
-                yield new_part
-
-        new = self.__class__(*new_parts())
-        if self._circuit is not None:
-            new.expgate_sets = {new_term: self.expgate_sets[t1]
-                                for (t1, _), new_term in new_terms.items()}
-            new._circuit = self._circuit
-            new._circuit.dt = None
-        return new
-
-    def __add__(self, o):
-        """Add operator."""
-        if isinstance(o, self.__class__):
-            return self._hamiltonian_op("__add__", o)
-        else:
-            return self._scalar_op("__add__", o / self.nterms)
-
-    def __radd__(self, o):
-        """Right operator addition."""
-        return self.__add__(o)
-
-    def __sub__(self, o):
-        """Subtraction operator."""
-        if isinstance(o, self.__class__):
-            return self._hamiltonian_op("__sub__", o)
-        else:
-            return self._scalar_op("__sub__", o / self.nterms)
-
-    def __rsub__(self, o):
-        """Right subtraction operator."""
-        return self._scalar_op("__rsub__", o / self.nterms)
-
-    def __mul__(self, o):
-        """Multiplication to scalar operator."""
-        return self._scalar_op("__mul__", o)
-
-    def __rmul__(self, o):
-        """Right scalar multiplication."""
-        return self.__mul__(o)
-
-    def __matmul__(self, state): # pragma: no cover
-        """Matrix multiplication with state vectors."""
-        # abstract method
-        raise_error(NotImplementedError)

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -481,6 +481,16 @@ class AbstractBackend(ABC):
         raise_error(NotImplementedError)
 
     @abstractmethod
+    def density_matrix_half_call(self, gate, state): # pragma: no cover
+        """Half gate application to density matrix."""
+        raise_error(NotImplementedError)
+
+    @abstractmethod
+    def density_matrix_half_matrix_call(self, gate, state): # pragma: no cover
+        """Half gate application to density matrix using the gate's unitary matrix representation."""
+        raise_error(NotImplementedError)
+
+    @abstractmethod
     def state_vector_collapse(self, gate, state, result): # pragma: no cover
         """Collapses state vector to a given result."""
         raise_error(NotImplementedError)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -325,6 +325,9 @@ class NumpyBackend(abstract.AbstractBackend):
             state = self.einsum_call(gate.cache.calculation_cache.left, state, gate.matrix)
         return self.reshape(state, gate.cache.flat_shape)
 
+    def density_matrix_matrix_call(self, gate, state):
+        return self.density_matrix_call(gate, state)
+
     def density_matrix_half_call(self, gate, state):
         if gate.is_controlled_by: # pragma: no cover
             raise_error(NotImplementedError, "Gate density matrix half call is "
@@ -333,9 +336,6 @@ class NumpyBackend(abstract.AbstractBackend):
         state = self.reshape(state, gate.cache.tensor_shape)
         state = self.einsum_call(gate.cache.calculation_cache.left, state, gate.matrix)
         return self.reshape(state, gate.cache.flat_shape)
-
-    def density_matrix_matrix_call(self, gate, state):
-        return self.density_matrix_call(gate, state)
 
     def density_matrix_half_matrix_call(self, gate, state):
         return self.density_matrix_half_call(gate, state)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -325,8 +325,20 @@ class NumpyBackend(abstract.AbstractBackend):
             state = self.einsum_call(gate.cache.calculation_cache.left, state, gate.matrix)
         return self.reshape(state, gate.cache.flat_shape)
 
+    def density_matrix_half_call(self, gate, state):
+        if gate.is_controlled_by: # pragma: no cover
+            raise_error(NotImplementedError, "Gate density matrix half call is "
+                                             "not implemented for ``controlled_by``"
+                                             "gates.")
+        state = self.reshape(state, gate.cache.tensor_shape)
+        state = self.einsum_call(gate.cache.calculation_cache.left, state, gate.matrix)
+        return self.reshape(state, gate.cache.flat_shape)
+
     def density_matrix_matrix_call(self, gate, state):
         return self.density_matrix_call(gate, state)
+
+    def density_matrix_half_matrix_call(self, gate, state):
+        return self.density_matrix_half_call(gate, state)
 
     def _append_zeros(self, state, qubits, results):
         """Helper method for `state_vector_collapse` and `density_matrix_collapse`."""

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -262,16 +262,6 @@ class TensorflowCustomBackend(TensorflowBackend):
                             gate.nqubits, *gate.target_qubits,
                             self.get_threads())
 
-    def density_matrix_half_call(self, gate, state):
-        return gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
-                            2 * gate.nqubits, *gate.target_qubits,
-                            self.get_threads())
-
-    def density_matrix_half_matrix_call(self, gate, state):
-        return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
-                            2 * gate.nqubits, *gate.target_qubits,
-                            self.get_threads())
-
     def density_matrix_call(self, gate, state):
         state = gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
                              2 * gate.nqubits, *gate.target_qubits,
@@ -289,6 +279,16 @@ class TensorflowCustomBackend(TensorflowBackend):
                              2 * gate.nqubits, *gate.cache.target_qubits_dm,
                              self.get_threads())
         return state
+
+    def density_matrix_half_call(self, gate, state):
+        return gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
+                            2 * gate.nqubits, *gate.target_qubits,
+                            self.get_threads())
+
+    def density_matrix_half_matrix_call(self, gate, state):
+        return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
+                            2 * gate.nqubits, *gate.target_qubits,
+                            self.get_threads())
 
     def state_vector_collapse(self, gate, state, result):
         return gate.gate_op(state, gate.cache.qubits_tensor, result,

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -262,6 +262,16 @@ class TensorflowCustomBackend(TensorflowBackend):
                             gate.nqubits, *gate.target_qubits,
                             self.get_threads())
 
+    def density_matrix_half_call(self, gate, state):
+        return gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
+                            2 * gate.nqubits, *gate.target_qubits,
+                            self.get_threads())
+
+    def density_matrix_half_matrix_call(self, gate, state):
+        return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
+                            2 * gate.nqubits, *gate.target_qubits,
+                            self.get_threads())
+
     def density_matrix_call(self, gate, state):
         state = gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
                              2 * gate.nqubits, *gate.target_qubits,

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -69,6 +69,10 @@ class BackendGate(BaseBackendGate):
     def density_matrix_call(self, state):
         return K.density_matrix_call(self, state)
 
+    def density_matrix_half_call(self, state):
+        self.set_nqubits(state)
+        return K.density_matrix_half_call(self, state)
+
 
 class MatrixGate(BackendGate):
     """Gate that uses matrix multiplication to be applied to states."""
@@ -78,6 +82,10 @@ class MatrixGate(BackendGate):
 
     def density_matrix_call(self, state):
         return K.density_matrix_matrix_call(self, state)
+
+    def density_matrix_half_call(self, state):
+        self.set_nqubits(state)
+        return K.density_matrix_half_matrix_call(self, state)
 
 
 class H(MatrixGate, abstract_gates.H):

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -232,13 +232,12 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             self.form = sympy.expand(form)
             termsdict = self.form.as_coefficients_dict()
             self.terms = [SymbolicTerm(c, f) for f, c in termsdict.items()]
-        else: # TODO: Fix this case
-            raise_error(NotImplementedError)
+        else:
             if terms is None:
                 raise_error(ValueError, "Cannot construct `SymbolicHamiltonian` "
                                         "if no form or terms are given.")
             self.terms = terms
-            self.form = 0
+            self.form = sum(term.full() for term in self.terms)
 
         self.nqubits = max(factor.target_qubit for term in self.terms for factor in term) + 1
         self._dense = None

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -208,7 +208,13 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
     Args:
         form (sympy.Expr): Hamiltonian form as a ``sympy.Expr``. The Hamiltonian
             should be created using Qibo symbols.
-            See ... # TODO: Add example here for more details.
+            See :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
+            example for more details.
+        symbol_map (dict): Dictionary that maps each ``sympy.Symbol`` to the
+            corresponding target qubit and matrix representation. This feature
+            is kept for compatibility with older versions where Qibo symbols
+            were not available and will be deprecated in the future.
+            It is not required if the Hamiltonian is constructed using Qibo symbols.
     """
 
     def __init__(self, form, symbol_map=None):

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -54,6 +54,9 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
             expression.
         """
         # TODO: Remove ``numpy`` feature from Hamiltonians?
+        log.warn("`Hamiltonian.from_symbolic` and the use of symbol maps is "
+                 "deprecated. Please use `SymbolicHamiltonian` and Qibo symbols "
+                 "to construct Hamiltonians using symbols.")
         return SymbolicHamiltonian(symbolic_hamiltonian, symbol_map)
 
     def eigenvalues(self):

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -219,6 +219,7 @@ class NumpyHamiltonian(Hamiltonian):
 class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
     def __init__(self, form=None, terms=None):
+        super().__init__()
         import sympy
         from qibo.symbols import SymbolicTerm
         if form is not None:

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -327,7 +327,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                                          "implemented.".format(type(o)))
 
 
-class TrotterHamiltonian(hamiltonians.SymbolicHamiltonian):
+class TrotterHamiltonian(hamiltonians.TrotterHamiltonian):
     """Hamiltonian operator used for Trotterized time evolution.
 
     The Hamiltonian represented by this class has the form of Eq. (57) in

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -244,11 +244,11 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                                           "number of qubits can be added.")
             new_ham = self.__class__(self.form + o.form)
             if self._dense is not None and o._dense is not None:
-                new_ham._dense = self.dense + o.dense
+                new_ham.dense = self.dense + o.dense
         elif isinstance(o, K.numeric_types):
             new_ham = self.__class__(self.form + o)
             if self._dense is not None:
-                new_ham._dense = self.dense + o
+                new_ham.dense = self.dense + o
         else:
             raise_error(NotImplementedError, "SymbolicHamiltonian addition to {} not "
                                              "implemented.".format(type(o)))
@@ -261,11 +261,11 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                                           "number of qubits can be subtracted.")
             new_ham = self.__class__(self.form - o.form)
             if self._dense is not None and o._dense is not None:
-                new_ham._dense = self.dense - o.dense
+                new_ham.dense = self.dense - o.dense
         elif isinstance(o, K.numeric_types):
             new_ham = self.__class__(self.form - o)
             if self._dense is not None:
-                new_ham._dense = self.dense - o
+                new_ham.dense = self.dense - o
         else:
             raise_error(NotImplementedError, "Hamiltonian subtraction to {} "
                                              "not implemented.".format(type(o)))
@@ -275,7 +275,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
         if isinstance(o, K.numeric_types):
             new_ham = self.__class__(o - self.form)
             if self._dense is not None:
-                new_ham._dense = o - self.dense
+                new_ham.dense = o - self.dense
         else:
             raise_error(NotImplementedError, "Hamiltonian subtraction to {} "
                                              "not implemented.".format(type(o)))
@@ -288,7 +288,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
         new_form = o * self.form
         new_ham = self.__class__(new_form)
         if self._dense is not None:
-            new_ham._dense = o * self._dense
+            new_ham.dense = o * self._dense
         return new_ham
 
     def apply_gates(self, state):
@@ -306,7 +306,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             new_form = self.form * o.form
             new_ham = self.__class__(new_form)
             if self._dense is not None and o._dense is not None:
-                new_ham._dense = self.dense @ o.dense
+                new_ham.dense = self.dense @ o.dense
             return new_ham
 
         if isinstance(o, states.AbstractState):
@@ -319,8 +319,8 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                 raise_error(NotImplementedError, "Cannot multiply `SymbolicHamiltonian` "
                                                  "with density matrix.")
             else:
-                raise_error(ValueError, "Cannot multiply Hamiltonian with "
-                                        "rank-{} tensor.".format(rank))
+                raise_error(NotImplementedError, "Cannot multiply Hamiltonian with "
+                                                 "rank-{} tensor.".format(rank))
 
         raise_error(NotImplementedError, "Hamiltonian matmul to {} not "
                                          "implemented.".format(type(o)))

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -1,5 +1,5 @@
 import itertools
-from qibo import K
+from qibo import K, gates
 from qibo.config import log, raise_error, EINSUM_CHARS
 from qibo.abstractions import hamiltonians, states
 from qibo.core.symbolic import multikron
@@ -26,6 +26,24 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
 
     @classmethod
     def from_symbolic(cls, symbolic_hamiltonian, symbol_map, numpy=False):
+        """Creates a ``Hamiltonian`` from a symbolic Hamiltonian.
+
+        We refer to the :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
+        example for more details.
+
+        Args:
+            symbolic_hamiltonian (sympy.Expr): The full Hamiltonian written
+                with symbols.
+            symbol_map (dict): Dictionary that maps each symbol that appears in
+                the Hamiltonian to a pair of (target, matrix).
+            numpy (bool): If ``True`` the Hamiltonian is created using numpy as
+                the calculation backend, otherwise the selected backend is used.
+                Default option is ``numpy = False``.
+
+        Returns:
+            A :class:`qibo.abstractions.hamiltonians.Hamiltonian` object that
+            implements the given symbolic Hamiltonian.
+        """
         from qibo.core.symbolic import parse_symbolic
         terms = parse_symbolic(symbolic_hamiltonian, symbol_map)
         nqubits = max(set(q for targets in terms.keys() for q in targets)) + 1
@@ -198,7 +216,7 @@ class NumpyHamiltonian(Hamiltonian):
         hamiltonians.MatrixHamiltonian.__init__(self, nqubits, matrix)
 
 
-class SymbolicHamiltonian(hamiltonians.AbstractHamiltonian):
+class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
     def __init__(self, form=None, terms=None):
         import sympy
@@ -225,20 +243,7 @@ class SymbolicHamiltonian(hamiltonians.AbstractHamiltonian):
         self.nqubits = max(factor.target_qubit for term in self.terms for factor in term) + 1
         self._dense = None
 
-    @property
-    def dense(self):
-        if self._dense is None:
-            log.warn("Calculating the dense form of a symbolic Hamiltonian. "
-                     "This operation is memory inefficient.")
-            matrix = self.calculate_dense_matrix()
-            self._dense = Hamiltonian(self.nqubits, matrix)
-        return self._dense
-
-    @property
-    def matrix(self):
-        return self.dense.matrix
-
-    def calculate_dense_matrix(self):
+    def calculate_dense(self):
         matrix = 0
         for term in self.terms:
             kronlist = self.nqubits * [K.qnp.eye(2)]
@@ -246,16 +251,7 @@ class SymbolicHamiltonian(hamiltonians.AbstractHamiltonian):
                 q = factor.target_qubit
                 kronlist[q] = kronlist[q] @ factor.matrix
             matrix += term.coefficient * multikron(kronlist)
-        return matrix
-
-    def eigenvalues(self):
-        return self.dense.eigenvalues()
-
-    def eigenvectors(self):
-        return self.dense.eigenvectors()
-
-    def exp(self, a):
-        return self.dense.exp(a)
+        return Hamiltonian(self.nqubits, matrix)
 
     def expectation(self, state, normalize=False):
         return Hamiltonian.expectation(self, state, normalize)
@@ -349,15 +345,135 @@ class SymbolicHamiltonian(hamiltonians.AbstractHamiltonian):
                                          "implemented.".format(type(o)))
 
 
-class TrotterHamiltonian(hamiltonians.TrotterHamiltonian):
-    """Backend implementation of :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`."""
+class TrotterHamiltonian(hamiltonians.SymbolicHamiltonian):
+    """Hamiltonian operator used for Trotterized time evolution.
+
+    The Hamiltonian represented by this class has the form of Eq. (57) in
+    `arXiv:1901.05824 <https://arxiv.org/abs/1901.05824>`_.
+
+    Args:
+        *parts (dict): Dictionary whose values are
+            :class:`qibo.abstractions.hamiltonians.Hamiltonian` objects representing
+            the h operators of Eq. (58) in the reference. The keys of the
+            dictionary are tuples of qubit ids (int) that represent the targets
+            of each h term.
+        ground_state (Callable): Optional callable with no arguments that
+            returns the ground state of this ``TrotterHamiltonian``. Specifying
+            this method is useful if the ``TrotterHamiltonian`` is used as
+            the easy Hamiltonian of the adiabatic evolution and its ground
+            state is used as the initial condition.
+
+    Example:
+        ::
+
+            from qibo import matrices, hamiltonians
+            # Create h term for critical TFIM Hamiltonian
+            matrix = -np.kron(matrices.Z, matrices.Z) - np.kron(matrices.X, matrices.I)
+            term = hamiltonians.Hamiltonian(2, matrix)
+            # TFIM with periodic boundary conditions is translationally
+            # invariant and therefore the same term can be used for all qubits
+            # Create even and odd Hamiltonian parts (Eq. (43) in arXiv:1901.05824)
+            even_part = {(0, 1): term, (2, 3): term}
+            odd_part = {(1, 2): term, (3, 0): term}
+            # Create a ``TrotterHamiltonian`` object using these parts
+            h = hamiltonians.TrotterHamiltonian(even_part, odd_part)
+
+            # Alternatively the precoded TFIM model may be used with the
+            # ``trotter`` flag set to ``True``
+            h = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    """
 
     def __init__(self, *parts, ground_state=None):
+        super().__init__()
         self.K = K
-        super().__init__(*parts, ground_state=ground_state)
+        self.dtype = None
+        self.term_class = None
+        # maps each distinct ``Hamiltonian`` term to the set of gates that
+        # are associated with it
+        self.expgate_sets = {}
+        self.term_sets = {}
+        self.targets_map = {}
+        for part in parts:
+            if not isinstance(part, dict):
+                raise_error(TypeError, "``TrotterHamiltonian`` part should be "
+                                       "dictionary but is {}."
+                                       "".format(type(part)))
+            for targets, term in part.items():
+                if not issubclass(type(term), hamiltonians.AbstractHamiltonian):
+                    raise_error(TypeError, "Invalid term type {}."
+                                           "".format(type(term)))
+                if len(targets) != term.nqubits:
+                    raise_error(ValueError, "Term targets {} but supports {} "
+                                            "qubits."
+                                            "".format(targets, term.nqubits))
+
+                if targets in self.targets_map:
+                    raise_error(ValueError, "Targets {} are given in more than "
+                                            "one term.".format(targets))
+                self.targets_map[targets] = term
+                if term in self.term_sets:
+                    self.term_sets[term].add(targets)
+                else:
+                    self.term_sets[term] = {targets}
+                    self.expgate_sets[term] = set()
+
+                if self.term_class is None:
+                    self.term_class = term.__class__
+                elif term.__class__ != self.term_class:
+                    raise_error(TypeError,
+                                "Terms of different types {} and {} were "
+                                "given.".format(term, self.term_class))
+                if self.dtype is None:
+                    self.dtype = term.matrix.dtype
+                elif term.matrix.dtype != self.dtype: # pragma: no cover
+                    raise_error(TypeError,
+                                "Terms of different types {} and {} were "
+                                "given.".format(term.matrix.dtype, self.dtype))
+        self.parts = parts
+        self.nqubits = len({t for targets in self.targets_map.keys()
+                            for t in targets})
+        self.nterms = sum(len(part) for part in self.parts)
+        # Function that creates the ground state of this Hamiltonian
+        # can be ``None``
+        self.ground_state_func = ground_state
+        # Circuit that implements on Trotter dt step
+        self._circuit = None
+        # List of gates that implement each Hamiltonian term. Useful for
+        # calculating expectation
+        self._terms = None
+        # Define dense Hamiltonian attributes
+        self._matrix = None
+        self._dense = None
+        self._eigenvalues = None
+        self._eigenvectors = None
+        self._exp = {"a": None, "result": None}
+
+    @classmethod
+    def from_dictionary(cls, terms, ground_state=None):
+        parts = cls._split_terms(terms)
+        return cls(*parts, ground_state=ground_state)
 
     @classmethod
     def from_symbolic(cls, symbolic_hamiltonian, symbol_map, ground_state=None):
+        """Creates a ``TrotterHamiltonian`` from a symbolic Hamiltonian.
+
+        We refer to the :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
+        example for more details.
+
+        Args:
+            symbolic_hamiltonian (sympy.Expr): The full Hamiltonian written
+                with symbols.
+            symbol_map (dict): Dictionary that maps each symbol that appears in
+                the Hamiltonian to a pair of (target, matrix).
+            ground_state (Callable): Optional callable with no arguments that
+                returns the ground state of this ``TrotterHamiltonian``.
+                See :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` for more
+                details.
+
+        Returns:
+            A :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` object that
+            implements the given symbolic Hamiltonian.
+        """
         terms, constant = cls.symbolic_terms(symbolic_hamiltonian, symbol_map)
         terms = cls.construct_terms(terms)
         return cls.from_dictionary(terms, ground_state=ground_state) + constant
@@ -381,6 +497,38 @@ class TrotterHamiltonian(hamiltonians.TrotterHamiltonian):
         if set(len(t) for t in terms.keys()) == {1, 2}:
             terms = merge_one_qubit(terms, sterms)
         return terms, constant
+
+    @staticmethod
+    def _split_terms(terms):
+        """Splits a dictionary of terms to multiple parts.
+
+        Each qubit should not appear in more that one terms in each
+        part to ensure commutation relations in the definition of
+        :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`.
+
+        Args:
+            terms (dict): Dictionary that maps tuples of targets to the matrix
+                          that acts on these on targets.
+
+        Returns:
+            List of dictionary parts to be used for the creation of a
+            ``TrotterHamiltonian``. The parts are such that no qubit appears
+            twice in each part.
+        """
+        groups, singles = [set()], [set()]
+        for targets in terms.keys():
+            flag = True
+            t = set(targets)
+            for g, s in zip(groups, singles):
+                if not t & s:
+                    s |= t
+                    g.add(targets)
+                    flag = False
+                    break
+            if flag:
+                groups.append({targets})
+                singles.append(t)
+        return [{k: terms[k] for k in g} for g in groups]
 
     @staticmethod
     def construct_terms(terms):
@@ -415,7 +563,89 @@ class TrotterHamiltonian(hamiltonians.TrotterHamiltonian):
             hterms[targets] = ham
         return hterms
 
+    def calculate_dense(self):
+        if 2 * self.nqubits > len(EINSUM_CHARS): # pragma: no cover
+            # case not tested because it only happens in large examples
+            raise_error(NotImplementedError, "Not enough einsum characters.")
+
+        matrix = K.np.zeros(2 * self.nqubits * (2,), dtype=self.dtype)
+        chars = EINSUM_CHARS[:2 * self.nqubits]
+        for targets, term in self:
+            tmat = term.matrix.reshape(2 * term.nqubits * (2,))
+            n = self.nqubits - len(targets)
+            emat = K.np.eye(2 ** n, dtype=self.dtype).reshape(2 * n * (2,))
+            gen = lambda x: (chars[i + x] for i in targets)
+            tc = "".join(itertools.chain(gen(0), gen(self.nqubits)))
+            ec = "".join((c for c in chars if c not in tc))
+            matrix += K.np.einsum(f"{tc},{ec}->{chars}", tmat, emat)
+        matrix = matrix.reshape(2 * (2 ** self.nqubits,))
+        return Hamiltonian(self.nqubits, matrix)
+
+    def expectation(self, state, normalize=False):
+        return Hamiltonian.expectation(self, state, normalize)
+
+    def ground_state(self):
+        """Computes the ground state of the Hamiltonian.
+
+        If this method is needed it should be implemented efficiently for the
+        particular Hamiltonian by passing the ``ground_state`` argument during
+        initialization. If this argument is not passed then this method will
+        diagonalize the full (dense) Hamiltonian matrix which is computationally
+        and memory intensive.
+        """
+        if self.ground_state_func is None:
+            log.info("Ground state function not available for ``TrotterHamiltonian``."
+                     "Using dense Hamiltonian eigenvectors.")
+            return self.eigenvectors()[:, 0]
+        return self.ground_state_func()
+
+    def is_compatible(self, o):
+        """Checks if a ``TrotterHamiltonian`` has the same part structure.
+
+        By part structure we mean that the target keys of the dictionaries
+        contained in the ``self.parts`` list are the same for both Hamiltonians.
+        Two :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` objects can be
+        added only when they are compatible (have the same part structure).
+        When using Trotter decomposition to simulate adiabatic evolution then
+        ``h0`` and ``h1`` should be compatible.
+
+        Args:
+            o: The Hamiltonian to check compatibility with.
+
+        Returns:
+            ``True`` if ``o`` has the same structure as ``self`` otherwise
+            ``False``.
+        """
+        if isinstance(o, self.__class__):
+            if len(self.parts) != len(o.parts):
+                return False
+            for part1, part2 in zip(self.parts, o.parts):
+                if set(part1.keys()) != set(part2.keys()):
+                    return False
+            return True
+        return False
+
     def make_compatible(self, o):
+        """Makes given ``TrotterHamiltonian`` compatible to the current one.
+
+        See :meth:`qibo.abstractions.hamiltonians.TrotterHamiltonian.is_compatible` for
+        more details on how compatibility is defined in this context.
+        The current method will be used automatically by
+        :class:`qibo.evolution.AdiabaticEvolution` to make the ``h0`` and ``h1``
+        Hamiltonians compatible if they are not.
+        We note that in some applications making the Hamiltonians compatible
+        manually instead of relying in this method may take better advantage of
+        caching and lead to better execution performance.
+
+        Args:
+            o: The ``TrotterHamiltonian`` to make compatible to the current.
+               Should be non-interacting (contain only one-qubit terms).
+
+        Returns:
+            A new :class:`qibo.abstractions.hamiltonians.TrotterHamiltonian` object
+            that is equivalent to ``o`` but has the same part structure as
+            ``self``.
+        """
         if not isinstance(o, self.__class__):
             raise TypeError("Only ``TrotterHamiltonians`` can be made "
                             "compatible but {} was given.".format(type(o)))
@@ -447,7 +677,6 @@ class TrotterHamiltonian(hamiltonians.TrotterHamiltonian):
             if v == 0:
                 raise_error(ValueError, "Given non-interacting Hamiltonian "
                                         "cannot be made compatible.")
-
         new_terms = {}
         for targets, matrices in term_matrices.items():
             n = len(targets)
@@ -463,25 +692,127 @@ class TrotterHamiltonian(hamiltonians.TrotterHamiltonian):
                      for part in self.parts]
         return self.__class__(*new_parts, ground_state=o.ground_state_func)
 
-    def calculate_dense_matrix(self):
-        if 2 * self.nqubits > len(EINSUM_CHARS): # pragma: no cover
-            # case not tested because it only happens in large examples
-            raise_error(NotImplementedError, "Not enough einsum characters.")
+    def __iter__(self):
+        """Helper iteration method to loop over the Hamiltonian terms."""
+        for part in self.parts:
+            for targets, term in part.items():
+                yield targets, term
 
-        matrix = K.np.zeros(2 * self.nqubits * (2,), dtype=self.dtype)
-        chars = EINSUM_CHARS[:2 * self.nqubits]
-        for targets, term in self:
-            tmat = term.matrix.reshape(2 * term.nqubits * (2,))
-            n = self.nqubits - len(targets)
-            emat = K.np.eye(2 ** n, dtype=self.dtype).reshape(2 * n * (2,))
-            gen = lambda x: (chars[i + x] for i in targets)
-            tc = "".join(itertools.chain(gen(0), gen(self.nqubits)))
-            ec = "".join((c for c in chars if c not in tc))
-            matrix += K.np.einsum(f"{tc},{ec}->{chars}", tmat, emat)
-        return matrix.reshape(2 * (2 ** self.nqubits,))
+    def _create_circuit(self, dt, accelerators=None, memory_device="/CPU:0"):
+        """Creates circuit that implements the Trotterized evolution."""
+        from qibo.models import Circuit
+        self._circuit = Circuit(self.nqubits, accelerators=accelerators,
+                                memory_device=memory_device)
+        self._circuit.check_initial_state_shape = False
+        self._circuit.dt = None
+        for part in itertools.chain(self.parts, self.parts[::-1]):
+            for targets, term in part.items():
+                gate = gates.Unitary(term.exp(dt / 2.0), *targets)
+                self.expgate_sets[term].add(gate)
+                self._circuit.add(gate)
 
-    def expectation(self, state, normalize=False):
-        return Hamiltonian.expectation(self, state, normalize)
+    def terms(self):
+        if self._terms is None:
+            self._terms = [gates.Unitary(term.matrix, *targets)
+                           for targets, term in self]
+        return self._terms
+
+    def circuit(self, dt, accelerators=None, memory_device="/CPU:0"):
+        """Circuit implementing second order Trotter time step.
+
+        Args:
+            dt (float): Time step to use for Trotterization.
+
+        Returns:
+            :class:`qibo.abstractions.circuit.AbstractCircuit` that implements a single
+            time step of the second order Trotterized evolution.
+        """
+        if self._circuit is None:
+            self._create_circuit(dt, accelerators, memory_device)
+        elif dt != self._circuit.dt:
+            self._circuit.dt = dt
+            self._circuit.set_parameters({
+                gate: term.exp(dt / 2.0)
+                for term, expgates in self.expgate_sets.items()
+                for gate in expgates})
+        return self._circuit
+
+    def _scalar_op(self, op, o):
+        """Helper method for implementing operations with scalars.
+
+        Args:
+            op (str): String that defines the operation, such as '__add__' or
+                '__mul__'.
+            o: Scalar to perform operation for.
+        """
+        new_parts = []
+        new_terms = {term: getattr(term, op)(o) for term in self.expgate_sets.keys()}
+        new_parts = ({targets: new_terms[term]
+                      for targets, term in part.items()}
+                     for part in self.parts)
+        new = self.__class__(*new_parts)
+        if self._dense is not None:
+            new.dense = getattr(self.dense, op)(o)
+        if self._circuit is not None:
+            new._circuit = self._circuit
+            new._circuit.dt = None
+            new.expgate_sets = {new_terms[term]: gate_set
+                              for term, gate_set in self.expgate_sets.items()}
+        return new
+
+    def _hamiltonian_op(self, op, o):
+        """Helper method for implementing operations between local Hamiltonians.
+
+        Args:
+            op (str): String that defines the operation, such as '__add__'.
+            o (:class:`qibo.abstractions.hamiltonians.TrotterHamiltonian`): Other local
+                Hamiltonian to perform the operation.
+        """
+        if len(self.parts) != len(o.parts):
+            raise_error(ValueError, "Cannot add local Hamiltonians if their "
+                                    "parts are not compatible.")
+
+        new_terms = {}
+        def new_parts():
+            for part1, part2 in zip(self.parts, o.parts):
+                if set(part1.keys()) != set(part2.keys()):
+                    raise_error(ValueError, "Cannot add local Hamiltonians "
+                                            "if their parts are not "
+                                            "compatible.")
+                new_part = {}
+                for targets in part1.keys():
+                    term_tuple = (part1[targets], part2[targets])
+                    if term_tuple not in new_terms:
+                        new_terms[term_tuple] = getattr(part1[targets], op)(
+                            part2[targets])
+                    new_part[targets] = new_terms[term_tuple]
+                yield new_part
+
+        new = self.__class__(*new_parts())
+        if self._circuit is not None:
+            new.expgate_sets = {new_term: self.expgate_sets[t1]
+                                for (t1, _), new_term in new_terms.items()}
+            new._circuit = self._circuit
+            new._circuit.dt = None
+        return new
+
+    def __add__(self, o):
+        if isinstance(o, self.__class__):
+            return self._hamiltonian_op("__add__", o)
+        else:
+            return self._scalar_op("__add__", o / self.nterms)
+
+    def __sub__(self, o):
+        if isinstance(o, self.__class__):
+            return self._hamiltonian_op("__sub__", o)
+        else:
+            return self._scalar_op("__sub__", o / self.nterms)
+
+    def __rsub__(self, o):
+        return self._scalar_op("__rsub__", o / self.nterms)
+
+    def __mul__(self, o):
+        return self._scalar_op("__mul__", o)
 
     def __matmul__(self, state):
         if isinstance(state, states.AbstractState):

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -6,8 +6,16 @@ from qibo.core.symbolic import multikron
 
 
 class Hamiltonian(hamiltonians.MatrixHamiltonian):
-    """Backend implementation of :class:`qibo.abstractions.hamiltonians.Hamiltonian`."""
+    """Backend implementation of :class:`qibo.abstractions.hamiltonians.MatrixHamiltonian`.
 
+    Args:
+        nqubits (int): number of quantum bits.
+        matrix (np.ndarray): Matrix representation of the Hamiltonian in the
+            computational basis as an array of shape ``(2 ** nqubits, 2 ** nqubits)``.
+        numpy (bool): If ``True`` the Hamiltonian is created using numpy as the
+            calculation backend, otherwise the selected backend is used.
+            Default option is ``numpy = False``.
+    """
     def __new__(cls, nqubits, matrix, numpy=False):
         if not isinstance(matrix, K.tensor_types):
             raise_error(TypeError, "Matrix of invalid type {} given during "
@@ -73,12 +81,6 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
         return self._eigenvectors
 
     def exp(self, a):
-        """Computes a tensor corresponding to exp(-1j * a * H).
-
-        Args:
-            a (complex): Complex number to multiply Hamiltonian before
-                exponentiation.
-        """
         if self._exp.get("a") != a:
             self._exp["a"] = a
             if self._eigenvectors is None:
@@ -118,7 +120,6 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
         return self.K.eye(n, dtype=self.matrix.dtype)
 
     def __add__(self, o):
-        """Add operator."""
         if isinstance(o, self.__class__):
             if self.nqubits != o.nqubits:
                 raise_error(RuntimeError, "Only hamiltonians with the same "
@@ -132,7 +133,6 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
         return self.__class__(self.nqubits, new_matrix)
 
     def __sub__(self, o):
-        """Subtraction operator."""
         if isinstance(o, self.__class__):
             if self.nqubits != o.nqubits:
                 raise_error(RuntimeError, "Only hamiltonians with the same "
@@ -146,7 +146,6 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
         return self.__class__(self.nqubits, new_matrix)
 
     def __rsub__(self, o):
-        """Right subtraction operator."""
         if isinstance(o, self.__class__): # pragma: no cover
             # impractical case because it will be handled by `__sub__`
             if self.nqubits != o.nqubits:
@@ -161,7 +160,6 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
         return self.__class__(self.nqubits, new_matrix)
 
     def __mul__(self, o):
-        """Multiplication to scalar operator."""
         if isinstance(o, self.K.Tensor):
             o = self.K.cast(o, dtype=self.matrix.dtype)
         if isinstance(o, K.numeric_types) or isinstance(o, K.tensor_types):
@@ -183,7 +181,6 @@ class Hamiltonian(hamiltonians.MatrixHamiltonian):
                                              "not implemented.".format(type(o)))
 
     def __matmul__(self, o):
-        """Matrix multiplication with other Hamiltonians or state vectors."""
         if isinstance(o, self.__class__):
             new_matrix = self.K.matmul(self.matrix, o.matrix)
             return self.__class__(self.nqubits, new_matrix)
@@ -217,6 +214,13 @@ class NumpyHamiltonian(Hamiltonian):
 
 
 class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
+    """Backend implementation of :class:`qibo.abstractions.hamiltonians.SymbolicHamiltonian`.
+
+    Args:
+        form (sympy.Expr): Hamiltonian form as a ``sympy.Expr``. The Hamiltonian
+            should be created using Qibo symbols.
+            See ... # TODO: Add example here for more details.
+    """
 
     def __init__(self, form=None, terms=None):
         super().__init__()

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -303,6 +303,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             temp_state = K.copy(state)
             for factor in term:
                 if density_matrix:
+                    factor.gate.density_matrix = True
                     temp_state = factor.gate.density_matrix_half_call(temp_state)
                 else:
                     temp_state = factor.gate(temp_state)

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -222,30 +222,27 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             See ... # TODO: Add example here for more details.
     """
 
-    def __init__(self, form=None, terms=None):
+    def __init__(self, form, terms=None):
         super().__init__()
         import sympy
         from qibo.symbols import SymbolicTerm
-        if form is not None:
-            if not issubclass(form.__class__, sympy.Expr):
-                raise_error(TypeError, "Symbolic Hamiltonian should be a "
-                                       "`sympy` expression but is {}."
-                                       "".format(type(form)))
-            if terms is not None:
-                raise_error(ValueError, "Cannot construct `SymbolicHamiltonian` "
-                                        "when both form and terms are given.")
-            self.form = sympy.expand(form)
+        if not issubclass(form.__class__, sympy.Expr):
+            raise_error(TypeError, "Symbolic Hamiltonian should be a ``sympy`` "
+                                   "expression but is {}.".format(type(form)))
+        self.form = sympy.expand(form)
+        if terms is None:
             termsdict = self.form.as_coefficients_dict()
             self.terms = [SymbolicTerm(c, f) for f, c in termsdict.items()]
         else:
-            if terms is None:
-                raise_error(ValueError, "Cannot construct `SymbolicHamiltonian` "
-                                        "if no form or terms are given.")
             self.terms = terms
-            self.form = sum(term.full() for term in self.terms)
 
         self.nqubits = max(factor.target_qubit for term in self.terms for factor in term) + 1
         self._dense = None
+
+    @classmethod
+    def from_terms(cls, terms):
+        form = sum(term.full() for term in terms)
+        return cls(form, terms)
 
     def calculate_dense(self):
         matrix = 0

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -315,7 +315,8 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             rank = len(tuple(o.shape))
             if rank == 1: # vector
                 return self.apply_gates(o)
-            elif rank == 2: # matrix # TODO: Fix this
+            elif rank == 2: # pragma: no cover
+                # matrix # TODO: Fix this
                 raise_error(NotImplementedError, "Cannot multiply `SymbolicHamiltonian` "
                                                  "with density matrix.")
             else:

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -153,8 +153,8 @@ class MatrixState(VectorState):
         return K.reshape(K.cast(state, dtype='DTYPE'), len(qubits) * (2,))
 
     def expectation(self, hamiltonian, normalize=False):
-        from qibo.abstractions.hamiltonians import TrotterHamiltonian
-        if isinstance(hamiltonian, TrotterHamiltonian):
+        from qibo.abstractions.hamiltonians import SymbolicHamiltonian
+        if isinstance(hamiltonian, SymbolicHamiltonian):
             # use dense form of Trotter Hamiltonians because their
             # multiplication to rank-2 tensors is not implemented
             hamiltonian = hamiltonian.dense

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -153,8 +153,8 @@ class MatrixState(VectorState):
         return K.reshape(K.cast(state, dtype='DTYPE'), len(qubits) * (2,))
 
     def expectation(self, hamiltonian, normalize=False):
-        from qibo.abstractions.hamiltonians import SymbolicHamiltonian
-        if isinstance(hamiltonian, SymbolicHamiltonian):
+        from qibo.abstractions.hamiltonians import TrotterHamiltonian
+        if isinstance(hamiltonian, TrotterHamiltonian):
             # use dense form of Trotter Hamiltonians because their
             # multiplication to rank-2 tensors is not implemented
             hamiltonian = hamiltonian.dense

--- a/src/qibo/hamiltonians.py
+++ b/src/qibo/hamiltonians.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from qibo import matrices, K
 from qibo.config import raise_error
-from qibo.core.hamiltonians import Hamiltonian, TrotterHamiltonian
+from qibo.core.hamiltonians import Hamiltonian, TrotterHamiltonian, SymbolicHamiltonian
 from qibo.core.symbolic import multikron
 
 

--- a/src/qibo/models/evolution.py
+++ b/src/qibo/models/evolution.py
@@ -54,12 +54,12 @@ class StateEvolution:
         self.dt = dt
 
         if (accelerators is not None and
-            (not isinstance(ham, hamiltonians.TrotterHamiltonian)
+            (not isinstance(ham, hamiltonians.SymbolicHamiltonian)
              or solver != "exp")):
             raise_error(NotImplementedError, "Distributed evolution is only "
                                              "implemented using the Trotter "
                                              "exponential solver.")
-        if isinstance(ham, hamiltonians.TrotterHamiltonian):
+        if isinstance(ham, hamiltonians.SymbolicHamiltonian):
             ham.circuit(dt, accelerators, memory_device)
         self.solver = solvers.factory[solver](self.dt, hamiltonian)
 
@@ -174,7 +174,7 @@ class AdiabaticEvolution(StateEvolution):
         if h0.nqubits != h1.nqubits:
             raise_error(ValueError, "H0 has {} qubits while H1 has {}."
                                     "".format(h0.nqubits, h1.nqubits))
-        if isinstance(h0, hamiltonians.TrotterHamiltonian):
+        if isinstance(h0, hamiltonians.SymbolicHamiltonian):
             if not h1.is_compatible(h0):
                 h0 = h1.make_compatible(h0)
         super(AdiabaticEvolution, self).__init__(h0, dt, solver, callbacks,

--- a/src/qibo/models/evolution.py
+++ b/src/qibo/models/evolution.py
@@ -54,12 +54,12 @@ class StateEvolution:
         self.dt = dt
 
         if (accelerators is not None and
-            (not isinstance(ham, hamiltonians.SymbolicHamiltonian)
+            (not isinstance(ham, hamiltonians.TrotterHamiltonian)
              or solver != "exp")):
             raise_error(NotImplementedError, "Distributed evolution is only "
                                              "implemented using the Trotter "
                                              "exponential solver.")
-        if isinstance(ham, hamiltonians.SymbolicHamiltonian):
+        if isinstance(ham, hamiltonians.TrotterHamiltonian):
             ham.circuit(dt, accelerators, memory_device)
         self.solver = solvers.factory[solver](self.dt, hamiltonian)
 
@@ -174,7 +174,7 @@ class AdiabaticEvolution(StateEvolution):
         if h0.nqubits != h1.nqubits:
             raise_error(ValueError, "H0 has {} qubits while H1 has {}."
                                     "".format(h0.nqubits, h1.nqubits))
-        if isinstance(h0, hamiltonians.SymbolicHamiltonian):
+        if isinstance(h0, hamiltonians.TrotterHamiltonian):
             if not h1.is_compatible(h0):
                 h0 = h1.make_compatible(h0)
         super(AdiabaticEvolution, self).__init__(h0, dt, solver, callbacks,

--- a/src/qibo/models/evolution.py
+++ b/src/qibo/models/evolution.py
@@ -41,11 +41,11 @@ class StateEvolution:
 
     def __init__(self, hamiltonian, dt, solver="exp", callbacks=[],
                  accelerators=None, memory_device="/CPU:0"):
-        if isinstance(hamiltonian, hamiltonians.HAMILTONIAN_TYPES):
+        if isinstance(hamiltonian, hamiltonians.AbstractHamiltonian):
             ham = hamiltonian
         else:
             ham = hamiltonian(0)
-            if not isinstance(ham, hamiltonians.HAMILTONIAN_TYPES):
+            if not isinstance(ham, hamiltonians.AbstractHamiltonian):
                 raise TypeError("Hamiltonian type {} not understood."
                                 "".format(type(ham)))
         self.nqubits = ham.nqubits
@@ -165,7 +165,7 @@ class AdiabaticEvolution(StateEvolution):
 
     def __init__(self, h0, h1, s, dt, solver="exp", callbacks=[],
                  accelerators=None, memory_device="/CPU:0"):
-        if not issubclass(type(h0), hamiltonians.HAMILTONIAN_TYPES):
+        if not issubclass(type(h0), hamiltonians.AbstractHamiltonian):
             raise_error(TypeError, "h0 should be a hamiltonians.Hamiltonian "
                                    "object but is {}.".format(type(h0)))
         if type(h1) != type(h0):

--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -131,14 +131,14 @@ class QAOA(object):
     """
     from qibo import hamiltonians, optimizers
     from qibo.core import states
-    from qibo.abstractions.hamiltonians import HAMILTONIAN_TYPES
+    from qibo.abstractions.hamiltonians import AbstractHamiltonian
 
     def __init__(self, hamiltonian, mixer=None, solver="exp", callbacks=[],
                  accelerators=None, memory_device="/CPU:0"):
         # list of QAOA variational parameters (angles)
         self.params = None
         # problem hamiltonian
-        if not isinstance(hamiltonian, self.HAMILTONIAN_TYPES):
+        if not isinstance(hamiltonian, AbstractHamiltonian):
             raise_error(TypeError, "Invalid Hamiltonian type {}."
                                    "".format(type(hamiltonian)))
         self.hamiltonian = hamiltonian

--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -131,10 +131,10 @@ class QAOA(object):
     """
     from qibo import hamiltonians, optimizers
     from qibo.core import states
-    from qibo.abstractions.hamiltonians import AbstractHamiltonian
 
     def __init__(self, hamiltonian, mixer=None, solver="exp", callbacks=[],
                  accelerators=None, memory_device="/CPU:0"):
+        from qibo.abstractions.hamiltonians import AbstractHamiltonian
         # list of QAOA variational parameters (angles)
         self.params = None
         # problem hamiltonian

--- a/src/qibo/solvers.py
+++ b/src/qibo/solvers.py
@@ -14,7 +14,7 @@ class BaseSolver:
 
     def __init__(self, dt, hamiltonian):
         self.dt = dt
-        if issubclass(type(hamiltonian), hamiltonians.HAMILTONIAN_TYPES):
+        if isinstance(hamiltonian, hamiltonians.AbstractHamiltonian):
             self.hamiltonian = lambda t: hamiltonian
         else:
             self.hamiltonian = hamiltonian
@@ -61,11 +61,11 @@ class Exponential(BaseSolver):
     """
 
     def __new__(cls, dt, hamiltonian):
-        if issubclass(type(hamiltonian), hamiltonians.HAMILTONIAN_TYPES):
+        if isinstance(hamiltonian, hamiltonians.AbstractHamiltonian):
             h0 = hamiltonian
         else:
             h0 = hamiltonian(0)
-        if isinstance(h0, hamiltonians.TrotterHamiltonian):
+        if isinstance(h0, hamiltonians.SymbolicHamiltonian):
             return TrotterizedExponential(dt, hamiltonian)
         else:
             return super(Exponential, cls).__new__(cls)

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -1,5 +1,6 @@
 import sympy
 from qibo import gates, matrices, K
+from qibo.config import raise_error
 
 
 class Symbol(sympy.Symbol):
@@ -24,7 +25,7 @@ class Symbol(sympy.Symbol):
         return self._gate
 
     def calculate_gate(self):
-        return gates.Unitary(self.matrix, *self.target_qubits)
+        return gates.Unitary(self.matrix, self.target_qubit)
 
 
 class PauliSymbol(Symbol):

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -58,7 +58,6 @@ class SymbolicTerm(list):
 
     def __init__(self, coefficient, factors):
         super().__init__()
-        self.coefficient = coefficient
 
         ordered_factors = []
         if factors != 1:
@@ -77,8 +76,10 @@ class SymbolicTerm(list):
                 if isinstance(factor.matrix, K.qnp.tensor_types):
                     self.extend(pow * [factor])
                 else:
-                    self.coefficient *= factor.matrix
+                    coefficient *= factor.matrix
             elif factor == sympy.I:
-                self.coefficient *= 1j
+                coefficient *= 1j
             else:
                 raise_error(TypeError, "Cannot parse factor {}.".format(factor))
+
+        self.coefficient = complex(coefficient)

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -12,7 +12,7 @@ class Symbol(sympy.Symbol):
         self.target_qubit = q
         self._gate = None
         if not (matrix is None or isinstance(matrix, K.qnp.numeric_types) or
-                isinstance(K.qnp.tensor_types)):
+                isinstance(matrix, K.qnp.tensor_types)):
             raise_error(TypeError, "Invalid type {} of symbol matrix."
                                    "".format(type(matrix)))
         self.matrix = matrix

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -17,7 +17,7 @@ class Symbol(sympy.Symbol):
 
     def __new__(cls, q, matrix=None, name="Symbol"):
         name = "{}{}".format(name, q)
-        return super().__new__(cls=cls, name=name)
+        return super().__new__(cls=cls, name=name, commutative=False)
 
     def __init__(self, q, matrix=None, name="Symbol"):
         self.target_qubit = q

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -84,3 +84,9 @@ class SymbolicTerm(list):
                 raise_error(TypeError, "Cannot parse factor {}.".format(factor))
 
         self.coefficient = complex(coefficient)
+
+    def full(self):
+        term = self.coefficient
+        for factor in self:
+            term *= factor
+        return term

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -1,0 +1,84 @@
+import sympy
+from qibo import gates, matrices, K
+
+
+class Symbol(sympy.Symbol):
+
+    def __new__(cls, q, matrix=None, name="Symbol"):
+        name = "{}{}".format(name, q)
+        return super().__new__(cls=cls, name=name)
+
+    def __init__(self, q, matrix=None, name="Symbol"):
+        self.target_qubit = q
+        self._gate = None
+        if not (matrix is None or isinstance(matrix, K.qnp.numeric_types) or
+                isinstance(K.qnp.tensor_types)):
+            raise_error(TypeError, "Invalid type {} of symbol matrix."
+                                   "".format(type(matrix)))
+        self.matrix = matrix
+
+    @property
+    def gate(self):
+        if self._gate is None:
+            self._gate = self.calculate_gate()
+        return self._gate
+
+    def calculate_gate(self):
+        return gates.Unitary(self.matrix, *self.target_qubits)
+
+
+class PauliSymbol(Symbol):
+
+    def __new__(cls, q):
+        return super().__new__(cls=cls, q=q, name=cls.__name__)
+
+    def __init__(self, q):
+        self.target_qubit = q
+        self._gate = None
+        self.matrix = getattr(matrices, self.__class__.__name__)
+
+    def calculate_gate(self):
+        name = self.__class__.__name__
+        return getattr(gates, name)(self.target_qubit)
+
+
+class X(PauliSymbol):
+    pass
+
+
+class Y(PauliSymbol):
+    pass
+
+
+class Z(PauliSymbol):
+    pass
+
+
+class SymbolicTerm(list):
+
+    def __init__(self, coefficient, factors):
+        super().__init__()
+        self.coefficient = coefficient
+
+        ordered_factors = []
+        if factors != 1:
+            ordered_factors = factors.as_ordered_factors()
+
+        for factor in ordered_factors:
+            if isinstance(factor, sympy.Pow):
+                factor, pow = factor.args
+                assert isinstance(pow, sympy.Integer)
+                assert isinstance(factor, sympy.Symbol)
+                pow = int(pow)
+            else:
+                pow = 1
+
+            if isinstance(factor, sympy.Symbol):
+                if isinstance(factor.matrix, K.qnp.tensor_types):
+                    self.extend(pow * [factor])
+                else:
+                    self.coefficient *= factor.matrix
+            elif factor == sympy.I:
+                self.coefficient *= 1j
+            else:
+                raise_error(TypeError, "Cannot parse factor {}.".format(factor))

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -132,14 +132,7 @@ class SymbolicTerm(list):
                     coefficient *= factor.matrix
             elif factor == sympy.I:
                 coefficient *= 1j
-            else:
+            else: # pragma: no cover
                 raise_error(TypeError, "Cannot parse factor {}.".format(factor))
 
         self.coefficient = complex(coefficient)
-
-    def full(self):
-        """Recreates the full ``sympy.Expr`` corresponding to the term."""
-        term = self.coefficient
-        for factor in self:
-            term *= factor
-        return term

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -4,6 +4,16 @@ from qibo.config import raise_error
 
 
 class Symbol(sympy.Symbol):
+    """Qibo specialization for ``sympy`` symbols.
+
+    These symbols can be used to create :class:`qibo.core.hamiltonians.SymbolicHamiltonian`.
+
+    Args:
+        q (int): Target qubit id.
+        matrix (np.ndarray): 2x2 matrix represented by this symbol.
+        name (str): Name of the symbol which defines how it is represented in
+            symbolic expressions.
+    """
 
     def __new__(cls, q, matrix=None, name="Symbol"):
         name = "{}{}".format(name, q)
@@ -20,6 +30,7 @@ class Symbol(sympy.Symbol):
 
     @property
     def gate(self):
+        """Qibo gate that implements the action of the symbol on states."""
         if self._gate is None:
             self._gate = self.calculate_gate()
         return self._gate
@@ -44,18 +55,51 @@ class PauliSymbol(Symbol):
 
 
 class X(PauliSymbol):
+    """Qibo symbol for the Pauli-X operator.
+
+    Args:
+        q (int): Target qubit id.
+    """
     pass
 
 
 class Y(PauliSymbol):
+    """Qibo symbol for the Pauli-X operator.
+
+    Args:
+        q (int): Target qubit id.
+    """
     pass
 
 
 class Z(PauliSymbol):
+    """Qibo symbol for the Pauli-X operator.
+
+    Args:
+        q (int): Target qubit id.
+    """
     pass
 
 
 class SymbolicTerm(list):
+    """Helper method for parsing symbolic Hamiltonian terms.
+
+    Each :class:`qibo.symbols.SymbolicTerm` corresponds to a term in the
+    Hamiltonian.
+
+    Example:
+        ::
+
+            from qibo.symbols import X, Y, SymbolicTerm
+            sham = X(0) * X(1) + 2 * Y(0) * Y(1)
+            termsdict = sham.as_coefficients_dict()
+            sterms = [SymbolicTerm(c, f) for f, c in termsdict.items()]
+
+    Args:
+        coefficient (complex): Complex number coefficient of the underlying
+            term in the Hamiltonian.
+        factors (sympy.Expr): Sympy expression for the underlying term.
+    """
 
     def __init__(self, coefficient, factors):
         super().__init__()
@@ -86,6 +130,7 @@ class SymbolicTerm(list):
         self.coefficient = complex(coefficient)
 
     def full(self):
+        """Recreates the full ``sympy.Expr`` corresponding to the term."""
         term = self.coefficient
         for factor in self:
             term *= factor

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -99,11 +99,15 @@ class SymbolicTerm(list):
         coefficient (complex): Complex number coefficient of the underlying
             term in the Hamiltonian.
         factors (sympy.Expr): Sympy expression for the underlying term.
+        symbol_map (dict): Dictionary that maps symbols in the given ``factors``
+            expression to tuples of (target qubit id, matrix).
+            This is required only if the expression is not created using Qibo
+            symbols and to keep compatibility with older versions where Qibo
+            symbols were not available.
     """
 
-    def __init__(self, coefficient, factors):
+    def __init__(self, coefficient, factors, symbol_map=None):
         super().__init__()
-
         ordered_factors = []
         if factors != 1:
             ordered_factors = factors.as_ordered_factors()
@@ -116,6 +120,10 @@ class SymbolicTerm(list):
                 pow = int(pow)
             else:
                 pow = 1
+
+            if symbol_map is not None and factor in symbol_map:
+                q, matrix = symbol_map.get(factor)
+                factor = Symbol(q, matrix, name=factor.name)
 
             if isinstance(factor, sympy.Symbol):
                 if isinstance(factor.matrix, K.qnp.tensor_types):

--- a/src/qibo/tests/test_core_hamiltonians_from_symbols.py
+++ b/src/qibo/tests/test_core_hamiltonians_from_symbols.py
@@ -1,0 +1,258 @@
+"""Test dense matrix of Hamiltonians constructed using symbols."""
+import pytest
+import numpy as np
+import sympy
+from qibo import hamiltonians, matrices, K
+from qibo.tests.utils import random_hermitian
+
+
+@pytest.mark.parametrize("nqubits", [4, 5])
+@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
+def test_tfim_hamiltonian_from_symbols(nqubits, hamtype):
+    """Check creating TFIM Hamiltonian using sympy."""
+    if hamtype == "symbolic":
+        from qibo.symbols import X, Z
+        h = 0.5
+        symham = sum(Z(i) * Z(i + 1) for i in range(nqubits - 1))
+        symham += Z(0) * Z(nqubits - 1)
+        symham += h * sum(X(i) for i in range(nqubits))
+        ham = hamiltonians.SymbolicHamiltonian(-symham)
+    else:
+        h = 0.5
+        z_symbols = sympy.symbols(" ".join((f"Z{i}" for i in range(nqubits))))
+        x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(nqubits))))
+
+        symham = sum(z_symbols[i] * z_symbols[i + 1] for i in range(nqubits - 1))
+        symham += z_symbols[0] * z_symbols[-1]
+        symham += h * sum(x_symbols)
+        symmap = {z: (i, matrices.Z) for i, z in enumerate(z_symbols)}
+        symmap.update({x: (i, matrices.X) for i, x in enumerate(x_symbols)})
+        if hamtype == "trotter":
+            ham = hamiltonians.TrotterHamiltonian.from_symbolic(-symham, symmap)
+            ham = ham.dense
+        else:
+            ham = hamiltonians.Hamiltonian.from_symbolic(-symham, symmap)
+
+    final_matrix = ham.matrix
+    target_matrix = hamiltonians.TFIM(nqubits, h=h).matrix
+    np.testing.assert_allclose(final_matrix, target_matrix)
+
+
+@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
+def test_from_symbolic_with_power(hamtype):
+    """Check ``from_symbolic`` when the expression contains powers."""
+    if hamtype == "symbolic":
+        from qibo.symbols import Symbol
+        matrix = random_hermitian(1)
+        symham =  (Symbol(0, matrix) ** 2 - Symbol(1, matrix) ** 2 +
+                   3 * Symbol(1, matrix) - 2 * Symbol(0, matrix) * Symbol(2, matrix) + 1)
+        ham = hamiltonians.SymbolicHamiltonian(symham)
+    else:
+        z = sympy.symbols(" ".join((f"Z{i}" for i in range(3))))
+        symham =  z[0] ** 2 - z[1] ** 2 + 3 * z[1] - 2 * z[0] * z[2] + 1
+        matrix = random_hermitian(1)
+        symmap = {x: (i, matrix) for i, x in enumerate(z)}
+        if hamtype == "trotter":
+            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
+            ham = ham.dense
+        else:
+            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
+
+    final_matrix = ham.matrix
+    matrix2 = matrix.dot(matrix)
+    eye = np.eye(2, dtype=matrix.dtype)
+    target_matrix = np.kron(np.kron(matrix2, eye), eye)
+    target_matrix -= np.kron(np.kron(eye, matrix2), eye)
+    target_matrix += 3 * np.kron(np.kron(eye, matrix), eye)
+    target_matrix -= 2 * np.kron(np.kron(matrix, eye), matrix)
+    target_matrix += np.eye(8, dtype=matrix.dtype)
+    np.testing.assert_allclose(final_matrix, target_matrix)
+
+
+@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
+def test_from_symbolic_with_complex_numbers(hamtype):
+    """Check ``from_symbolic`` when the expression contains imaginary unit."""
+    if hamtype == "symbolic":
+        from qibo.symbols import X, Y
+        symham = (1 + 2j) * X(0) * X(1) + 2 * Y(0) * Y(1) - 3j * X(0) * Y(1) + 1j * Y(0) * X(1)
+        ham = hamiltonians.SymbolicHamiltonian(symham)
+    else:
+        x = sympy.symbols(" ".join((f"X{i}" for i in range(2))))
+        y = sympy.symbols(" ".join((f"Y{i}" for i in range(2))))
+        symham = (1 + 2j) * x[0] * x[1] + 2 * y[0] * y[1] - 3j * x[0] * y[1] + 1j * y[0] * x[1]
+        symmap = {s: (i, matrices.X) for i, s in enumerate(x)}
+        symmap.update({s: (i, matrices.Y) for i, s in enumerate(y)})
+        if hamtype == "trotter":
+            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
+            ham = ham.dense
+        else:
+            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
+
+    final_matrix = ham.matrix
+    target_matrix = (1 + 2j) * np.kron(matrices.X, matrices.X)
+    target_matrix += 2 * np.kron(matrices.Y, matrices.Y)
+    target_matrix -= 3j * np.kron(matrices.X, matrices.Y)
+    target_matrix += 1j * np.kron(matrices.Y, matrices.X)
+    np.testing.assert_allclose(final_matrix, target_matrix)
+
+
+def test_from_symbolic_application_hamiltonian():
+    """Check ``from_symbolic`` for a specific four-qubit Hamiltonian."""
+    z1, z2, z3, z4 = sympy.symbols("z1 z2 z3 z4")
+    symmap = {z: (i, matrices.Z) for i, z in enumerate([z1, z2, z3, z4])}
+    symham = (z1 * z2 - 0.5 * z1 * z3 + 2 * z2 * z3 + 0.35 * z2
+              + 0.25 * z3 * z4 + 0.5 * z3 + z4 - z1)
+    # Check that Trotter dense matrix agrees will full Hamiltonian matrix
+    fham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
+    tham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
+    from qibo.symbols import Z
+    symham = (Z(0) * Z(1) - 0.5 * Z(0) * Z(2) + 2 * Z(1) * Z(2) + 0.35 * Z(1)
+              + 0.25 * Z(2) * Z(3) + 0.5 * Z(2) + Z(3) - Z(0))
+    sham = hamiltonians.SymbolicHamiltonian(symham)
+    np.testing.assert_allclose(tham.dense.matrix, fham.matrix)
+    np.testing.assert_allclose(sham.matrix, fham.matrix)
+    # Check that no one-qubit terms exist in the Trotter Hamiltonian
+    # (this means that merging was successful)
+    first_targets = set()
+    for part in tham.parts:
+        for targets, term in part.items():
+            first_targets.add(targets[0])
+            assert len(targets) == 2
+            assert term.nqubits == 2
+    assert first_targets == set(range(4))
+    # Check making an ``X`` Hamiltonian compatible with ``tham``
+    xham = hamiltonians.X(nqubits=4, trotter=True)
+    cxham = tham.make_compatible(xham)
+    assert not tham.is_compatible(xham)
+    assert tham.is_compatible(cxham)
+    np.testing.assert_allclose(xham.dense.matrix, cxham.dense.matrix)
+
+
+@pytest.mark.parametrize("nqubits", [4, 5])
+@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
+def test_x_hamiltonian_from_symbols(nqubits, hamtype):
+    """Check creating sum(X) Hamiltonian using sympy."""
+    if hamtype == "symbolic":
+        from qibo.symbols import X
+        symham = -sum(X(i) for i in range(nqubits))
+        ham = hamiltonians.SymbolicHamiltonian(symham)
+    else:
+        x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(nqubits))))
+        symham =  -sum(x_symbols)
+        symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
+        if hamtype == "trotter":
+            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
+            ham = ham.dense
+        else:
+            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
+    final_matrix = ham.matrix
+    target_matrix = hamiltonians.X(nqubits).matrix
+    np.testing.assert_allclose(final_matrix, target_matrix)
+
+
+@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
+def test_three_qubit_term_hamiltonian_from_symbols(hamtype):
+    """Check creating Hamiltonian with three-qubit interaction using sympy."""
+    if hamtype == "symbolic":
+        from qibo.symbols import X, Y, Z
+        symham = X(0) * Y(1) * Z(2) + 0.5 * Y(0) * Z(1) * X(3) + Z(0) * X(2)
+        symham += Y(2) + 1.5 * Z(1) - 2 - 3 * X(1) * Y(3)
+        ham = hamiltonians.SymbolicHamiltonian(symham)
+    else:
+        x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(4))))
+        y_symbols = sympy.symbols(" ".join((f"Y{i}" for i in range(4))))
+        z_symbols = sympy.symbols(" ".join((f"Z{i}" for i in range(4))))
+        symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
+        symmap.update({x: (i, matrices.Y) for i, x in enumerate(y_symbols)})
+        symmap.update({x: (i, matrices.Z) for i, x in enumerate(z_symbols)})
+
+        symham = x_symbols[0] * y_symbols[1] * z_symbols[2]
+        symham += 0.5 * y_symbols[0] * z_symbols[1] * x_symbols[3]
+        symham += z_symbols[0] * x_symbols[2]
+        symham += -3 * x_symbols[1] * y_symbols[3]
+        symham += y_symbols[2]
+        symham += 1.5 * z_symbols[1]
+        symham -= 2
+        if hamtype == "trotter":
+            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
+            ham = ham.dense
+        else:
+            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
+
+    final_matrix = ham.matrix
+
+    target_matrix = np.kron(np.kron(matrices.X, matrices.Y),
+                            np.kron(matrices.Z, matrices.I))
+    target_matrix += 0.5 * np.kron(np.kron(matrices.Y, matrices.Z),
+                                   np.kron(matrices.I, matrices.X))
+    target_matrix += np.kron(np.kron(matrices.Z, matrices.I),
+                             np.kron(matrices.X, matrices.I))
+    target_matrix += -3 * np.kron(np.kron(matrices.I, matrices.X),
+                             np.kron(matrices.I, matrices.Y))
+    target_matrix += np.kron(np.kron(matrices.I, matrices.I),
+                             np.kron(matrices.Y, matrices.I))
+    target_matrix += 1.5 * np.kron(np.kron(matrices.I, matrices.Z),
+                                   np.kron(matrices.I, matrices.I))
+    target_matrix -= 2 * np.eye(2**4, dtype=target_matrix.dtype)
+    np.testing.assert_allclose(final_matrix, target_matrix)
+
+
+@pytest.mark.parametrize("sufficient", [True, False])
+def test_symbolic_hamiltonian_merge_one_qubit(sufficient):
+    """Check that ``merge_one_qubit`` works both when two-qubit are sufficient and no."""
+    from qibo.hamiltonians import TrotterHamiltonian
+    x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(5))))
+    z_symbols = sympy.symbols(" ".join((f"Z{i}" for i in range(5))))
+    symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
+    symmap.update({x: (i, matrices.Z) for i, x in enumerate(z_symbols)})
+    symham = sum(z_symbols[i] * z_symbols[i + 1] for i in range(4))
+    symham += sum(x_symbols)
+    if sufficient:
+        symham += z_symbols[0] * z_symbols[-1]
+    merged, _ = TrotterHamiltonian.symbolic_terms(symham, symmap)
+
+    two_qubit_keys = {(i, i + 1) for i in range(4)}
+    if sufficient:
+        target_matrix = (np.kron(matrices.Z, matrices.Z) +
+                         np.kron(matrices.X, matrices.I))
+        two_qubit_keys.add((4, 0))
+        assert set(merged.keys()) == two_qubit_keys
+        for matrix in merged.values():
+            np.testing.assert_allclose(matrix, target_matrix)
+    else:
+        one_qubit_keys = {(i,) for i in range(5)}
+        assert set(merged.keys()) == one_qubit_keys | two_qubit_keys
+        target_matrix = matrices.X
+        for t in one_qubit_keys:
+            np.testing.assert_allclose(merged[t], target_matrix)
+        target_matrix = np.kron(matrices.Z, matrices.Z)
+        for t in two_qubit_keys:
+            np.testing.assert_allclose(merged[t], target_matrix)
+
+
+def test_symbolic_hamiltonian_errors():
+    """Check errors raised by :meth:`qibo.core.symbolic.parse_symbolic`."""
+    from qibo.core.symbolic import parse_symbolic
+    a, b = sympy.symbols("a b")
+    ham = a * b
+    # Bad hamiltonian type
+    with pytest.raises(TypeError):
+        sh = parse_symbolic("test", "test")
+    # Bad symbol map type
+    with pytest.raises(TypeError):
+        sh = parse_symbolic(ham, "test")
+    # Bad symbol map key
+    with pytest.raises(TypeError):
+        sh = parse_symbolic(ham, {"a": 2})
+    # Bad symbol map value
+    with pytest.raises(TypeError):
+        sh = parse_symbolic(ham, {a: 2})
+    with pytest.raises(ValueError):
+        sh = parse_symbolic(ham, {a: (1, 2, 3)})
+    # Missing symbol
+    with pytest.raises(ValueError):
+        sh = parse_symbolic(ham, {a: (0, matrices.X)})
+    # Factor that cannot be parsed
+    ham = a * b + sympy.cos(a) * b
+    with pytest.raises(ValueError):
+        sh = parse_symbolic(ham, {a: (0, matrices.X), b: (1, matrices.Z)})

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -20,7 +20,10 @@ def test_symbolic_hamiltonian_init():
     # Wrong type of symbolic expression
     with pytest.raises(TypeError):
         ham = hamiltonians.SymbolicHamiltonian("test")
-    # TODO: Complete this when `SymbolicHamiltonian.__init__` is completed
+    # Wrong type of Symbol matrix
+    from qibo.symbols import Symbol
+    with pytest.raises(TypeError):
+        s = Symbol(0, "test")
 
 
 @pytest.mark.parametrize("nqubits", [3, 4])
@@ -32,39 +35,54 @@ def test_symbolic_hamiltonian_to_dense(nqubits):
     np.testing.assert_allclose(final_ham.matrix, target_ham.matrix, atol=1e-15)
 
 
-def test_symbolic_hamiltonian_scalar_mul(nqubits=3):
+@pytest.mark.parametrize("calcdense", [False, True])
+def test_symbolic_hamiltonian_scalar_mul(calcdense, nqubits=3):
     """Test multiplication of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 * hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
+    if calcdense:
+        _ = local_ham.dense
     local_dense = (2 * local_ham).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcdense:
+        _ = local_ham.dense
     local_dense = (local_ham * 2).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
-def test_symbolic_hamiltonian_scalar_add(nqubits=4):
+@pytest.mark.parametrize("calcdense", [False, True])
+def test_symbolic_hamiltonian_scalar_add(calcdense, nqubits=4):
     """Test addition of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 + hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
+    if calcdense:
+        _ = local_ham.dense
     local_dense = (2 + local_ham).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcdense:
+        _ = local_ham.dense
     local_dense = (local_ham + 2).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
-def test_symbolic_hamiltonian_scalar_sub(nqubits=3):
+@pytest.mark.parametrize("calcdense", [False, True])
+def test_symbolic_hamiltonian_scalar_sub(calcdense, nqubits=3):
     """Test subtraction of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 - hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
+    if calcdense:
+        _ = local_ham.dense
     local_dense = (2 - local_ham).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
     target_ham = hamiltonians.TFIM(nqubits, h=1.0, numpy=True) - 2
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcdense:
+        _ = local_ham.dense
     local_dense = (local_ham - 2).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
@@ -86,10 +104,13 @@ def test_symbolic_hamiltonian_operator_add_and_sub(nqubits=3):
     np.testing.assert_allclose(dense.matrix, target_ham.matrix)
 
 
+@pytest.mark.parametrize("calcdense", [False, True])
 @pytest.mark.parametrize("nqubits,normalize", [(3, False), (4, False)])
-def test_symbolic_hamiltonian_matmul(nqubits, normalize):
+def test_symbolic_hamiltonian_matmul(calcdense, nqubits, normalize):
     """Test Trotter Hamiltonian expectation value."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcdense:
+        _ = local_ham.dense
     dense_ham = hamiltonians.TFIM(nqubits, h=1.0)
 
     state = K.cast(random_complex((2 ** nqubits,)))
@@ -107,3 +128,27 @@ def test_symbolic_hamiltonian_matmul(nqubits, normalize):
     local_matmul = local_ham @ state
     target_matmul = dense_ham @ state
     np.testing.assert_allclose(local_matmul, target_matmul)
+
+
+def test_trotter_hamiltonian_operation_errors():
+    """Test errors in ``SymbolicHamiltonian`` addition and subtraction."""
+    h1 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(3, h=1.0))
+    h2 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(4, h=1.0))
+    with pytest.raises(RuntimeError):
+        h = h1 + h2
+    with pytest.raises(RuntimeError):
+        h = h1 - h2
+    with pytest.raises(NotImplementedError):
+        h = h1 + "test"
+    with pytest.raises(NotImplementedError):
+        h = "test" + h1
+    with pytest.raises(NotImplementedError):
+        h = h1 - "test"
+    with pytest.raises(NotImplementedError):
+        h = "test" - h1
+    with pytest.raises(NotImplementedError):
+        h = h1 * "test"
+    with pytest.raises(NotImplementedError):
+        h = h1 @ "test"
+    with pytest.raises(NotImplementedError):
+        h = h1 @ np.ones((2, 2, 2, 2))

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -28,7 +28,7 @@ def test_symbolic_hamiltonian_init():
 
 @pytest.mark.parametrize("nqubits", [3, 4])
 #@pytest.mark.parametrize("model", ["TFIM", "XXZ", "Y", "MaxCut"])
-def test_symbolic_hamiltonian_to_dense(nqubits):
+def test_symbolic_hamiltonian_to_dense(backend, nqubits):
     # TODO: Extend this to other models when `hamiltonians.py` is updated
     final_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1))
     target_ham = hamiltonians.TFIM(nqubits, h=1, numpy=True)

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -20,9 +20,6 @@ def test_symbolic_hamiltonian_init():
     # Wrong type of symbolic expression
     with pytest.raises(TypeError):
         ham = hamiltonians.SymbolicHamiltonian("test")
-    # Give both form and terms
-    with pytest.raises(ValueError):
-        ham = hamiltonians.SymbolicHamiltonian(sympy.Symbol("x"), "test")
     # TODO: Complete this when `SymbolicHamiltonian.__init__` is completed
 
 

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -1,258 +1,117 @@
-"""Test symbolic Hamiltonian methods from `qibo/core/hamiltonians.py`."""
+"""Test methods of :class:`qibo.core.hamiltonians.SymbolicHamiltonian`."""
 import pytest
 import numpy as np
 import sympy
-from qibo import hamiltonians, matrices, K
-from qibo.tests.utils import random_hermitian
+import qibo
+from qibo import hamiltonians, K
+from qibo.tests.utils import random_state, random_complex, random_hermitian
 
 
-@pytest.mark.parametrize("nqubits", [4, 5])
-@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
-def test_tfim_hamiltonian_from_symbols(nqubits, hamtype):
-    """Check creating TFIM Hamiltonian using sympy."""
-    if hamtype == "symbolic":
-        from qibo.symbols import X, Z
-        h = 0.5
-        symham = sum(Z(i) * Z(i + 1) for i in range(nqubits - 1))
-        symham += Z(0) * Z(nqubits - 1)
-        symham += h * sum(X(i) for i in range(nqubits))
-        ham = hamiltonians.SymbolicHamiltonian(-symham)
-    else:
-        h = 0.5
-        z_symbols = sympy.symbols(" ".join((f"Z{i}" for i in range(nqubits))))
-        x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(nqubits))))
-
-        symham = sum(z_symbols[i] * z_symbols[i + 1] for i in range(nqubits - 1))
-        symham += z_symbols[0] * z_symbols[-1]
-        symham += h * sum(x_symbols)
-        symmap = {z: (i, matrices.Z) for i, z in enumerate(z_symbols)}
-        symmap.update({x: (i, matrices.X) for i, x in enumerate(x_symbols)})
-        if hamtype == "trotter":
-            ham = hamiltonians.TrotterHamiltonian.from_symbolic(-symham, symmap)
-            ham = ham.dense
-        else:
-            ham = hamiltonians.Hamiltonian.from_symbolic(-symham, symmap)
-
-    final_matrix = ham.matrix
-    target_matrix = hamiltonians.TFIM(nqubits, h=h).matrix
-    np.testing.assert_allclose(final_matrix, target_matrix)
+def symbolic_tfim(nqubits, h=1.0):
+    """Constructs symbolic Hamiltonian for TFIM."""
+    from qibo.symbols import Z, X
+    sham = -sum(Z(i) * Z(i + 1) for i in range(nqubits - 1))
+    sham -= Z(0) * Z(nqubits - 1)
+    sham -= h * sum(X(i) for i in range(nqubits))
+    return sham
 
 
-@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
-def test_from_symbolic_with_power(hamtype):
-    """Check ``from_symbolic`` when the expression contains powers."""
-    if hamtype == "symbolic":
-        from qibo.symbols import Symbol
-        matrix = random_hermitian(1)
-        symham =  (Symbol(0, matrix) ** 2 - Symbol(1, matrix) ** 2 +
-                   3 * Symbol(1, matrix) - 2 * Symbol(0, matrix) * Symbol(2, matrix) + 1)
-        ham = hamiltonians.SymbolicHamiltonian(symham)
-    else:
-        z = sympy.symbols(" ".join((f"Z{i}" for i in range(3))))
-        symham =  z[0] ** 2 - z[1] ** 2 + 3 * z[1] - 2 * z[0] * z[2] + 1
-        matrix = random_hermitian(1)
-        symmap = {x: (i, matrix) for i, x in enumerate(z)}
-        if hamtype == "trotter":
-            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
-            ham = ham.dense
-        else:
-            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
-
-    final_matrix = ham.matrix
-    matrix2 = matrix.dot(matrix)
-    eye = np.eye(2, dtype=matrix.dtype)
-    target_matrix = np.kron(np.kron(matrix2, eye), eye)
-    target_matrix -= np.kron(np.kron(eye, matrix2), eye)
-    target_matrix += 3 * np.kron(np.kron(eye, matrix), eye)
-    target_matrix -= 2 * np.kron(np.kron(matrix, eye), matrix)
-    target_matrix += np.eye(8, dtype=matrix.dtype)
-    np.testing.assert_allclose(final_matrix, target_matrix)
-
-
-@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
-def test_from_symbolic_with_complex_numbers(hamtype):
-    """Check ``from_symbolic`` when the expression contains imaginary unit."""
-    if hamtype == "symbolic":
-        from qibo.symbols import X, Y
-        symham = (1 + 2j) * X(0) * X(1) + 2 * Y(0) * Y(1) - 3j * X(0) * Y(1) + 1j * Y(0) * X(1)
-        ham = hamiltonians.SymbolicHamiltonian(symham)
-    else:
-        x = sympy.symbols(" ".join((f"X{i}" for i in range(2))))
-        y = sympy.symbols(" ".join((f"Y{i}" for i in range(2))))
-        symham = (1 + 2j) * x[0] * x[1] + 2 * y[0] * y[1] - 3j * x[0] * y[1] + 1j * y[0] * x[1]
-        symmap = {s: (i, matrices.X) for i, s in enumerate(x)}
-        symmap.update({s: (i, matrices.Y) for i, s in enumerate(y)})
-        if hamtype == "trotter":
-            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
-            ham = ham.dense
-        else:
-            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
-
-    final_matrix = ham.matrix
-    target_matrix = (1 + 2j) * np.kron(matrices.X, matrices.X)
-    target_matrix += 2 * np.kron(matrices.Y, matrices.Y)
-    target_matrix -= 3j * np.kron(matrices.X, matrices.Y)
-    target_matrix += 1j * np.kron(matrices.Y, matrices.X)
-    np.testing.assert_allclose(final_matrix, target_matrix)
-
-
-def test_from_symbolic_application_hamiltonian():
-    """Check ``from_symbolic`` for a specific four-qubit Hamiltonian."""
-    z1, z2, z3, z4 = sympy.symbols("z1 z2 z3 z4")
-    symmap = {z: (i, matrices.Z) for i, z in enumerate([z1, z2, z3, z4])}
-    symham = (z1 * z2 - 0.5 * z1 * z3 + 2 * z2 * z3 + 0.35 * z2
-              + 0.25 * z3 * z4 + 0.5 * z3 + z4 - z1)
-    # Check that Trotter dense matrix agrees will full Hamiltonian matrix
-    fham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
-    tham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
-    from qibo.symbols import Z
-    symham = (Z(0) * Z(1) - 0.5 * Z(0) * Z(2) + 2 * Z(1) * Z(2) + 0.35 * Z(1)
-              + 0.25 * Z(2) * Z(3) + 0.5 * Z(2) + Z(3) - Z(0))
-    sham = hamiltonians.SymbolicHamiltonian(symham)
-    np.testing.assert_allclose(tham.dense.matrix, fham.matrix)
-    np.testing.assert_allclose(sham.matrix, fham.matrix)
-    # Check that no one-qubit terms exist in the Trotter Hamiltonian
-    # (this means that merging was successful)
-    first_targets = set()
-    for part in tham.parts:
-        for targets, term in part.items():
-            first_targets.add(targets[0])
-            assert len(targets) == 2
-            assert term.nqubits == 2
-    assert first_targets == set(range(4))
-    # Check making an ``X`` Hamiltonian compatible with ``tham``
-    xham = hamiltonians.X(nqubits=4, trotter=True)
-    cxham = tham.make_compatible(xham)
-    assert not tham.is_compatible(xham)
-    assert tham.is_compatible(cxham)
-    np.testing.assert_allclose(xham.dense.matrix, cxham.dense.matrix)
-
-
-@pytest.mark.parametrize("nqubits", [4, 5])
-@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
-def test_x_hamiltonian_from_symbols(nqubits, hamtype):
-    """Check creating sum(X) Hamiltonian using sympy."""
-    if hamtype == "symbolic":
-        from qibo.symbols import X
-        symham = -sum(X(i) for i in range(nqubits))
-        ham = hamiltonians.SymbolicHamiltonian(symham)
-    else:
-        x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(nqubits))))
-        symham =  -sum(x_symbols)
-        symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
-        if hamtype == "trotter":
-            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
-            ham = ham.dense
-        else:
-            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
-    final_matrix = ham.matrix
-    target_matrix = hamiltonians.X(nqubits).matrix
-    np.testing.assert_allclose(final_matrix, target_matrix)
-
-
-@pytest.mark.parametrize("hamtype", ["normal", "symbolic", "trotter"])
-def test_three_qubit_term_hamiltonian_from_symbols(hamtype):
-    """Check creating Hamiltonian with three-qubit interaction using sympy."""
-    if hamtype == "symbolic":
-        from qibo.symbols import X, Y, Z
-        symham = X(0) * Y(1) * Z(2) + 0.5 * Y(0) * Z(1) * X(3) + Z(0) * X(2)
-        symham += Y(2) + 1.5 * Z(1) - 2 - 3 * X(1) * Y(3)
-        ham = hamiltonians.SymbolicHamiltonian(symham)
-    else:
-        x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(4))))
-        y_symbols = sympy.symbols(" ".join((f"Y{i}" for i in range(4))))
-        z_symbols = sympy.symbols(" ".join((f"Z{i}" for i in range(4))))
-        symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
-        symmap.update({x: (i, matrices.Y) for i, x in enumerate(y_symbols)})
-        symmap.update({x: (i, matrices.Z) for i, x in enumerate(z_symbols)})
-
-        symham = x_symbols[0] * y_symbols[1] * z_symbols[2]
-        symham += 0.5 * y_symbols[0] * z_symbols[1] * x_symbols[3]
-        symham += z_symbols[0] * x_symbols[2]
-        symham += -3 * x_symbols[1] * y_symbols[3]
-        symham += y_symbols[2]
-        symham += 1.5 * z_symbols[1]
-        symham -= 2
-        if hamtype == "trotter":
-            ham = hamiltonians.TrotterHamiltonian.from_symbolic(symham, symmap)
-            ham = ham.dense
-        else:
-            ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
-
-    final_matrix = ham.matrix
-
-    target_matrix = np.kron(np.kron(matrices.X, matrices.Y),
-                            np.kron(matrices.Z, matrices.I))
-    target_matrix += 0.5 * np.kron(np.kron(matrices.Y, matrices.Z),
-                                   np.kron(matrices.I, matrices.X))
-    target_matrix += np.kron(np.kron(matrices.Z, matrices.I),
-                             np.kron(matrices.X, matrices.I))
-    target_matrix += -3 * np.kron(np.kron(matrices.I, matrices.X),
-                             np.kron(matrices.I, matrices.Y))
-    target_matrix += np.kron(np.kron(matrices.I, matrices.I),
-                             np.kron(matrices.Y, matrices.I))
-    target_matrix += 1.5 * np.kron(np.kron(matrices.I, matrices.Z),
-                                   np.kron(matrices.I, matrices.I))
-    target_matrix -= 2 * np.eye(2**4, dtype=target_matrix.dtype)
-    np.testing.assert_allclose(final_matrix, target_matrix)
-
-
-@pytest.mark.parametrize("sufficient", [True, False])
-def test_symbolic_hamiltonian_merge_one_qubit(sufficient):
-    """Check that ``merge_one_qubit`` works both when two-qubit are sufficient and no."""
-    from qibo.hamiltonians import TrotterHamiltonian
-    x_symbols = sympy.symbols(" ".join((f"X{i}" for i in range(5))))
-    z_symbols = sympy.symbols(" ".join((f"Z{i}" for i in range(5))))
-    symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
-    symmap.update({x: (i, matrices.Z) for i, x in enumerate(z_symbols)})
-    symham = sum(z_symbols[i] * z_symbols[i + 1] for i in range(4))
-    symham += sum(x_symbols)
-    if sufficient:
-        symham += z_symbols[0] * z_symbols[-1]
-    merged, _ = TrotterHamiltonian.symbolic_terms(symham, symmap)
-
-    two_qubit_keys = {(i, i + 1) for i in range(4)}
-    if sufficient:
-        target_matrix = (np.kron(matrices.Z, matrices.Z) +
-                         np.kron(matrices.X, matrices.I))
-        two_qubit_keys.add((4, 0))
-        assert set(merged.keys()) == two_qubit_keys
-        for matrix in merged.values():
-            np.testing.assert_allclose(matrix, target_matrix)
-    else:
-        one_qubit_keys = {(i,) for i in range(5)}
-        assert set(merged.keys()) == one_qubit_keys | two_qubit_keys
-        target_matrix = matrices.X
-        for t in one_qubit_keys:
-            np.testing.assert_allclose(merged[t], target_matrix)
-        target_matrix = np.kron(matrices.Z, matrices.Z)
-        for t in two_qubit_keys:
-            np.testing.assert_allclose(merged[t], target_matrix)
-
-
-def test_symbolic_hamiltonian_errors():
-    """Check errors raised by :meth:`qibo.core.symbolic.parse_symbolic`."""
-    from qibo.core.symbolic import parse_symbolic
-    a, b = sympy.symbols("a b")
-    ham = a * b
-    # Bad hamiltonian type
+def test_symbolic_hamiltonian_init():
+    # Wrong type of symbolic expression
     with pytest.raises(TypeError):
-        sh = parse_symbolic("test", "test")
-    # Bad symbol map type
-    with pytest.raises(TypeError):
-        sh = parse_symbolic(ham, "test")
-    # Bad symbol map key
-    with pytest.raises(TypeError):
-        sh = parse_symbolic(ham, {"a": 2})
-    # Bad symbol map value
-    with pytest.raises(TypeError):
-        sh = parse_symbolic(ham, {a: 2})
+        ham = hamiltonians.SymbolicHamiltonian("test")
+    # Give both form and terms
     with pytest.raises(ValueError):
-        sh = parse_symbolic(ham, {a: (1, 2, 3)})
-    # Missing symbol
-    with pytest.raises(ValueError):
-        sh = parse_symbolic(ham, {a: (0, matrices.X)})
-    # Factor that cannot be parsed
-    ham = a * b + sympy.cos(a) * b
-    with pytest.raises(ValueError):
-        sh = parse_symbolic(ham, {a: (0, matrices.X), b: (1, matrices.Z)})
+        ham = hamiltonians.SymbolicHamiltonian(sympy.Symbol("x"), "test")
+    # TODO: Complete this when `SymbolicHamiltonian.__init__` is completed
+
+
+@pytest.mark.parametrize("nqubits", [3, 4])
+#@pytest.mark.parametrize("model", ["TFIM", "XXZ", "Y", "MaxCut"])
+def test_symbolic_hamiltonian_to_dense(nqubits):
+    # TODO: Extend this to other models when `hamiltonians.py` is updated
+    final_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1))
+    target_ham = hamiltonians.TFIM(nqubits, h=1, numpy=True)
+    np.testing.assert_allclose(final_ham.matrix, target_ham.matrix, atol=1e-15)
+
+
+@pytest.mark.skip
+def test_trotter_hamiltonian_scalar_mul(nqubits=3):
+    """Test multiplication of Trotter Hamiltonian with scalar."""
+    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    target_ham = 2 * hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
+    local_dense = (2 * local_ham).dense
+    np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
+
+    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_dense = (local_ham * 2).dense
+    np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
+
+
+@pytest.mark.skip
+def test_trotter_hamiltonian_scalar_add(nqubits=4):
+    """Test addition of Trotter Hamiltonian with scalar."""
+    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    target_ham = 2 + hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
+    local_dense = (2 + local_ham).dense
+    np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
+
+    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_dense = (local_ham + 2).dense
+    np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
+
+
+@pytest.mark.skip
+def test_symbolic_hamiltonian_scalar_sub(nqubits=3):
+    """Test subtraction of Trotter Hamiltonian with scalar."""
+    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    target_ham = 2 - hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
+    local_dense = (2 - local_ham).dense
+    np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
+
+    target_ham = hamiltonians.TFIM(nqubits, h=1.0, numpy=True) - 2
+    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_dense = (local_ham - 2).dense
+    np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
+
+
+@pytest.mark.skip
+def test_symbolic_hamiltonian_operator_add_and_sub(nqubits=3):
+    """Test addition and subtraction between Trotter Hamiltonians."""
+    local_ham1 = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham2 = hamiltonians.TFIM(nqubits, h=0.5, trotter=True)
+
+    local_ham = local_ham1 + local_ham2
+    target_ham = (hamiltonians.TFIM(nqubits, h=1.0, numpy=True) +
+                  hamiltonians.TFIM(nqubits, h=0.5, numpy=True))
+    dense = local_ham.dense
+    np.testing.assert_allclose(dense.matrix, target_ham.matrix)
+
+    local_ham = local_ham1 - local_ham2
+    target_ham = (hamiltonians.TFIM(nqubits, h=1.0, numpy=True) -
+                  hamiltonians.TFIM(nqubits, h=0.5, numpy=True))
+    dense = local_ham.dense
+    np.testing.assert_allclose(dense.matrix, target_ham.matrix)
+
+
+@pytest.mark.parametrize("nqubits,normalize", [(3, False), (4, False)])
+def test_symbolic_hamiltonian_matmul(nqubits, normalize):
+    """Test Trotter Hamiltonian expectation value."""
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    dense_ham = hamiltonians.TFIM(nqubits, h=1.0)
+
+    state = K.cast(random_complex((2 ** nqubits,)))
+    local_ev = local_ham.expectation(state, normalize)
+    target_ev = dense_ham.expectation(state, normalize)
+    np.testing.assert_allclose(local_ev, target_ev)
+
+    state = random_complex((2 ** nqubits,))
+    local_ev = local_ham.expectation(state, normalize)
+    target_ev = dense_ham.expectation(state, normalize)
+    np.testing.assert_allclose(local_ev, target_ev)
+
+    from qibo.core.states import VectorState
+    state = VectorState.from_tensor(state)
+    local_matmul = local_ham @ state
+    target_matmul = dense_ham @ state
+    np.testing.assert_allclose(local_matmul, target_matmul)

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -36,7 +36,7 @@ def test_symbolic_hamiltonian_to_dense(nqubits):
 
 
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_scalar_mul(calcdense, nqubits=3):
+def test_symbolic_hamiltonian_scalar_mul(backend, calcdense, nqubits=3):
     """Test multiplication of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 * hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
@@ -53,7 +53,7 @@ def test_symbolic_hamiltonian_scalar_mul(calcdense, nqubits=3):
 
 
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_scalar_add(calcdense, nqubits=4):
+def test_symbolic_hamiltonian_scalar_add(backend, calcdense, nqubits=4):
     """Test addition of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 + hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
@@ -70,7 +70,7 @@ def test_symbolic_hamiltonian_scalar_add(calcdense, nqubits=4):
 
 
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_scalar_sub(calcdense, nqubits=3):
+def test_symbolic_hamiltonian_scalar_sub(backend, calcdense, nqubits=3):
     """Test subtraction of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 - hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
@@ -88,7 +88,7 @@ def test_symbolic_hamiltonian_scalar_sub(calcdense, nqubits=3):
 
 
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_operator_add_and_sub(calcdense, nqubits=3):
+def test_symbolic_hamiltonian_operator_add_and_sub(backend, calcdense, nqubits=3):
     """Test addition and subtraction between Trotter Hamiltonians."""
     local_ham1 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_ham2 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5))
@@ -115,7 +115,7 @@ def test_symbolic_hamiltonian_operator_add_and_sub(calcdense, nqubits=3):
 
 @pytest.mark.parametrize("calcdense", [False, True])
 @pytest.mark.parametrize("nqubits,normalize", [(3, False), (4, False)])
-def test_symbolic_hamiltonian_state_ev(calcdense, nqubits, normalize):
+def test_symbolic_hamiltonian_state_ev(backend, calcdense, nqubits, normalize):
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     if calcdense:
         _ = local_ham.dense
@@ -134,7 +134,7 @@ def test_symbolic_hamiltonian_state_ev(calcdense, nqubits, normalize):
 
 @pytest.mark.parametrize("density_matrix", [False, True])
 @pytest.mark.parametrize("nqubits", [3, 4])
-def test_symbolic_hamiltonian_matmul(density_matrix, nqubits):
+def test_symbolic_hamiltonian_matmul(backend, density_matrix, nqubits):
     if density_matrix:
         from qibo.core.states import MatrixState
         shape = (2 ** nqubits, 2 ** nqubits)
@@ -151,7 +151,7 @@ def test_symbolic_hamiltonian_matmul(density_matrix, nqubits):
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
-def test_symbolic_hamiltonian_abstract_symbol_ev(density_matrix):
+def test_symbolic_hamiltonian_abstract_symbol_ev(backend, density_matrix):
     from qibo.symbols import X, Symbol
     matrix = np.random.random((2, 2))
     form = X(0) * Symbol(1, matrix) + Symbol(0, matrix) * X(1)
@@ -166,7 +166,7 @@ def test_symbolic_hamiltonian_abstract_symbol_ev(density_matrix):
 
 
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_hamiltonianmatmul(calcdense, nqubits=5):
+def test_symbolic_hamiltonian_hamiltonianmatmul(backend, calcdense, nqubits=5):
     local_ham1 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_ham2 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5))
     dense_ham1 = hamiltonians.TFIM(nqubits, h=1.0)

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -35,59 +35,54 @@ def test_symbolic_hamiltonian_to_dense(nqubits):
     np.testing.assert_allclose(final_ham.matrix, target_ham.matrix, atol=1e-15)
 
 
-@pytest.mark.skip
-def test_trotter_hamiltonian_scalar_mul(nqubits=3):
+def test_symbolic_hamiltonian_scalar_mul(nqubits=3):
     """Test multiplication of Trotter Hamiltonian with scalar."""
-    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 * hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
     local_dense = (2 * local_ham).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
-    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_dense = (local_ham * 2).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
-@pytest.mark.skip
-def test_trotter_hamiltonian_scalar_add(nqubits=4):
+def test_symbolic_hamiltonian_scalar_add(nqubits=4):
     """Test addition of Trotter Hamiltonian with scalar."""
-    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 + hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
     local_dense = (2 + local_ham).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
-    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_dense = (local_ham + 2).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
-@pytest.mark.skip
 def test_symbolic_hamiltonian_scalar_sub(nqubits=3):
     """Test subtraction of Trotter Hamiltonian with scalar."""
-    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 - hamiltonians.TFIM(nqubits, h=1.0, numpy=True)
     local_dense = (2 - local_ham).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
     target_ham = hamiltonians.TFIM(nqubits, h=1.0, numpy=True) - 2
-    local_ham = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
+    local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_dense = (local_ham - 2).dense
     np.testing.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
-@pytest.mark.skip
 def test_symbolic_hamiltonian_operator_add_and_sub(nqubits=3):
     """Test addition and subtraction between Trotter Hamiltonians."""
-    local_ham1 = hamiltonians.TFIM(nqubits, h=1.0, trotter=True)
-    local_ham2 = hamiltonians.TFIM(nqubits, h=0.5, trotter=True)
-
-    local_ham = local_ham1 + local_ham2
+    local_ham = (hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0)) +
+                 hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5)))
     target_ham = (hamiltonians.TFIM(nqubits, h=1.0, numpy=True) +
                   hamiltonians.TFIM(nqubits, h=0.5, numpy=True))
     dense = local_ham.dense
     np.testing.assert_allclose(dense.matrix, target_ham.matrix)
 
-    local_ham = local_ham1 - local_ham2
+    local_ham = (hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0)) -
+                 hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5)))
     target_ham = (hamiltonians.TFIM(nqubits, h=1.0, numpy=True) -
                   hamiltonians.TFIM(nqubits, h=0.5, numpy=True))
     dense = local_ham.dense


### PR DESCRIPTION
Following the discussion in #413 this calculates the `hamiltonian.expectation` term-by-term instead of constructing the full matrix. The custom backend can also be used for this calculation even for Hamiltonians with terms acting on more than two qubits because the calculation involves only single qubit gates. 

Here are some benchmarks using a Fermi-Hubbard Hamiltonian provided by @igres26:

nsites | nqubits | qibotf (this branch) | tensorflow (master) | numpy (master)
-- | -- | -- | -- | --
3 | 9 | 0.043816 | 0.053682 | 0.008743
4 | 12 | 0.061650 | 0.094803 | 0.030591
5 | 15 | 0.117778 | 0.200112 | 0.208575
6 | 18 | 0.280394 | 0.840739 | 2.054210
7 | 21 | 3.864714 | 9.843416 | 21.948270
8 | 24 | 29.415665 | 90.591800 | 232.787657

The way this is implemented currently is the following:

* When a `Hamiltonian` is constructed using `Hamiltonian.from_symbolic`, instead of constructing the full matrix directly a dictionary with terms is created. The matrix is calculated only when needed.
* The Hamiltonian-state multiplication is implemented using single qubit `gates.Unitary` gates for each term in the Hamiltonian.

Before finalizing this, I would propose to change the API for defining Hamiltonians and Trotter Hamiltonians with symbols. For example a possible API would be the following:
```Python
from qibo.symbols import X, Y, Z
ham = X(0) * X(1) + Y(0) * Y(1) + Z(0) * Z(1) + ...
```
The advantage of this is:
1. simplified Hamiltonian construction as the user does not to define symbol maps with matrices,
2. Pauli symbols which are the most common for Hamiltonian construction can be mapped to the corresponding gates for which we already have very fast specialized kernels in qibotf. These kernels can be used for expectation value calculation. 