### PR TITLE
Set threshold for using Metropolis custom op

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -196,6 +196,29 @@ obtain more measurement shots without having to re-execute the full simulation.
 For applications that require the state vector to be collapsed during measurements
 we refer to the :ref:`How to collapse state during measurements? <collapse-examples>`
 
+The measured shots are obtained using pseudo-random number generators of the
+underlying backend (numpy or Tensorflow). If the user has installed a custom
+backend (eg. qibotf) and asks for frequencies with more than 100000 shots,
+a custom Metropolis algorithm will be used to obtain the corresponding samples,
+for increase performance. The user can change the threshold for which this
+algorithm is used using the ``qibo.set_metropolis_threshold()`` method,
+for example:
+
+.. code-block:: python
+
+    import qibo
+
+    print(qibo.get_metropolis_threshold()) # prints 100000
+    qibo.set_metropolis_threshold(int(1e8))
+    print(qibo.get_metropolis_threshold()) # prints 10^8
+
+
+If the Metropolis algorithm is not used and the user asks for frequencies with
+a high number of shots then the corresponding samples are generated in batches.
+The batch size can be controlled using the ``qibo.get_batch_size()`` and
+``qibo.set_batch_size()`` functions similarly to the above example.
+The default batch size is 2^18.
+
 
 How to write a Quantum Fourier Transform?
 -----------------------------------------

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,7 +1,10 @@
 __version__ = "0.1.6.dev1"
-from qibo.config import set_threads, get_threads, set_batch_size, get_batch_size
-from qibo.backends import set_precision, set_backend, set_device
-from qibo.backends import get_backend, get_precision, get_device
+from qibo.config import set_threads, get_threads
+from qibo.config import set_batch_size, get_batch_size
+from qibo.config import set_metropolis_threshold, get_metropolis_threshold
+from qibo.backends import set_backend, get_backend
+from qibo.backends import set_precision, get_precision
+from qibo.backends import set_device, get_device
 from qibo.backends import numpy_matrices as matrices
 from qibo.backends import K
 from qibo import callbacks, gates, hamiltonians, models

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -224,8 +224,8 @@ class TensorflowCustomBackend(TensorflowBackend):
                                        self.get_threads())
 
     def sample_frequencies(self, probs, nshots):
-        from qibo.config import SHOT_CUSTOM_OP_THREASHOLD
-        if nshots < SHOT_CUSTOM_OP_THREASHOLD:
+        from qibo.config import SHOT_METROPOLIS_THRESHOLD
+        if nshots < SHOT_METROPOLIS_THRESHOLD:
             return super().sample_frequencies(probs, nshots)
         # Generate random seed using tf
         dtype = self.dtypes('DTYPEINT')

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -78,6 +78,7 @@ def get_batch_size():
     return SHOT_BATCH_SIZE
 
 def set_batch_size(batch_size):
+    """Sets batch size used for sampling measurement shots."""
     if not isinstance(batch_size, int):
         raise_error(TypeError, "Shot batch size must be integer.")
     elif batch_size < 1:
@@ -93,6 +94,7 @@ def get_metropolis_threshold():
     return SHOT_METROPOLIS_THRESHOLD
 
 def set_metropolis_threshold(threshold):
+    """Sets threshold for using Metropolis algorithm for sampling measurement shots."""
     if not isinstance(threshold, int):
         raise_error(TypeError, "Shot threshold must be integer.")
     elif threshold < 1:

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -26,7 +26,7 @@ EIGVAL_CUTOFF = 1e-14
 SHOT_BATCH_SIZE = 2 ** 18
 
 # Threshold size for sampling shots in measurements frequencies with custom operator
-SHOT_CUSTOM_OP_THREASHOLD = 100000
+SHOT_METROPOLIS_THRESHOLD = 100000
 
 # Flag for raising warning in ``set_precision`` and ``set_backend``
 ALLOW_SWITCHERS = True
@@ -86,6 +86,19 @@ def set_batch_size(batch_size):
          raise_error(ValueError, "Shot batch size cannot be greater than 2^31.")
     global SHOT_BATCH_SIZE
     SHOT_BATCH_SIZE = batch_size
+
+
+def get_metropolis_threshold():
+    """Returns threshold for using Metropolis algorithm for sampling measurement shots."""
+    return SHOT_METROPOLIS_THRESHOLD
+
+def set_metropolis_threshold(threshold):
+    if not isinstance(threshold, int):
+        raise_error(TypeError, "Shot threshold must be integer.")
+    elif threshold < 1:
+        raise_error(ValueError, "Shot threshold be a positive integer.")
+    global SHOT_METROPOLIS_THRESHOLD
+    SHOT_METROPOLIS_THRESHOLD = threshold
 
 
 # Configuration for logging mechanism

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -120,7 +120,8 @@ def test_set_shot_batch_size():
 
 def test_set_metropolis_threshold():
     import qibo
-    assert qibo.get_metropolis_threshold() == 100000
+    original_threshold = qibo.get_metropolis_threshold()
+    assert original_threshold == 100000
     qibo.set_metropolis_threshold(100)
     assert qibo.get_metropolis_threshold() == 100
     from qibo.config import SHOT_METROPOLIS_THRESHOLD
@@ -129,3 +130,4 @@ def test_set_metropolis_threshold():
         qibo.set_metropolis_threshold("test")
     with pytest.raises(ValueError):
         qibo.set_metropolis_threshold(-10)
+    qibo.set_metropolis_threshold(original_threshold)

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -116,3 +116,16 @@ def test_set_shot_batch_size():
         qibo.set_batch_size(-10)
     with pytest.raises(ValueError):
         qibo.set_batch_size(2 ** 35)
+
+
+def test_set_metropolis_threshold():
+    import qibo
+    assert qibo.get_metropolis_threshold() == 100000
+    qibo.set_metropolis_threshold(100)
+    assert qibo.get_metropolis_threshold() == 100
+    from qibo.config import SHOT_METROPOLIS_THRESHOLD
+    assert SHOT_METROPOLIS_THRESHOLD == 100
+    with pytest.raises(TypeError):
+        qibo.set_metropolis_threshold("test")
+    with pytest.raises(ValueError):
+        qibo.set_metropolis_threshold(-10)


### PR DESCRIPTION
Following a discussion with @igres26, this implements a getter/setter for the threshold value beyond which measuring shot frequencies will fall to the Metropolis custom operator.

The reason we need this is that the current Metropolis implementation does not seem to work very well for specific (usually sparse) distributions. Of course the proper solution would be to improve the custom operator itself, however the threshold setter is a good temporary solution that allows the user to disable the custom operator if its results are not good, by setting a very high threshold (eg. 10^12). The default tensorflow/numpy implementation is quite fast for up to 10^7 shots anyway, which is sufficient for many applications.