### PR TITLE
Set number of threads for qibojit

### DIFF
--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,10 +1,10 @@
 __version__ = "0.1.6.dev1"
-from qibo.config import set_threads, get_threads
 from qibo.config import set_batch_size, get_batch_size
 from qibo.config import set_metropolis_threshold, get_metropolis_threshold
 from qibo.backends import set_backend, get_backend
 from qibo.backends import set_precision, get_precision
 from qibo.backends import set_device, get_device
+from qibo.backends import set_threads, get_threads
 from qibo.backends import numpy_matrices as matrices
 from qibo.backends import K
 from qibo import callbacks, gates, hamiltonians, models

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -203,3 +203,18 @@ def set_device(name):
 
 def get_device():
     return K.default_device
+
+
+def set_threads(nthreads):
+    """Set number of CPU threads.
+
+    Args:
+        nthreads (int): number of threads.
+    """
+    for bk in K.constructed_backends.values():
+        bk.set_threads(nthreads)
+
+
+def get_threads():
+    """Returns number of threads."""
+    return K.nthreads

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -17,14 +17,9 @@ class AbstractBackend(ABC):
         self.gpu_devices = []
         self.default_device = []
         self.nthreads = None
-        if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
-            self.nthreads = int(os.environ.get("OMP_NUM_THREADS"))
-        elif "NUMBA_NUM_THREADS" in os.environ: # pragma: no cover
-            self.nthreads = int(os.environ.get("NUMBA_NUM_THREADS"))
-        else:
-            import psutil
-            # using physical cores by default
-            self.nthreads = psutil.cpu_count(logical=False)
+        import psutil
+        # using physical cores by default
+        self.nthreads = psutil.cpu_count(logical=False)
 
         self.op = None
         self._matrices = None

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -17,12 +17,14 @@ class AbstractBackend(ABC):
         self.gpu_devices = []
         self.default_device = []
         self.nthreads = None
-        if "OMP_NUM_THREADS" not in os.environ:
+        if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
+            self.nthreads = int(os.environ.get("OMP_NUM_THREADS"))
+        elif "NUMBA_NUM_THREADS" in os.environ: # pragma: no cover
+            self.nthreads = int(os.environ.get("NUMBA_NUM_THREADS"))
+        else:
             import psutil
             # using physical cores by default
             self.nthreads = psutil.cpu_count(logical=False)
-        else: # pragma: no cover
-            self.nthreads = int(os.environ.get("OMP_NUM_THREADS"))
 
         self.op = None
         self._matrices = None

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from qibo.config import raise_error, log
 
@@ -15,6 +16,13 @@ class AbstractBackend(ABC):
         self.cpu_devices = []
         self.gpu_devices = []
         self.default_device = []
+        self.nthreads = None
+        if "OMP_NUM_THREADS" not in os.environ:
+            import psutil
+            # using physical cores by default
+            self.nthreads = psutil.cpu_count(logical=False)
+        else: # pragma: no cover
+            self.nthreads = int(os.environ.get("OMP_NUM_THREADS"))
 
         self.op = None
         self._matrices = None
@@ -67,6 +75,18 @@ class AbstractBackend(ABC):
         self.default_device = name
         with self.device(self.default_device):
             self.matrices.allocate_matrices()
+
+    def set_threads(self, nthreads):
+        """Set number of OpenMP threads.
+
+        Args:
+            num_threads (int): number of threads.
+        """
+        if not isinstance(nthreads, int): # pragma: no cover
+            raise_error(RuntimeError, "Number of threads must be integer.")
+        if nthreads < 1: # pragma: no cover
+            raise_error(RuntimeError, "Number of threads must be positive.")
+        self.nthreads = nthreads
 
     def get_cpu(self): # pragma: no cover
         """Returns default CPU device to use for OOM fallback."""

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -435,7 +435,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
 
     def set_threads(self, nthreads):
         super().set_threads(nthreads)
-        import numba
+        import numba # pylint: disable=E0401
         numba.set_num_threads(nthreads)
 
     def to_numpy(self, x):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -432,6 +432,11 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
             self.set_engine("numba")
         abstract.AbstractBackend.set_device(self, name)
 
