### PR TITLE
Tensorflow not installed warning

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -42,13 +42,6 @@ class Backend:
                             "high performance custom operators please use "
                             "`pip install qibotf`.")
 
-        # check if IcarusQ is installed
-        if self.check_availability("qiboicarusq"): # pragma: no cover
-            # hardware backend is not tested until `qiboicarusq` is available
-            from qibo.backends.hardware import IcarusQBackend
-            self.available_backends["icarusq"] = IcarusQBackend
-            self.hardware_backends["icarusq"] = IcarusQBackend
-
         else:  # pragma: no cover
             # case not tested because CI has tf installed
             log.warning("Tensorflow is not installed, falling back to numpy. "
@@ -57,6 +50,13 @@ class Backend:
                         "with `pip install tensorflow`. To install the "
                         "optimized Qibo custom operators please use "
                         "`pip install qibotf` after installing Tensorflow.")
+
+        # check if IcarusQ is installed
+        if self.check_availability("qiboicarusq"): # pragma: no cover
+            # hardware backend is not tested until `qiboicarusq` is available
+            from qibo.backends.hardware import IcarusQBackend
+            self.available_backends["icarusq"] = IcarusQBackend
+            self.hardware_backends["icarusq"] = IcarusQBackend
 
         self.constructed_backends = {}
         self._active_backend = None


### PR DESCRIPTION
The latest master after merging the hardware backend switcher gives a warning that Tensorflow is not installed even if it is installed. For example the following script
```Python
import qibo
print(qibo.get_backend)
```
prints
```
[Qibo|WARNING|2021-06-02 13:22:24]: Tensorflow is not installed, falling back to numpy. Numpy backend uses `np.einsum` and supports CPU only. To enable GPU acceleration please install Tensorflow with `pip install tensorflow`. To install the optimized Qibo custom operators please use `pip install qibotf` after installing Tensorflow.
qibotf
```
so the warning appears even though the default backend is properly set to `qibotf`. @scarrazza could you please confirm that you also get this warning?

This PR should fix this issue.