### PR TITLE
Fix gate.matrix property

### DIFF
--- a/src/qibo/abstractions/abstract_gates.py
+++ b/src/qibo/abstractions/abstract_gates.py
@@ -405,7 +405,8 @@ class ParametrizedGate(Gate):
         # pylint: disable=E1101
         if isinstance(self, BaseBackendGate):
             self._matrix = None
-            self._internal_matrix = None
+            self._native_op_matrix = None
+            self._custom_op_matrix = None
             for devgate in self.device_gates:
                 devgate.parameters = x
 

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -272,7 +272,7 @@ class TensorflowCustomBackend(TensorflowBackend):
                             *gate.target_qubits, self.nthreads)
 
     def state_vector_matrix_call(self, gate, state):
-        return gate.gate_op(state, gate.internal_matrix, gate.cache.qubits_tensor, # pylint: disable=E1121
+        return gate.gate_op(state, gate.custom_op_matrix, gate.cache.qubits_tensor, # pylint: disable=E1121
                             gate.nqubits, *gate.target_qubits,
                             self.nthreads)
 
@@ -285,10 +285,10 @@ class TensorflowCustomBackend(TensorflowBackend):
         return state
 
     def density_matrix_matrix_call(self, gate, state):
-        state = gate.gate_op(state, gate.internal_matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
+        state = gate.gate_op(state, gate.custom_op_matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
                              2 * gate.nqubits, *gate.target_qubits,
                              self.nthreads)
-        adjmatrix = self.conj(gate.internal_matrix)
+        adjmatrix = self.conj(gate.custom_op_matrix)
         state = gate.gate_op(state, adjmatrix, gate.cache.qubits_tensor,
                              2 * gate.nqubits, *gate.cache.target_qubits_dm,
                              self.nthreads)
@@ -300,7 +300,7 @@ class TensorflowCustomBackend(TensorflowBackend):
                             self.nthreads)
 
     def density_matrix_half_matrix_call(self, gate, state):
-        return gate.gate_op(state, gate.internal_matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
+        return gate.gate_op(state, gate.custom_op_matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
                             2 * gate.nqubits, *gate.target_qubits,
                             self.nthreads)
 

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -272,7 +272,7 @@ class TensorflowCustomBackend(TensorflowBackend):
                             *gate.target_qubits, self.nthreads)
 
     def state_vector_matrix_call(self, gate, state):
-        return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor, # pylint: disable=E1121
+        return gate.gate_op(state, gate.internal_matrix, gate.cache.qubits_tensor, # pylint: disable=E1121
                             gate.nqubits, *gate.target_qubits,
                             self.nthreads)
 
@@ -285,10 +285,10 @@ class TensorflowCustomBackend(TensorflowBackend):
         return state
 
     def density_matrix_matrix_call(self, gate, state):
-        state = gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
+        state = gate.gate_op(state, gate.internal_matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
                              2 * gate.nqubits, *gate.target_qubits,
                              self.nthreads)
-        adjmatrix = self.conj(gate.matrix)
+        adjmatrix = self.conj(gate.internal_matrix)
         state = gate.gate_op(state, adjmatrix, gate.cache.qubits_tensor,
                              2 * gate.nqubits, *gate.cache.target_qubits_dm,
                              self.nthreads)
@@ -300,7 +300,7 @@ class TensorflowCustomBackend(TensorflowBackend):
                             self.nthreads)
 
     def density_matrix_half_matrix_call(self, gate, state):
-        return gate.gate_op(state, gate.matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
+        return gate.gate_op(state, gate.internal_matrix, gate.cache.qubits_tensor + gate.nqubits, # pylint: disable=E1121
                             2 * gate.nqubits, *gate.target_qubits,
                             self.nthreads)
 

--- a/src/qibo/tests/test_core_gates_features.py
+++ b/src/qibo/tests/test_core_gates_features.py
@@ -52,6 +52,7 @@ def test_construct_unitary_rotations(backend, gate, target_matrix):
     else:
         gate = getattr(gates, gate)(0, theta)
     K.assert_allclose(gate.unitary, target_matrix(theta))
+    K.assert_allclose(gate.matrix, target_matrix(theta))
 
 
 def test_construct_unitary_controlled(backend):


### PR DESCRIPTION
Fixes #444 by making the `.matrix` property to return the matrix representation of gates in the computational basis. @igres26 you can try now for the U1 and you should get the correct matrix with both `.matrix` and `.unitary`.

The backends now use different matrix properties which should not be used by the user. These are `native_op_matrix` for numpy/tensorflow backends and `custom_op_matrix` for qibojit/qibotf backends.