### PR TITLE
disabling parallel evaluation on darwin

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Test examples
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'
       run: |
-        pytest examples/
+        OMP_NUM_THREADS=1 pytest examples/
     - name: Upload coverage to Codecov
       if: startsWith(matrix.os, 'ubuntu')
       uses: codecov/codecov-action@v1

--- a/examples/EF_QAE/main.py
+++ b/examples/EF_QAE/main.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from qibo.models import Circuit
-from qibo import hamiltonians, gates, models, matrices
+from qibo import hamiltonians, gates, models, K
 from qibo.hamiltonians import Hamiltonian
 from scipy.optimize import minimize
 from sklearn.datasets import load_digits
@@ -10,7 +10,7 @@ import argparse
 
 
 def main(layers, autoencoder, example):
-    
+
     def encoder_hamiltonian_simple(nqubits, ncompress):
         """Creates the encoding Hamiltonian.
         Args:
@@ -24,7 +24,7 @@ def main(layers, autoencoder, example):
         m1 = np.eye(2 ** (nqubits - ncompress), dtype=m0.dtype)
         ham = hamiltonians.Hamiltonian(nqubits, np.kron(m1, m0))
         return 0.5 * (ham + ncompress)
-    
+
     def rotate(theta, x):
         new_theta = []
         index = 0
@@ -45,14 +45,14 @@ def main(layers, autoencoder, example):
     compress = 2
     encoder = encoder_hamiltonian_simple(nqubits, compress)
     count = [0]
-    
+
     if example == 0:
         ising_groundstates = []
         lambdas = np.linspace(0.5, 1.0, 20)
         for lamb in lambdas:
             ising_ham = -1 * hamiltonians.TFIM(nqubits, h=lamb)
             ising_groundstates.append(ising_ham.eigenvectors()[0])
-            
+
         if autoencoder == 1:
             circuit = models.Circuit(nqubits)
             for l in range(layers):
@@ -72,36 +72,36 @@ def main(layers, autoencoder, example):
                 circuit.add(gates.CZ(4, 1))
             for q in range(nqubits-compress, nqubits, 1):
                 circuit.add(gates.RY(q, theta=0))
-                
+
             def cost_function_QAE_Ising(params, count):
                 """Evaluates the cost function to be minimized for the QAE and Ising model.
-        
+
                 Args:
                     params (array or list): values of the parameters.
-        
+
                 Returns:
                     Value of the cost function.
-                """                    
+                """
                 cost = 0
                 circuit.set_parameters(params) # this will change all thetas to the appropriate values
                 for i in range(len(ising_groundstates)):
                     final_state = circuit.execute(np.copy(ising_groundstates[i]))
-                    cost += encoder.expectation(final_state).numpy().real
-                    
+                    cost += K.to_numpy(encoder.expectation(final_state)).real
+
                 cost_function_steps.append(cost/len(ising_groundstates)) # save cost function value after each step
-        
+
                 if count[0] % 50 == 0:
                     print(count[0], cost/len(ising_groundstates))
                 count[0] += 1
-        
+
                 return cost/len(ising_groundstates)
-        
+
             nparams = 2 * nqubits * layers + compress
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
-        
+
             result = minimize(cost_function_QAE_Ising, initial_params,
                               args=(count), method='BFGS', options={'maxiter': 5.0e4})
-            
+
         elif autoencoder == 0:
             circuit = models.Circuit(nqubits)
             for l in range(layers):
@@ -121,38 +121,38 @@ def main(layers, autoencoder, example):
                 circuit.add(gates.CZ(4, 1))
             for q in range(nqubits-compress, nqubits, 1):
                 circuit.add(gates.RY(q, theta=0))
-                
+
             def cost_function_EF_QAE_Ising(params, count):
                 """Evaluates the cost function to be minimized for the EF-QAE and Ising model.
-        
+
                 Args:
                     params (array or list): values of the parameters.
-        
+
                 Returns:
                     Value of the cost function.
-                """                                                               
+                """
                 cost = 0
                 for i in range(len(ising_groundstates)):
                     newparams = rotate(params, lambdas[i])
                     circuit.set_parameters(newparams)
                     final_state = circuit.execute(np.copy(ising_groundstates[i]))
-                    cost += encoder.expectation(final_state).numpy().real
-                    
+                    cost += K.to_numpy(encoder.expectation(final_state)).real
+
                 cost_function_steps.append(cost/len(ising_groundstates)) # save cost function value after each step
-        
+
                 if count[0] % 50 == 0:
                     print(count[0], cost/len(ising_groundstates))
                 count[0] += 1
-        
+
                 return cost/len(ising_groundstates)
-        
-            
+
+
             nparams = 4 * nqubits * layers + 2 * compress
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
-        
+
             result = minimize(cost_function_EF_QAE_Ising, initial_params,
                               args=(count), method='BFGS', options={'maxiter': 5.0e4})
-            
+
         else:
             raise ValueError("You have to introduce a value of 0 or 1 in the autoencoder argument.")
 
@@ -161,10 +161,10 @@ def main(layers, autoencoder, example):
         vector_0 = []
         vector_1 = []
         for value in [0, 10, 20, 30, 36, 48, 49, 55, 72, 78]:
-            vector_0.append(np.array(digits.data[value])/np.linalg.norm(np.array(digits.data[value])))    
+            vector_0.append(np.array(digits.data[value])/np.linalg.norm(np.array(digits.data[value])))
         for value in [1, 11, 21, 42, 47, 56, 70, 85, 90, 93]:
             vector_1.append(np.array(digits.data[value])/np.linalg.norm(np.array(digits.data[value])))
-        
+
         if autoencoder == 1:
             circuit = models.Circuit(nqubits)
             for l in range(layers):
@@ -184,36 +184,36 @@ def main(layers, autoencoder, example):
                 circuit.add(gates.CZ(4, 1))
             for q in range(nqubits-compress, nqubits, 1):
                 circuit.add(gates.RY(q, theta=0))
-                
+
             def cost_function_QAE_Digits(params, count):
                 """Evaluates the cost function to be minimized for the QAE and Handwritten digits.
-        
+
                 Args:
                     params (array or list): values of the parameters.
-        
+
                 Returns:
                     Value of the cost function.
-                """                                            
+                """
                 cost = 0
                 circuit.set_parameters(params) # this will change all thetas to the appropriate values
                 for i in range(len(vector_0)):
                     final_state = circuit.execute(np.copy(vector_0[i]))
-                    cost += encoder.expectation(final_state).numpy().real
+                    cost += K.to_numpy(encoder.expectation(final_state)).real
                 for i in range(len(vector_1)):
                     final_state = circuit.execute(np.copy(vector_1[i]))
