### PR TITLE
Set threads warnings

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -214,8 +214,7 @@ def set_threads(nthreads):
     Args:
         nthreads (int): number of threads.
     """
-    for bk in K.constructed_backends.values():
-        bk.set_threads(nthreads)
+    K.set_threads(nthreads)
 
 
 def get_threads():

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -105,8 +105,6 @@ class Backend:
             new_backend = self.available_backends.get(name)()
             if self.active_backend is not None:
                 new_backend.set_precision(self.active_backend.precision)
-                if self.active_backend.default_device:
-                    new_backend.set_device(self.active_backend.default_device)
             self.constructed_backends[name] = new_backend
         return self.constructed_backends.get(name)
 
@@ -199,8 +197,9 @@ def set_device(name):
     """
     if not config.ALLOW_SWITCHERS and name != K.default_device:
         log.warning("Device should not be changed after allocating gates.")
+    K.set_device(name)
     for bk in K.constructed_backends.values():
-        if bk.name != "numpy":
+        if bk.name != "numpy" and bk != K.active_backend:
             bk.set_device(name)
 
 

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -33,6 +33,7 @@ class NumpyBackend(abstract.AbstractBackend):
     def set_threads(self, nthreads):
         log.warning("Numpy backend supports only single-thread execution."
                     "Cannot change the number of threads.")
+        abstract.AbstractBackend.set_threads(self, nthreads)
 
     def to_numpy(self, x):
         return x

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -25,6 +25,9 @@ class NumpyBackend(abstract.AbstractBackend):
         self.newaxis = np.newaxis
         self.oom_error = MemoryError
         self.optimization = None
+        self.cpu_devices = ["/CPU:0"]
+        self.gpu_devices = []
+        self.default_device = self.cpu_devices[0]
 
     def set_device(self, name):
         log.warning("Numpy does not support device placement. "
@@ -409,7 +412,6 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
         if "NUMBA_NUM_THREADS" in os.environ: # pragma: no cover
             self.set_threads(int(os.environ.get("NUMBA_NUM_THREADS")))
 
-        # TODO: reconsider device management
         self.cpu_devices = ["/CPU:0"]
         self.gpu_devices = [f"/GPU:{i}" for i in range(ngpu)]
         if self.gpu_devices: # pragma: no cover

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -30,6 +30,10 @@ class NumpyBackend(abstract.AbstractBackend):
         log.warning("Numpy does not support device placement. "
                     "Aborting device change.")
 
+    def set_threads(self, nthreads):
+        log.warning("Numpy backend supports only single-thread execution."
+                    "Cannot change the number of threads.")
+
     def to_numpy(self, x):
         return x
 
@@ -446,7 +450,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
             self.set_engine("numba")
 
     def set_threads(self, nthreads):
-        super().set_threads(nthreads)
+        abstract.AbstractBackend.set_threads(self, nthreads)
         import numba # pylint: disable=E0401
         numba.set_num_threads(nthreads)
 

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -31,7 +31,7 @@ class NumpyBackend(abstract.AbstractBackend):
                     "Aborting device change.")
 
     def set_threads(self, nthreads):
-        log.warning("Numpy backend supports only single-thread execution."
+        log.warning("Numpy backend supports only single-thread execution. "
                     "Cannot change the number of threads.")
         abstract.AbstractBackend.set_threads(self, nthreads)
 

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -51,9 +51,9 @@ class TensorflowBackend(numpy.NumpyBackend):
 
     def set_threads(self, nthreads):
         log.warning("`set_threads` is not supported by the tensorflow "
-                    "backend. Please use tensorflow's thread setters:"
-                    "`tf.config.threading.set_inter_op_parallelism_threads`"
-                    "or `tf.config.threading.set_intra_op_parallelism_threads`"
+                    "backend. Please use tensorflow's thread setters: "
+                    "`tf.config.threading.set_inter_op_parallelism_threads` "
+                    "or `tf.config.threading.set_intra_op_parallelism_threads` "
                     "to switch the number of threads.")
         abstract.AbstractBackend.set_threads(self, nthreads)
 

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -49,6 +49,14 @@ class TensorflowBackend(numpy.NumpyBackend):
     def set_device(self, name):
         abstract.AbstractBackend.set_device(self, name)
 
+    def set_threads(self, nthreads):
+        log.warning("`set_threads` is not supported by the tensorflow "
+                    "backend. Please use tensorflow's thread setters:"
+                    "`tf.config.threading.set_inter_op_parallelism_threads`"
+                    "or `tf.config.threading.set_intra_op_parallelism_threads`"
+                    "to switch the number of threads.")
+        abstract.AbstractBackend.set_threads(self, nthreads)
+
     def to_numpy(self, x):
         if isinstance(x, self.np.ndarray):
             return x
@@ -215,6 +223,9 @@ class TensorflowCustomBackend(TensorflowBackend):
         import os
         if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
             self.set_threads(int(os.environ.get("OMP_NUM_THREADS")))
+
+    def set_threads(self, nthreads):
+        abstract.AbstractBackend.set_threads(self, nthreads)
 
     def initial_state(self, nqubits, is_matrix=False):
         return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -103,6 +103,16 @@ def test_set_device(backend, caplog):
         bk.set_device(device)
 
 
+def test_set_threads(backend, caplog):
+    original_threads = backends.get_threads()
+    bkname = backends.get_backend()
+    backends.set_threads(1)
+    if bkname == "numpy" or bkname == "tensorflow":
+        assert "WARNING" in caplog.text
+    assert backends.get_threads() == 1
+    backends.set_threads(original_threads)
+
+
 def test_set_shot_batch_size():
     import qibo
     assert qibo.get_batch_size() == 2 ** 18


### PR DESCRIPTION
Fixes #442 by:
* Modifying `qibo.set_threads` to update the number threads only for the currently active backend.
* Raising warnings when using `qibo.set_threads` with the numpy or tensorflow backends which do not support this kind of thread setting.