+    def set_threads(self, nthreads):
+        super().set_threads(nthreads)
+        import os
+        os.environ["NUMBA_NUM_THREADS"] = str(nthreads)
+
     def to_numpy(self, x):
         if isinstance(x, self.np.ndarray):
             return x

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -394,6 +394,11 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
         except:
             ngpu = 0
 
+        if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
+            self.set_threads(int(os.environ.get("OMP_NUM_THREADS")))
+        if "NUMBA_NUM_THREADS" in os.environ: # pragma: no cover
+            self.set_threads(int(os.environ.get("NUMBA_NUM_THREADS")))
+
         # TODO: reconsider device management
         self.cpu_devices = ["/CPU:0"]
         self.gpu_devices = [f"/GPU:{i}" for i in range(ngpu)]

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -394,6 +394,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
         except:
             ngpu = 0
 
+        import os
         if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
             self.set_threads(int(os.environ.get("OMP_NUM_THREADS")))
         if "NUMBA_NUM_THREADS" in os.environ: # pragma: no cover

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -404,6 +404,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
         elif self.cpu_devices:
             self.default_device = self.cpu_devices[0]
             self.set_engine("numba")
+            self.set_threads(self.nthreads)
 
     def set_engine(self, name): # pragma: no cover
         """Switcher between ``cupy`` for GPU and ``numba`` for CPU."""

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -500,7 +500,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
                                     is_matrix=is_matrix)
 
     def sample_frequencies(self, probs, nshots):
-        from qibo.config import SHOT_METROPOLIS_THRESHOLD, get_threads
+        from qibo.config import SHOT_METROPOLIS_THRESHOLD
         if nshots < SHOT_METROPOLIS_THRESHOLD:
             return super().sample_frequencies(probs, nshots)
         if self.op.get_backend() == "cupy":
@@ -510,7 +510,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
         nqubits = int(self.np.log2(tuple(probs.shape)[0]))
         frequencies = self.np.zeros(2 ** nqubits, dtype=dtype)
         frequencies = self.op.measure_frequencies(
-            frequencies, probs, nshots, nqubits, seed, get_threads())
+            frequencies, probs, nshots, nqubits, seed, self.nthreads)
         return frequencies
 
     def create_einsum_cache(self, qubits, nqubits, ncontrol=None): # pragma: no cover

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -434,8 +434,8 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
 
     def set_threads(self, nthreads):
         super().set_threads(nthreads)
-        import os
-        os.environ["NUMBA_NUM_THREADS"] = str(nthreads)
+        import numba
+        numba.set_num_threads(nthreads)
 
     def to_numpy(self, x):
         if isinstance(x, self.np.ndarray):

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -1,4 +1,3 @@
-import os
 from qibo.backends import abstract, numpy
 from qibo.config import raise_error, log
 
@@ -213,6 +212,7 @@ class TensorflowCustomBackend(TensorflowBackend):
         super().__init__()
         self.name = "qibotf"
         self.op = op
+        import os
         if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
             self.set_threads(int(os.environ.get("OMP_NUM_THREADS")))
 

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -213,17 +213,14 @@ class TensorflowCustomBackend(TensorflowBackend):
         super().__init__()
         self.name = "qibotf"
         self.op = op
-        from qibo.config import get_threads
-        self.get_threads = get_threads
 
     def initial_state(self, nqubits, is_matrix=False):
         return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),
                                     is_matrix=is_matrix,
-                                    omp_num_threads=self.get_threads())
+                                    omp_num_threads=self.nthreads)
 
     def transpose_state(self, pieces, state, nqubits, order):
-        return self.op.transpose_state(pieces, state, nqubits, order,
-                                       self.get_threads())
+        return self.op.transpose_state(pieces, state, nqubits, order, self.nthreads)
 
     def sample_frequencies(self, probs, nshots):
         from qibo.config import SHOT_METROPOLIS_THRESHOLD