-                    cost += encoder.expectation(final_state).numpy().real
-                    
+                    cost += K.to_numpy(encoder.expectation(final_state)).real
+
                 cost_function_steps.append(cost/(len(vector_0)+len(vector_1))) # save cost function value after each step
-        
+
                 if count[0] % 50 == 0:
                     print(count[0], cost/(len(vector_0)+len(vector_1)))
                 count[0] += 1
-        
+
                 return cost/(len(vector_0)+len(vector_1))
-        
+
             nparams = 2 * nqubits * layers + compress
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
-        
+
             result = minimize(cost_function_QAE_Digits, initial_params,
                               args=(count), method='BFGS', options={'maxiter': 5.0e4})
 
@@ -236,49 +236,49 @@ def main(layers, autoencoder, example):
                 circuit.add(gates.CZ(4, 1))
             for q in range(nqubits-compress, nqubits, 1):
                 circuit.add(gates.RY(q, theta=0))
-                
+
             def cost_function_EF_QAE_Digits(params, count):
                 """Evaluates the cost function to be minimized for the EF-QAE and Handwritten digits.
-        
+
                 Args:
                     params (array or list): values of the parameters.
-        
+
                 Returns:
                     Value of the cost function.
-                """                                    
+                """
                 cost = 0
                 newparams = rotate(params, 1)
                 circuit.set_parameters(newparams)
                 for i in range(len(vector_0)):
                     final_state = circuit.execute(np.copy(vector_0[i]))
-                    cost += encoder.expectation(final_state).numpy().real
+                    cost += K.to_numpy(encoder.expectation(final_state)).real
                 newparams = rotate(params, 2)
                 circuit.set_parameters(newparams)
                 for i in range(len(vector_1)):
                     final_state = circuit.execute(np.copy(vector_1[i]))
-                    cost += encoder.expectation(final_state).numpy().real
-                    
+                    cost += K.to_numpy(encoder.expectation(final_state)).real
+
                 cost_function_steps.append(cost/(len(vector_0)+len(vector_1))) # save cost function value after each step
-        
+
                 if count[0] % 50 == 0:
                     print(count[0], cost/(len(vector_0)+len(vector_1)))
                 count[0] += 1
-        
+
                 return cost/(len(vector_0)+len(vector_1))
-        
-            
+
+
             nparams = 4 * nqubits * layers + 2 * compress
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
-        
+
             result = minimize(cost_function_EF_QAE_Digits, initial_params,
-                              args=(count), method='BFGS', options={'maxiter': 5.0e4})           
-            
+                              args=(count), method='BFGS', options={'maxiter': 5.0e4})
+
         else:
             raise ValueError("You have to introduce a value of 0 or 1 in the autoencoder argument.")
-            
+
     else:
         raise ValueError("You have to introduce a value of 0 or 1 in the example argument.")
-        
+
     print('Final parameters: ', result.x)
     print('Final cost function: ', result.fun)
 

--- a/examples/EF_QAE/main.py
+++ b/examples/EF_QAE/main.py
@@ -9,7 +9,7 @@ from sklearn.datasets import load_digits
 import argparse
 
 
-def main(layers, autoencoder, example):
+def main(layers, autoencoder, example, maxiter):
 
     def encoder_hamiltonian_simple(nqubits, ncompress):
         """Creates the encoding Hamiltonian.
@@ -100,7 +100,7 @@ def main(layers, autoencoder, example):
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
 
             result = minimize(cost_function_QAE_Ising, initial_params,
-                              args=(count), method='BFGS', options={'maxiter': 5.0e4})
+                              args=(count), method='BFGS', options={'maxiter': maxiter})
 
         elif autoencoder == 0:
             circuit = models.Circuit(nqubits)
@@ -151,7 +151,7 @@ def main(layers, autoencoder, example):
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
 
             result = minimize(cost_function_EF_QAE_Ising, initial_params,
-                              args=(count), method='BFGS', options={'maxiter': 5.0e4})
+                              args=(count), method='BFGS', options={'maxiter': maxiter})
 
         else:
             raise ValueError("You have to introduce a value of 0 or 1 in the autoencoder argument.")
@@ -215,7 +215,7 @@ def main(layers, autoencoder, example):
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
 
             result = minimize(cost_function_QAE_Digits, initial_params,
-                              args=(count), method='BFGS', options={'maxiter': 5.0e4})
+                              args=(count), method='BFGS', options={'maxiter': maxiter})
 
         elif autoencoder == 0:
             circuit = models.Circuit(nqubits)
@@ -271,7 +271,7 @@ def main(layers, autoencoder, example):
             initial_params = np.random.uniform(0, 2*np.pi, nparams)
 
             result = minimize(cost_function_EF_QAE_Digits, initial_params,
-                              args=(count), method='BFGS', options={'maxiter': 5.0e4})
+                              args=(count), method='BFGS', options={'maxiter': maxiter})
 
         else:
             raise ValueError("You have to introduce a value of 0 or 1 in the autoencoder argument.")
@@ -288,5 +288,6 @@ if __name__ == "__main__":
     parser.add_argument("--layers", default=3, type=int, help='(int): number of ansatz layers')
     parser.add_argument("--autoencoder", default=0, type=int, help='(int): 0 to run the EF-QAE or 1 to run the QAE')
     parser.add_argument("--example", default=0, type=int, help='(int): 0 to run Ising model example or 1 to run the Handwritten digits example')
+    parser.add_argument("--maxiter", default=50000, type=int, help='(int): maximum number of iterations')
     args = parser.parse_args()
     main(**vars(args))

--- a/examples/aavqe/main.py
+++ b/examples/aavqe/main.py
@@ -59,8 +59,8 @@ def main(nqubits, layers, maxsteps, T_max):
 
     #We compute the difference from the exact value to check performance
     eigenvalue = problem_hamiltonian.eigenvalues()
-    print('Difference from exact value: ',best - eigenvalue[0].numpy().real)
-    print('Log difference: ',-np.log10(best - eigenvalue[0].numpy().real))
+    print('Difference from exact value: ',best - eigenvalue[0].real)
+    print('Log difference: ',-np.log10(best - eigenvalue[0].real))
 
 
 if __name__ == "__main__":

--- a/examples/adiabatic3sat/functions.py
+++ b/examples/adiabatic3sat/functions.py
@@ -83,10 +83,7 @@ def spolynomial(t, params):
 
 def ground_state(nqubits):
     """Returns |++...+> state to be used as the ground state of the easy Hamiltonian."""
-    import tensorflow as tf
-    from qibo.config import DTYPES
-    s = np.ones(2 ** nqubits) / np.sqrt(2 ** nqubits)
-    return tf.cast(s, dtype=DTYPES.get('DTYPECPX'))
+    return np.ones(2 ** nqubits) / np.sqrt(2 ** nqubits)
 
 
 def plot(qubits, ground, first, gap, dt, T):