@@ -237,7 +234,7 @@ class TensorflowCustomBackend(TensorflowBackend):
         shape = self.cast(2 ** nqubits, dtype='DTYPEINT')
         frequencies = self.zeros(shape, dtype='DTYPEINT')
         frequencies = self.op.measure_frequencies(
-            frequencies, probs, nshots, nqubits, seed, self.get_threads())
+            frequencies, probs, nshots, nqubits, seed, self.nthreads)
         return frequencies
 
     def create_einsum_cache(self, qubits, nqubits, ncontrol=None): # pragma: no cover
@@ -257,40 +254,40 @@ class TensorflowCustomBackend(TensorflowBackend):
 
     def state_vector_call(self, gate, state):
         return gate.gate_op(state, gate.cache.qubits_tensor, gate.nqubits,
-                            *gate.target_qubits, self.get_threads())
+                            *gate.target_qubits, self.nthreads)
 
     def state_vector_matrix_call(self, gate, state):
         return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor, # pylint: disable=E1121
                             gate.nqubits, *gate.target_qubits,
-                            self.get_threads())
+                            self.nthreads)
 
     def density_matrix_call(self, gate, state):
         state = gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
                              2 * gate.nqubits, *gate.target_qubits,
-                             self.get_threads())
+                             self.nthreads)
         state = gate.gate_op(state, gate.cache.qubits_tensor, 2 * gate.nqubits,
-                             *gate.cache.target_qubits_dm, self.get_threads())
+                             *gate.cache.target_qubits_dm, self.nthreads)
         return state
 
     def density_matrix_matrix_call(self, gate, state):
         state = gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
                              2 * gate.nqubits, *gate.target_qubits,
-                             self.get_threads())
+                             self.nthreads)
         adjmatrix = self.conj(gate.matrix)
         state = gate.gate_op(state, adjmatrix, gate.cache.qubits_tensor,
                              2 * gate.nqubits, *gate.cache.target_qubits_dm,
-                             self.get_threads())
+                             self.nthreads)
         return state
 
     def density_matrix_half_call(self, gate, state):
         return gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
                             2 * gate.nqubits, *gate.target_qubits,
-                            self.get_threads())
+                            self.nthreads)
 
     def density_matrix_half_matrix_call(self, gate, state):
         return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
                             2 * gate.nqubits, *gate.target_qubits,
-                            self.get_threads())
+                            self.nthreads)
 
     def _result_tensor(self, result):
         n = len(result)
@@ -300,14 +297,14 @@ class TensorflowCustomBackend(TensorflowBackend):
     def state_vector_collapse(self, gate, state, result):
         result = self._result_tensor(result)
         return gate.gate_op(state, gate.cache.qubits_tensor, result,
-                            gate.nqubits, True, self.get_threads())
+                            gate.nqubits, True, self.nthreads)
 
     def density_matrix_collapse(self, gate, state, result):
         result = self._result_tensor(result)
         state = gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits, result,
-                             2 * gate.nqubits, False, self.get_threads())
+                             2 * gate.nqubits, False, self.nthreads)
         state = gate.gate_op(state, gate.cache.qubits_tensor, result,
-                             2 * gate.nqubits, False, self.get_threads())
+                             2 * gate.nqubits, False, self.nthreads)
         return state / self.trace(state)
 
     def compile(self, func):

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -213,6 +213,8 @@ class TensorflowCustomBackend(TensorflowBackend):
         super().__init__()
         self.name = "qibotf"
         self.op = op
+        if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
+            self.set_threads(int(os.environ.get("OMP_NUM_THREADS")))
 
     def initial_state(self, nqubits, is_matrix=False):
         return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -46,33 +46,6 @@ def raise_error(exception, message=None, args=None):
         raise exception(message)
 
 
-# Set the number of threads from the environment variable
-OMP_NUM_THREADS = None
-if "OMP_NUM_THREADS" not in os.environ:
-    import psutil
-    # using physical cores by default
-    cores = psutil.cpu_count(logical=False)
-    OMP_NUM_THREADS = cores
-else: # pragma: no cover
-    OMP_NUM_THREADS = int(os.environ.get("OMP_NUM_THREADS"))
-
-def get_threads():
-    """Returns number of threads."""
-    return OMP_NUM_THREADS
-
-def set_threads(num_threads):
-    """Set number of OpenMP threads.
-
-    Args:
-        num_threads (int): number of threads.
-    """
-    if not isinstance(num_threads, int): # pragma: no cover
-        raise_error(RuntimeError, "Number of threads must be integer.")
-    if num_threads < 1: # pragma: no cover
-        raise_error(RuntimeError, "Number of threads must be positive.")
-    global OMP_NUM_THREADS
-    OMP_NUM_THREADS = num_threads
-
 def get_batch_size():
     """Returns batch size used for sampling measurement shots."""
     return SHOT_BATCH_SIZE

--- a/src/qibo/core/distcircuit.py
+++ b/src/qibo/core/distcircuit.py
@@ -6,7 +6,7 @@ from qibo import K
 from qibo import gates as gate_module
 from qibo.abstractions import gates
 from qibo.abstractions.circuit import AbstractCircuit
-from qibo.config import raise_error, get_threads
+from qibo.config import raise_error
 from qibo.core import callbacks, circuit, measurements, states
 from qibo.core.distutils import DistributedQueues
 from typing import Dict, List, Optional, Set, Tuple, Union
@@ -148,7 +148,7 @@ class DistributedCircuit(circuit.Circuit):
             local_eff = self.queues.qubits.reduced_local[local_qubit]
             with K.device(self.memory_device):
                 K.op.swap_pieces(state.pieces[i], state.pieces[i + t],
-                                 local_eff, self.nlocal, get_threads())
+                                 local_eff, self.nlocal, K.nthreads)
 
     def _revert_swaps(self, state, swap_pairs: List[Tuple[int, int]]):
         for q1, q2 in swap_pairs:

--- a/src/qibo/core/distutils.py
+++ b/src/qibo/core/distutils.py
@@ -1,7 +1,7 @@
 import copy
 from qibo import K
 from qibo.abstractions import gates
-from qibo.config import raise_error, get_threads
+from qibo.config import raise_error
 from typing import Dict, List, Optional, Sequence, Tuple
 
 

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -1,5 +1,5 @@
 from qibo import K
-from qibo.config import raise_error, get_threads
+from qibo.config import raise_error
 from qibo.core import measurements
 from qibo.abstractions.states import AbstractState
 

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -189,8 +189,8 @@ def parallel_parametrized_execution(circuit, parameters, initial_state=None, pro
 def _check_parallel_configuration(processes):
     """Check if configuration is suitable for efficient parallel execution."""
     import os, psutil
-    from qibo import get_device, get_backend
-    from qibo.config import raise_error, get_threads, log
+    from qibo import get_device, get_backend, get_threads
+    from qibo.config import raise_error, log
     device = get_device()
     if os.name == "nt":  # pragma: no cover
         raise_error(RuntimeError, "Parallel evaluations not supported on Windows.")


### PR DESCRIPTION
As we discussed, this moves the `set_threads` and `get_threads` methods at the backend level so that we can set the number of threads for numba properly. I checked and it seems to work properly for qibojit, for example
```Python
import qibo
from qibo.models import QFT

qibo.set_backend("qibojit")
qibo.set_threads(10)
c = QFT(28)
state = c()
```
should use 10 threads. The default number of threads is read from `psutil` (unless the `OMP_NUM_THREADS` variable is provided) and is equal to the physical number of cores. This is usually half of total threads.

Note that the above mechanism works for qibotf, but not for pure tensorflow operators. So when using the pure `tensorflow` backend, `set_threads` is completely ignored and when using `qibotf`, custom operators will use the proper number of threads while all other tf operations will use all threads (which is tensorflow's default). I am not sure if there is a way around this because tensorflow does not allow use of `tf.config.threading.set_inter_op_parallelism_threads` after import. This is in contrast to `numba.set_num_threads()` which can be called anytime during execution.