--- a/examples/adiabatic3sat/main.py
+++ b/examples/adiabatic3sat/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import numpy as np
-from qibo import hamiltonians, models, callbacks
+from qibo import hamiltonians, models, callbacks, K
 import functions
 import argparse
 
@@ -94,9 +94,9 @@ def main(nqubits, instance, T, dt, solver, plot, trotter, params,
     # Perform evolution
     initial_state = np.ones(2 ** nqubits) / np.sqrt(2 ** nqubits)
     final_state = evolve(final_time=T, initial_state=initial_state)
-    output_dec = (np.abs(final_state.numpy())**2).argmax()
+    output_dec = (np.abs(K.to_numpy(final_state))**2).argmax()
     max_output = "{0:0{bits}b}".format(output_dec, bits = nqubits)
-    max_prob = (np.abs(final_state.numpy())**2).max()
+    max_prob = (np.abs(K.to_numpy(final_state))**2).max()
     print("Exact cover instance with {} qubits.\n".format(nqubits))
     if solution:
         print('Known solution: {}\n'.format(''.join(solution)))

--- a/examples/autoencoder/main.py
+++ b/examples/autoencoder/main.py
@@ -7,7 +7,7 @@ from scipy.optimize import minimize
 import argparse
 
 
-def main(nqubits, layers, compress, lambdas):
+def main(nqubits, layers, compress, lambdas, maxiter):
 
     def encoder_hamiltonian_simple(nqubits, ncompress):
         """Creates the encoding Hamiltonian.
@@ -69,7 +69,7 @@ def main(nqubits, layers, compress, lambdas):
 
     count = [0]
     result = minimize(lambda p: cost_function(p, count), initial_params,
-                      method='L-BFGS-B', options={'maxiter': 2.0e3, 'maxfun': 2.0e3})
+                      method='L-BFGS-B', options={'maxiter': maxiter, 'maxfun': 2.0e3})
 
     print('Final parameters: ', result.x)
     print('Final cost function: ', result.fun)
@@ -81,5 +81,6 @@ if __name__ == "__main__":
     parser.add_argument("--layers", default=2, type=int)
     parser.add_argument("--compress", default=2, type=int)
     parser.add_argument("--lambdas", default=[0.9, 0.95, 1.0, 1.05, 1.10], type=list)
+    parser.add_argument("--maxiter", default=2000, type=int)
     args = parser.parse_args()
     main(**vars(args))

--- a/examples/autoencoder/main.py
+++ b/examples/autoencoder/main.py
@@ -56,7 +56,7 @@ def main(nqubits, layers, compress, lambdas, maxiter):
             print(count[0], cost/len(ising_groundstates))
         count[0] += 1
 
-        return cost/len(ising_groundstates)
+        return K.to_numpy(cost)/len(ising_groundstates)
 
     nparams = 2 * nqubits * layers + nqubits
     initial_params = np.random.uniform(0, 2*np.pi, nparams)

--- a/examples/autoencoder/main.py
+++ b/examples/autoencoder/main.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from qibo.models import Circuit
-from qibo import hamiltonians, gates, models
+from qibo import hamiltonians, gates, models, K
 from scipy.optimize import minimize
 import argparse
 
 
 def main(nqubits, layers, compress, lambdas):
-    
+
     def encoder_hamiltonian_simple(nqubits, ncompress):
         """Creates the encoding Hamiltonian.
         Args:
@@ -50,7 +50,7 @@ def main(nqubits, layers, compress, lambdas):
         circuit.set_parameters(params) # this will change all thetas to the appropriate values
         for i in range(len(ising_groundstates)):
             final_state = circuit(np.copy(ising_groundstates[i]))
-            cost += encoder.expectation(final_state).numpy().real
+            cost += K.real(encoder.expectation(final_state))
 
         if count[0] % 50 == 0:
             print(count[0], cost/len(ising_groundstates))

--- a/examples/benchmarks/main.py
+++ b/examples/benchmarks/main.py
@@ -14,7 +14,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3" # disable Tensorflow warnings
 parser = argparse.ArgumentParser()
 parser.add_argument("--nqubits", default=20, type=int)
 parser.add_argument("--type", default="qft", type=str)
-parser.add_argument("--backend", default="qibotf", type=str)
+parser.add_argument("--backend", default="qibojit", type=str)
 parser.add_argument("--precision", default="double", type=str)
 
 parser.add_argument("--device", default=None, type=str)

--- a/examples/benchmarks/qaoa.py
+++ b/examples/benchmarks/qaoa.py
@@ -4,7 +4,7 @@ Testing Quantum Approximate Optimization Algorithm model.
 import argparse
 import time
 import numpy as np
-from qibo import models, hamiltonians
+from qibo import models, hamiltonians, K
 
 
 parser = argparse.ArgumentParser()
@@ -28,7 +28,7 @@ def main(nqubits, nangles, trotter=False, solver="exp",
     qaoa = models.QAOA(hamiltonian, solver=solver)
     creation_time = time.time() - start_time
 
-    target = np.real(np.min(hamiltonian.eigenvalues()))
+    target = np.real(np.min(K.to_numpy(hamiltonian.eigenvalues())))
     print("\nTarget state =", target)
 
     np.random.seed(0)

--- a/examples/benchmarks/vqe.py
+++ b/examples/benchmarks/vqe.py
@@ -7,7 +7,7 @@ import json
 import time
 import numpy as np
 import qibo
-from qibo import gates, models, hamiltonians
+from qibo import gates, models, hamiltonians, K
 
 
 parser = argparse.ArgumentParser()
@@ -83,7 +83,7 @@ def main(nqubits, nlayers, backend, varlayer=False, method="Powell",
     vqe = models.VQE(circuit, hamiltonian)
     logs[-1]["creation_time"] = time.time() - start_time
 
-    target = np.real(np.min(hamiltonian.eigenvalues()))
+    target = np.real(np.min(K.to_numpy(hamiltonian.eigenvalues())))
     print("\nTarget state =", target)
 
     np.random.seed(0)

--- a/examples/falqon/README.md
+++ b/examples/falqon/README.md
@@ -29,7 +29,7 @@ The `FALQON` class behaves similarly to the `QAOA` one. It admits the following 
             Default solver is 'exp'.
 - `callbacks`: List of callbacks to calculate during evolution.
 - `accelerators`: Dictionary of devices to use for distributed
-            execution. See `qibo.tensorflow.distcircuit.DistributedCircuit`
+            execution. See `qibo.core.distcircuit.DistributedCircuit`
             for more details. This option is available only when ``hamiltonian``
             is a `qibo.abstractions.hamiltonians.TrotterHamiltonian`.
 - `memory_device`: Name of device where the full state will be saved.

--- a/examples/qsvd/main.py
+++ b/examples/qsvd/main.py
@@ -17,9 +17,11 @@ parser.add_argument("--RY", action="store_true",
                     help="Use Ry rotations or RxRzRx rotations in the ansatz")
 parser.add_argument("--method", default='Powell',
                     help="Classical otimizer employed", type=str)
+parser.add_argument("--maxiter", default=None,
+                    help="Maximum number of iterations.", type=int)
 
 
-def main(nqubits, subsize, nlayers, nshots, RY, method):
+def main(nqubits, subsize, nlayers, nshots, RY, method, maxiter):
 
     # We initialize the QSVD
     Qsvd = QSVD(nqubits, subsize, nlayers, RY=RY)
@@ -60,7 +62,7 @@ def main(nqubits, subsize, nlayers, nshots, RY, method):
     # We train the QSVD
     print('Training QSVD...')
     cost_function, optimal_angles = Qsvd.minimize(initial_parameters, init_state=initial_state,
-                                                  nshots=nshots, method=method)
+                                                  nshots=nshots, method=method, maxiter=maxiter)
 
     # We use the optimal angles to compute the Schmidt coefficients of the bipartion
     Schmidt_coefficients = Qsvd.Schmidt_coeff(

--- a/examples/qsvd/qsvd.py
+++ b/examples/qsvd/qsvd.py
@@ -111,7 +111,7 @@ class QSVD():
         return loss/nshots
 
     def minimize(self, init_theta, init_state=None, nshots=100000,
-                 method='Powell'):
+                 method='Powell', maxiter=None):
         """
         Args:
             theta: list or numpy.array with the angles to be used in the circuit
@@ -125,7 +125,7 @@ class QSVD():
         from scipy.optimize import minimize
 
         result = minimize(self.QSVD_cost, init_theta, args=(init_state, nshots),
-                          method=method, options={'disp': True})
+                          method=method, options={'disp': True, 'maxiter': maxiter})
         loss = result.fun
         optimal_angles = result.x
 

--- a/examples/qsvd/qsvd.py
+++ b/examples/qsvd/qsvd.py
@@ -51,7 +51,7 @@ class QSVD():
             rotations: Function that generates rotation gates (defined in __init__)
 
         Returns:
-            qibo.tensorflow.circuit.TensorflowCircuit with the ansatz to be used in the variational circuit
+            Circuit model implementing the variational ansatz
         """
         c = Circuit(self.nqubits)
         for _ in range(nlayers):
@@ -74,7 +74,7 @@ class QSVD():
             theta: list or numpy.array with the angles to be used in the circuit
 
         Returns:
-            qibo.tensorflow.circuit.TensorflowCircuit with the variational circuit for the QSVD
+            Circuit model implementing the variational ansatz for QSVD
         """
         self._circuit.set_parameters(theta)
         return self._circuit

--- a/examples/reuploading_classifier/main.py
+++ b/examples/reuploading_classifier/main.py
@@ -42,7 +42,7 @@ def main(dataset, layers):
 
     ql.set_parameters(parameters)
     value_loss = ql.cost_function_fidelity()
-    print('The value of the cost function achieved is %.6f' % value_loss.numpy())
+    print('The value of the cost function achieved is %.6f' % value_loss)
     ql.paint_results()
     ql.paint_world_map()
 

--- a/examples/reuploading_classifier/qlassifier.py
+++ b/examples/reuploading_classifier/qlassifier.py
@@ -1,6 +1,6 @@
-from qibo.models import Circuit
-from qibo import gates
 import numpy as np
+from qibo.models import Circuit
+from qibo import gates, K
 from datasets import create_dataset, create_target, fig_template, world_map_template
 from matplotlib.cm import get_cmap
 from matplotlib.colors import Normalize
@@ -270,4 +270,4 @@ class single_qubit_classifier:
 
 
 def fidelity(state1, state2):
-    return tf.constant(tf.abs(tf.reduce_sum(tf.math.conj(state2) * state1))**2)
+    return K.abs(K.sum(K.conj(state2) * state1))**2)

--- a/examples/reuploading_classifier/qlassifier.py
+++ b/examples/reuploading_classifier/qlassifier.py
@@ -2,7 +2,6 @@ from qibo.models import Circuit
 from qibo import gates
 import numpy as np
 from datasets import create_dataset, create_target, fig_template, world_map_template
-import tensorflow as tf
 from matplotlib.cm import get_cmap
 from matplotlib.colors import Normalize
 import os

--- a/examples/reuploading_classifier/qlassifier.py
+++ b/examples/reuploading_classifier/qlassifier.py
@@ -223,7 +223,7 @@ class single_qubit_classifier:
         norm_class = Normalize(vmin=0, vmax=10)
         for i, x in enumerate(self.test_set[0]):
             C = self.circuit(x)
-            state = K.to_numpy(C.execute())
+            state = C.execute()
             angles[i, 0] = np.pi / 2 - \
                 np.arccos(np.abs(state[0]) ** 2 - np.abs(state[1]) ** 2)
             angles[i, 1] = np.angle(state[1] / state[0])
@@ -268,4 +268,4 @@ class single_qubit_classifier:
 
 
 def fidelity(state1, state2):
-    return K.abs(K.sum(K.conj(state2) * state1)) ** 2
+    return K.abs(K.sum(K.qnp.conj(state2) * state1)) ** 2

--- a/examples/reuploading_classifier/qlassifier.py
+++ b/examples/reuploading_classifier/qlassifier.py
@@ -110,12 +110,11 @@ class single_qubit_classifier:
         if method == 'cma':
             # Genetic optimizer
             import cma
-            r = cma.fmin2(lambda p: loss(p).numpy(), self.params, 2)
+            r = cma.fmin2(lambda p: K.to_numpy(loss(p)), self.params, 2)
             result = r[1].result.fbest
             parameters = r[1].result.xbest
 
         elif method == 'sgd':
-            from qibo import K
             circuit = self.circuit(self.training_set[0])
             for gate in circuit.queue:
                 if K.name != "tensorflow":
@@ -133,7 +132,6 @@ class single_qubit_classifier:
                 sgd_options.update(options)
 
             # proceed with the training
-            from qibo import K
             vparams = K.Variable(self.params)
             optimizer = getattr(K.optimizers, sgd_options["optimizer"])(
                 learning_rate=sgd_options["learning_rate"])
@@ -154,15 +152,15 @@ class single_qubit_classifier:
                 if l < l_optimal:
                     l_optimal, params_optimal = l, vparams
                 if e % sgd_options["nmessage"] == 0:
-                    print('ite %d : loss %f' % (e, l.numpy()))
+                    print('ite %d : loss %f' % (e, K.to_numpy(l)))
 
-            result = self.cost_function(params_optimal).numpy()
-            parameters = params_optimal.numpy()
+            result = K.to_numpy(self.cost_function(params_optimal))
+            parameters = K.to_numpy(params_optimal)
 
         else:
             import numpy as np
             from scipy.optimize import minimize
-            m = minimize(lambda p: loss(p).numpy(), self.params,
+            m = minimize(lambda p: K.to_numpy(loss(p)), self.params,
                          method=method, options=options)
             result = m.fun
             parameters = m.x
@@ -225,7 +223,7 @@ class single_qubit_classifier:
         norm_class = Normalize(vmin=0, vmax=10)
         for i, x in enumerate(self.test_set[0]):
             C = self.circuit(x)
-            state = C.execute().numpy()
+            state = K.to_numpy(C.execute())
             angles[i, 0] = np.pi / 2 - \
                 np.arccos(np.abs(state[0]) ** 2 - np.abs(state[1]) ** 2)
             angles[i, 1] = np.angle(state[1] / state[0])
@@ -270,4 +268,4 @@ class single_qubit_classifier:
 
 
 def fidelity(state1, state2):
-    return K.abs(K.sum(K.conj(state2) * state1))**2)
+    return K.abs(K.sum(K.conj(state2) * state1)) ** 2

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -144,7 +144,7 @@ def test_benchmarks(nqubits, type):
     header = ("import argparse\nimport os\nimport time\nimport numpy as np"
               "\nimport qibo\nimport circuits\n\n")
     args = {"nqubits": nqubits, "type": type,
-            "backend": "qibotf", "precision": "double",
+            "backend": "qibojit", "precision": "double",
             "device": None, "accelerators": None,
             "nshots": None, "fuse": False, "compile": False,
             "nlayers": None, "gate_type": None, "params": {},
@@ -159,7 +159,7 @@ def test_benchmarks(nqubits, type):
 @pytest.mark.parametrize("varlayer", [False, True])
 def test_vqe_benchmarks(nqubits, nlayers, varlayer, method="Powell"):
     args = locals()
-    args["backend"] = "qibotf"
+    args["backend"] = "qibojit"
     path = os.path.join(base_dir, "benchmarks")
     sys.path[-1] = path
     os.chdir(path)
@@ -232,8 +232,7 @@ def test_ef_qae(layers, autoencoder, example):
     run_script(args)
 
 
-@pytest.mark.skip
-@pytest.mark.parametrize("N", [15])
+@pytest.mark.parametrize("N", [15, 21])
 @pytest.mark.parametrize("times", [2, 10])
 @pytest.mark.parametrize("A", [None])
 @pytest.mark.parametrize("semiclassical", [True, False])

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -205,6 +205,7 @@ def test_grover3sat(nqubits, instance):
     run_script(args)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("nqubits,instance,T,dt", [(4, 1, 10, 1e-1)])
 @pytest.mark.parametrize("solver", ["exp", "rk4"])
 @pytest.mark.parametrize("trotter", [True, False])
@@ -221,6 +222,7 @@ def test_adiabatic3sat(nqubits, instance, T, dt, solver, trotter, params,
     run_script(args)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("layers", [3, 2])
 @pytest.mark.parametrize("autoencoder", [0, 1])
 @pytest.mark.parametrize("example", [0, 1])

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -224,7 +224,8 @@ def test_adiabatic3sat(nqubits, instance, T, dt, solver, trotter, params,
 @pytest.mark.parametrize("layers", [3, 2])
 @pytest.mark.parametrize("autoencoder", [0, 1])
 @pytest.mark.parametrize("example", [0, 1])
-def test_ef_qae(layers, autoencoder, example):
+@pytest.mark.parametrize("maxiter", [1])
+def test_ef_qae(layers, autoencoder, example, maxiter):
     args = locals()
     os.chdir(os.path.join(base_dir, "EF_QAE"))
     run_script(args)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -232,6 +232,7 @@ def test_ef_qae(layers, autoencoder, example):
     run_script(args)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("N", [15])
 @pytest.mark.parametrize("times", [2, 10])
 @pytest.mark.parametrize("A", [None])

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -122,7 +122,7 @@ def test_reuploading_classifier(dataset, layers):
 
 
 @pytest.mark.parametrize("data", [(2, 0.4, 0.05, 0.1, 1.9)])
-@pytest.mark.parametrize("bins", [8, 16])
+@pytest.mark.parametrize("bins", [8, 10])
 def test_unary(data, bins, M=10, shots=1000):
     args = locals()
     if "functions" in sys.modules:

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -205,7 +205,6 @@ def test_grover3sat(nqubits, instance):
     run_script(args)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("nqubits,instance,T,dt", [(4, 1, 10, 1e-1)])
 @pytest.mark.parametrize("solver", ["exp", "rk4"])
 @pytest.mark.parametrize("trotter", [True, False])
@@ -222,7 +221,6 @@ def test_adiabatic3sat(nqubits, instance, T, dt, solver, trotter, params,
     run_script(args)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("layers", [3, 2])
 @pytest.mark.parametrize("autoencoder", [0, 1])
 @pytest.mark.parametrize("example", [0, 1])

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -232,7 +232,7 @@ def test_ef_qae(layers, autoencoder, example):
     run_script(args)
 
 
-@pytest.mark.parametrize("N", [15, 21])
+@pytest.mark.parametrize("N", [15])
 @pytest.mark.parametrize("times", [2, 10])
 @pytest.mark.parametrize("A", [None])
 @pytest.mark.parametrize("semiclassical", [True, False])

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -78,7 +78,8 @@ def test_aavqe(nqubits, layers, maxsteps, T_max):
 @pytest.mark.parametrize("layers", [1, 2])
 @pytest.mark.parametrize("compress", [1])
 @pytest.mark.parametrize("lambdas", [[0.9, 0.95, 1.0, 1.05, 1.10]])
-def test_autoencoder(nqubits, layers, compress, lambdas):
+@pytest.mark.parametrize("maxiter", [1])
+def test_autoencoder(nqubits, layers, compress, lambdas, maxiter):
     args = locals()
     os.chdir(os.path.join(base_dir, "autoencoder"))
     run_script(args)
@@ -102,7 +103,7 @@ def test_hash_grover(h_value, collisions, b):
 @pytest.mark.parametrize("nlayers", [1, 2])
 @pytest.mark.parametrize("nshots", [1000])
 @pytest.mark.parametrize("RY", [False, True])
-def test_qsvd(nqubits, subsize, nlayers, nshots, RY, method="Powell"):
+def test_qsvd(nqubits, subsize, nlayers, nshots, RY, method="Powell", maxiter=1):
     args = locals()
     path = os.path.join(base_dir, "qsvd")
     sys.path[-1] = path

--- a/examples/variational_classifier/qclassifier.py
+++ b/examples/variational_classifier/qclassifier.py
@@ -7,22 +7,22 @@ from qibo import gates
 
 
 class QuantumClassifer():
-    
+
     def __init__(self, nclasses, nqubits, nlayers, RY=True):
         """
         Class for a multi-task variational quantum classifier
-    
-        Args: 
-            nclases: int number of classes to be classified     
+
+        Args:
+            nclases: int number of classes to be classified
             nqubits: int number of qubits employed in the quantum circuit
-        """     
-        self.nclasses = nclasses        
-        self.nqubits = nqubits   
+        """
+        self.nclasses = nclasses
+        self.nqubits = nqubits
         self.measured_qubits = int(np.ceil(np.log2(self.nclasses)))
-        
+
         if self.nqubits <= 1:
             raise ValueError('nqubits must be larger than 1')
-            
+
         if RY:
             def rotations():
                 for q in range(self.nqubits):
@@ -33,165 +33,165 @@ class QuantumClassifer():
                     yield gates.RX(q, theta=0)
                     yield gates.RZ(q, theta=0)
                     yield gates.RX(q, theta=0)
-                    
-        self._circuit = self.ansatz(nlayers, rotations)      
-        
+
+        self._circuit = self.ansatz(nlayers, rotations)
+
     def _CZ_gates1(self):
         """Yields CZ gates used in the variational circuit."""
-        for q in range(0, self.nqubits-1, 2):         
+        for q in range(0, self.nqubits-1, 2):
             yield gates.CZ(q, q+1)
-                
+
     def _CZ_gates2(self):
         """Yields CZ gates used in the variational circuit."""
-        for q in range(1, self.nqubits-1, 2):          
+        for q in range(1, self.nqubits-1, 2):
             yield gates.CZ(q, q+1)
-            
+
         yield gates.CZ(0, self.nqubits-1)
-        
+
     def ansatz(self, nlayers, rotations):
-        """    
-        Args: 
-            theta: list or numpy.array with the angles to be used in the circuit     
+        """
+        Args:
+            theta: list or numpy.array with the angles to be used in the circuit
             nlayers: int number of layers of the varitional circuit ansatz
-    
-        Returns: 
-            qibo.tensorflow.circuit.TensorflowCircuit with the ansatz to be used in the variational circuit
+
+        Returns:
+            Circuit implementing the variational ansatz
         """
         c = Circuit(self.nqubits)
-        for _ in range(nlayers):        
+        for _ in range(nlayers):
             c.add(rotations())
             c.add(self._CZ_gates1())
             c.add(rotations())
-            c.add(self._CZ_gates2())          
+            c.add(self._CZ_gates2())
         # Final rotations
         c.add(rotations())
         # Measurements
         c.add(gates.M(*range(self.measured_qubits)))
-            
+
         return c
-            
+
     def Classifier_circuit(self, theta):
-        """    
-        Args: 
-            theta: list or numpy.array with the biases and the angles to be used in the circuit       
-            nlayers: int number of layers of the varitional circuit ansatz         
+        """
+        Args:
+            theta: list or numpy.array with the biases and the angles to be used in the circuit
+            nlayers: int number of layers of the varitional circuit ansatz
             RY: if True, parameterized Rx,Rz,Rx gates are used in the circuit
                 if False, parameterized Ry gates are used in the circuit (default=False)
-    
-        Returns: 
-            qibo.tensorflow.circuit.TensorflowCircuit with the variational circuit for angles "theta"
+
+        Returns:
+            Circuit implementing the variational ansatz for angles "theta"
         """
         bias = np.array(theta[0:self.measured_qubits])
-        angles = theta[self.measured_qubits:] 
-        
+        angles = theta[self.measured_qubits:]
+
         self._circuit.set_parameters(angles)
-        
+
         return self._circuit
-        
+
     def Predictions(self, circuit, theta, init_state, nshots=10000):
-        """    
-        Args: 
-            theta: list or numpy.array with the biases to be used in the circuit                         
+        """
+        Args:
+            theta: list or numpy.array with the biases to be used in the circuit
             init_state: numpy.array with the quantum state to be classified
             nshots: int number of runs of the circuit during the sampling process (default=10000)
-    
-        Returns: 
+
+        Returns:
             numpy.array() with predictions for each qubit, for the initial state
-        """  
-        bias = np.array(theta[0:self.measured_qubits]) 
-        circuit = circuit(init_state, nshots)      
+        """
+        bias = np.array(theta[0:self.measured_qubits])
+        circuit = circuit(init_state, nshots)
         result = circuit.frequencies(binary=False)
         prediction = np.zeros(self.measured_qubits)
-    
-        for qubit in range(self.measured_qubits):      
-            for clase in range(self.nclasses):           
+
+        for qubit in range(self.measured_qubits):
+            for clase in range(self.nclasses):
                 binary = bin(clase)[2:].zfill(self.measured_qubits)
                 prediction[qubit] += result[clase] * (1-2*int(binary[-qubit-1]))
-    
+
         return prediction/nshots + bias
 
     def square_loss(self, labels, predictions):
-        """    
-        Args: 
-            labels: list or numpy.array with the qubit labels of the quantum states to be classified                    
+        """
+        Args:
+            labels: list or numpy.array with the qubit labels of the quantum states to be classified
             predictions: list or numpy.array with the qubit predictions for the quantum states to be classified
-    
-        Returns: 
+
+        Returns:
             numpy.float32 with the value of the square-loss function
         """
         loss = 0
-        for l, p in zip(labels, predictions):    
+        for l, p in zip(labels, predictions):
             for qubit in range(self.measured_qubits):
                 loss += (l[qubit] - p[qubit]) ** 2
-    
+
         return loss / len(labels)
 
     def Cost_function(self, theta, data=None, labels=None, nshots=10000):
-        """    
-        Args: 
-            theta: list or numpy.array with the biases and the angles to be used in the circuit  
-            nlayers: int number of layers of the varitional circuit ansatz   
-            data: numpy.array data[page][word]  (this is an array of kets)       
-            labels: list or numpy.array with the labels of the quantum states to be classified                 
+        """
+        Args:
+            theta: list or numpy.array with the biases and the angles to be used in the circuit
+            nlayers: int number of layers of the varitional circuit ansatz
+            data: numpy.array data[page][word]  (this is an array of kets)
+            labels: list or numpy.array with the labels of the quantum states to be classified
             nshots: int number of runs of the circuit during the sampling process (default=10000)
-    
-        Returns: 
+
+        Returns:
             numpy.float32 with the value of the square-loss function
-        """  
+        """
         circ = self.Classifier_circuit(theta)
-        
+
         Bias = np.array(theta[0:self.measured_qubits])
         predictions = np.zeros(shape=(len(data),self.measured_qubits))
-    
+
         for i, text in enumerate(data):
             predictions[i] = self.Predictions(circ, Bias, text, nshots)
-    
+
         s = self.square_loss(labels, predictions)
-        
-        return s   
-    
+
+        return s
+
     def minimize(self, init_theta, data=None, labels=None, nshots=10000, method='Powell'):
         """
-        Args: 
-            theta: list or numpy.array with the angles to be used in the circuit        
-            nlayers: int number of layers of the varitional ansatz             
-            init_state: numpy.array with the quantum state to be Schmidt-decomposed    
-            nshots: int number of runs of the circuit during the sampling process (default=10000)         
+        Args:
+            theta: list or numpy.array with the angles to be used in the circuit
+            nlayers: int number of layers of the varitional ansatz
+            init_state: numpy.array with the quantum state to be Schmidt-decomposed
+            nshots: int number of runs of the circuit during the sampling process (default=10000)
             RY: if True, parameterized Rx,Rz,Rx gates are used in the circuit
-                if False, parameterized Ry gates are used in the circuit (default=True)               
+                if False, parameterized Ry gates are used in the circuit (default=True)
             method: str 'classical optimizer for the minimization'. All methods from scipy.optimize.minmize are suported (default='Powell')
-        
-        Returns: 
-            numpy.float64 with value of the minimum found, numpy.ndarray with the optimal angles        
-        """        
+
+        Returns:
+            numpy.float64 with value of the minimum found, numpy.ndarray with the optimal angles
+        """
         from scipy.optimize import minimize
-        
+
         result = minimize(self.Cost_function, init_theta, args=(data,labels,nshots), method=method)
         loss = result.fun
-        optimal_angles = result.x     
-        
+        optimal_angles = result.x
+
         return loss, optimal_angles
-   
+
     def Accuracy(self, labels, predictions, sign=True, tolerance=1e-2):
         """
-        Args: 
+        Args:
             labels: numpy.array with the labels of the quantum states to be classified
-            predictions: numpy.array with the predictions for the quantum states classified         
-            sign: if True, labels = np.sign(labels) and predictions = np.sign(predictions) (default=True)            
+            predictions: numpy.array with the predictions for the quantum states classified
+            sign: if True, labels = np.sign(labels) and predictions = np.sign(predictions) (default=True)
             tolerance: float tolerance level to consider a prediction correct (default=1e-2)
-    
-        Returns: 
+
+        Returns:
             float with the proportion of states classified successfully
         """
-        if sign == True:     
+        if sign == True:
             labels = [np.sign(label) for label in labels]
             predictions = [np.sign(prediction) for prediction in predictions]
-    
+
         accur = 0
         for l, p in zip(labels, predictions):
-            if np.allclose(l, p, rtol=0., atol=tolerance):           
+            if np.allclose(l, p, rtol=0., atol=tolerance):
                 accur += 1
-            
+
         accur = accur / len(labels)
-    
+
         return accur

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -51,8 +51,16 @@ class Backend:
             self.available_backends["icarusq"] = IcarusQBackend
             self.hardware_backends["icarusq"] = IcarusQBackend
 
+        self.constructed_backends = {}
+        self._active_backend = None
+        self.qnp = self.construct_backend("numpy")
+        # Create the default active backend
+        if "QIBO_BACKEND" in os.environ:  # pragma: no cover
+            self.active_backend = os.environ.get("QIBO_BACKEND")
+        self.active_backend = active_backend
+
         # raise performance warning if qibojit and qibotf are not available
-        log.info("Using {} backend.".format(active_backend))
+        self.show_config()
         if active_backend == "numpy": # pragma: no cover
             log.warning("numpy backend uses `np.einsum` and supports CPU only. "
                         "Consider installing the qibojit or qibotf backends for "
@@ -64,14 +72,6 @@ class Backend:
                         "high performance custom operators for TensorFlow "
                         "please use `pip install qibotf`. Alternatively, "
                         "consider installing the qibojit backend.")
-
-        self.constructed_backends = {}
-        self._active_backend = None
-        self.qnp = self.construct_backend("numpy")
-        # Create the default active backend
-        if "QIBO_BACKEND" in os.environ:  # pragma: no cover
-            self.active_backend = os.environ.get("QIBO_BACKEND")
-        self.active_backend = active_backend
 
     @property
     def active_backend(self):
@@ -119,6 +119,9 @@ class Backend:
     def __repr__(self):
         return str(self)
 
+    def show_config(self):
+        log.info(f"Using {self.active_backend.name} backend on {self.active_backend.default_device}")
+
     @staticmethod
     def check_availability(module_name):
         """Check if module is installed.
@@ -152,6 +155,7 @@ def set_backend(backend="qibojit"):
     if not config.ALLOW_SWITCHERS and backend != K.name:
         log.warning("Backend should not be changed after allocating gates.")
     K.active_backend = backend
+    K.show_config()
 
 
 def get_backend():

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -1,3 +1,4 @@
+from qibo.abstractions.states import AbstractState
 from qibo.backends import abstract, einsum_utils
 from qibo.config import raise_error, log
 
@@ -452,6 +453,8 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
     def to_numpy(self, x):
         if isinstance(x, self.np.ndarray):
             return x
+        elif isinstance(x, AbstractState):
+            x = x.numpy()
         return self.op.to_numpy(x)
 
     def cast(self, x, dtype='DTYPECPX'):

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -10,6 +10,7 @@ class ParallelResources:  # pragma: no cover
     This class takes care of duplicating resources for each process
     and calling the respective loss function.
     """
+    import sys
     import multiprocessing as mp
 
     # private objects holding the state
@@ -25,10 +26,10 @@ class ParallelResources:  # pragma: no cover
         if cls._instance is None:
             cls._instance = super(ParallelResources, cls).__new__(
                 cls, *args, **kwargs)
-            if cls.platform == 'win32': # pragma: no cover
+            if cls.sys.platform == 'win32' or cls.sys.paltform == 'darwin': # pragma: no cover
                 from qibo.config import raise_error
                 raise_error(NotImplementedError,
-                    "Parallel evaluation not supported on Windows")
+                    "Parallel evaluation supported only on linux.")
         return cls._instance
 
     def run(self, params=None):
@@ -189,7 +190,7 @@ def _check_parallel_configuration(processes):
     from qibo.config import raise_error, log
     device = get_device()
     if sys.platform == "win32" or sys.platform == 'darwin':  # pragma: no cover
-        raise_error(RuntimeError, "Parallel evaluations is supported only on linux.")
+        raise_error(RuntimeError, "Parallel evaluations supported only on linux.")
     if get_backend() == "tensorflow" or get_backend() == "qibojit":  # pragma: no cover
         raise_error(RuntimeError, f"{get_backend()} backend does not support parallel evaluations.")
     if device is not None and "GPU" in device:  # pragma: no cover

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -194,8 +194,8 @@ def _check_parallel_configuration(processes):
     device = get_device()
     if os.name == "nt":  # pragma: no cover
         raise_error(RuntimeError, "Parallel evaluations not supported on Windows.")
-    if get_backend() == "tensorflow":  # pragma: no cover
-        raise_error(RuntimeError, "tensorflow backend does not support parallel evaluations.")
+    if get_backend() == "tensorflow" or get_backend() == "qibojit":  # pragma: no cover
+        raise_error(RuntimeError, f"{get_backend()} backend does not support parallel evaluations.")
     if device is not None and "GPU" in device:  # pragma: no cover
         raise_error(RuntimeError, "Parallel evaluations cannot be used with GPU.")
     if ((processes is not None and processes * get_threads() > psutil.cpu_count()) or

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -10,11 +10,7 @@ class ParallelResources:  # pragma: no cover
     This class takes care of duplicating resources for each process
     and calling the respective loss function.
     """
-    import os
-    from sys import platform
     import multiprocessing as mp
-    if platform == 'darwin':
-        mp.set_start_method('fork')  # enforce on Darwin
 
     # private objects holding the state
     _instance = None
@@ -188,12 +184,12 @@ def parallel_parametrized_execution(circuit, parameters, initial_state=None, pro
 
 def _check_parallel_configuration(processes):
     """Check if configuration is suitable for efficient parallel execution."""
-    import os, psutil
+    import sys, psutil
     from qibo import get_device, get_backend, get_threads
     from qibo.config import raise_error, log
     device = get_device()
-    if os.name == "nt":  # pragma: no cover
-        raise_error(RuntimeError, "Parallel evaluations not supported on Windows.")
+    if sys.platform == "win32" or sys.platform == 'darwin':  # pragma: no cover
+        raise_error(RuntimeError, "Parallel evaluations is supported only on linux.")
     if get_backend() == "tensorflow" or get_backend() == "qibojit":  # pragma: no cover
         raise_error(RuntimeError, f"{get_backend()} backend does not support parallel evaluations.")
     if device is not None and "GPU" in device:  # pragma: no cover

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -26,7 +26,7 @@ class ParallelResources:  # pragma: no cover
         if cls._instance is None:
             cls._instance = super(ParallelResources, cls).__new__(
                 cls, *args, **kwargs)
-            if cls.sys.platform == 'win32' or cls.sys.paltform == 'darwin': # pragma: no cover
+            if cls.sys.platform == 'win32' or cls.sys.platform == 'darwin': # pragma: no cover
                 from qibo.config import raise_error
                 raise_error(NotImplementedError,
                     "Parallel evaluation supported only on linux.")

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -204,20 +204,20 @@ def test_entropy_large_circuit(backend, accelerators):
     c1.add((gates.RY(i, thetas[0, i]) for i in range(8)))
     c1.add((gates.CZ(i, i + 1) for i in range(0, 7, 2)))
     state1 = c1()
-    e1 = target_entropy(state1)
+    e1 = K.to_numpy(target_entropy(state1))
 
     c2 = Circuit(8)
     c2.add((gates.RY(i, thetas[1, i]) for i in range(8)))
     c2.add((gates.CZ(i, i + 1) for i in range(1, 7, 2)))
     c2.add(gates.CZ(0, 7))
     state2 = (c1 + c2)()
-    e2 = target_entropy(state2)
+    e2 = K.to_numpy(target_entropy(state2))
 
     c3 = Circuit(8)
     c3.add((gates.RY(i, thetas[2, i]) for i in range(8)))
     c3.add((gates.CZ(i, i + 1) for i in range(0, 7, 2)))
     state3 = (c1 + c2 + c3)()
-    e3 = target_entropy(state3)
+    e3 = K.to_numpy(target_entropy(state3))
 
     entropy = callbacks.EntanglementEntropy([0, 2, 4, 5])
     c = Circuit(8, accelerators)
@@ -235,7 +235,7 @@ def test_entropy_large_circuit(backend, accelerators):
     state = c()
 
     K.assert_allclose(state3, state)
-    K.assert_allclose(entropy[:], K.cast([0, e1, e2, e3]))
+    K.assert_allclose(entropy[:], [0, e1, e2, e3])
 
 
 def test_entropy_density_matrix(backend):

--- a/src/qibo/tests/test_models_variational.py
+++ b/src/qibo/tests/test_models_variational.py
@@ -97,9 +97,9 @@ def test_vqe(backend, method, options, compile, filename):
         backend = qibo.get_backend()
         if backend == "tensorflow" or backend == "qibojit" or "GPU" in device:
             pytest.skip("unsupported configuration")
-        import os
-        if os.name == 'nt': # pragma: no cover
-            pytest.skip("Parallel L-BFGS-B not supported on Windows.")
+        import sys
+        if sys.platform == 'win32' or sys.platform == 'darwin': # pragma: no cover
+            pytest.skip("Parallel L-BFGS-B only supported on linux.")
         qibo.set_threads(1)
 
     nqubits = 6

--- a/src/qibo/tests/test_parallel.py
+++ b/src/qibo/tests/test_parallel.py
@@ -1,7 +1,7 @@
 """
 Testing parallel evaluations.
 """
-import os
+import sys
 import numpy as np
 import pytest
 import qibo
@@ -14,7 +14,7 @@ def test_parallel_circuit_evaluation(backend):
     """Evaluate circuit for multiple input states."""
     device = qibo.get_device()
     backend = qibo.get_backend()
-    if 'GPU' in qibo.get_device() or os.name == 'nt' or backend == "tensorflow" or backend == "qibojit": # pragma: no cover
+    if 'GPU' in qibo.get_device() or sys.platform == "win32" or sys.platform == "darwin" or backend == "tensorflow" or backend == "qibojit": # pragma: no cover
         pytest.skip("unsupported configuration")
     original_threads = qibo.get_threads()
     qibo.set_threads(1)
@@ -38,7 +38,7 @@ def test_parallel_parametrized_circuit(backend):
     """Evaluate circuit for multiple parameters."""
     device = qibo.get_device()
     backend = qibo.get_backend()
-    if 'GPU' in qibo.get_device() or os.name == 'nt' or backend == "tensorflow" or backend == "qibojit": # pragma: no cover
+    if 'GPU' in qibo.get_device() or sys.platform == "win32" or sys.platform == "darwin" or backend == "tensorflow" or backend == "qibojit": # pragma: no cover
         pytest.skip("unsupported configuration")
     original_threads = qibo.get_threads()
     qibo.set_threads(1)


### PR DESCRIPTION
With qibojit installed the multiprocessing import cannot be changed to "fork" mode on macos. This PR disables the parallel feature for macos. I believe we should schedule a revision of this module in the future, in particular considering better parallel algorithms rather than forcing circuit copies and async evaluation. @stavros11 please let me know your opinion.