### PR TITLE
replacing unitary with matrix

### DIFF
--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -409,36 +409,39 @@ fSim with general rotation
     :member-order: bysource
 
 
+Special gates
+^^^^^^^^^^^^^
+
 Toffoli
-^^^^^^^
+"""""""
 
 .. autoclass:: qibo.abstractions.gates.TOFFOLI
     :members:
     :member-order: bysource
 
 Arbitrary unitary
-^^^^^^^^^^^^^^^^^
+"""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.Unitary
     :members:
     :member-order: bysource
 
 Variational layer
-^^^^^^^^^^^^^^^^^
+"""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.VariationalLayer
     :members:
     :member-order: bysource
 
 Flatten
-^^^^^^^
+"""""""
 
 .. autoclass:: qibo.abstractions.gates.Flatten
     :members:
     :member-order: bysource
 
 Callback gate
-^^^^^^^^^^^^^
+"""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CallbackGate
     :members:

--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -9,7 +9,6 @@ The Qibo package comes with the following modules:
 * Gates_
 * Hamiltonians_
 * Callbacks_
-* Solvers_
 * Optimizers_
 * Parallel_
 * Backends_
@@ -218,173 +217,197 @@ the gate on an arbitrary number of qubits. For example
 * ``gates.RY(0, np.pi).controlled_by(1, 2, 3)`` applies the Y-rotation to qubit 0 when qubits 1, 2 and 3 are in the |111> state.
 * ``gates.SWAP(0, 1).controlled_by(3, 4)`` swaps qubits 0 and 1 when qubits 3 and 4 are in the |11> state.
 
+Gate models
+^^^^^^^^^^^
+
+Abstract gates
+""""""""""""""
+
+.. autoclass:: qibo.abstractions.gates.Gate
+    :members:
+    :member-order: bysource
+
+Abstract backend gates
+""""""""""""""""""""""
+
+.. autoclass:: qibo.abstractions.abstract_gates.BaseBackendGate
+    :members:
+    :member-order: bysource
+
+Single qubit gates
+^^^^^^^^^^^^^^^^^^
+
 Hadamard (H)
-^^^^^^^^^^^^
+""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.H
    :members:
    :member-order: bysource
 
 Pauli X (X)
-^^^^^^^^^^^
+"""""""""""
 
 .. autoclass:: qibo.abstractions.gates.X
    :members:
    :member-order: bysource
 
 Pauli Y (Y)
-^^^^^^^^^^^
+"""""""""""
 
 .. autoclass:: qibo.abstractions.gates.Y
     :members:
     :member-order: bysource
 
 Pauli Z (Z)
-^^^^^^^^^^^
+"""""""""""
 
 .. autoclass:: qibo.abstractions.gates.Z
     :members:
     :member-order: bysource
 
 Identity (I)
-^^^^^^^^^^^^
+""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.I
     :members:
     :member-order: bysource
 
 Measurement (M)
-^^^^^^^^^^^^^^^
+"""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.M
     :members:
     :member-order: bysource
 
 Rotation X-axis (RX)
-^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.RX
     :members:
     :member-order: bysource
 
 Rotation Y-axis (RY)
-^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.RY
     :members:
     :member-order: bysource
 
 Rotation Z-axis (RZ)
-^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.RZ
     :members:
     :member-order: bysource
 
 First general unitary (U1)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.U1
     :members:
     :member-order: bysource
 
 Second general unitary (U2)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.U2
     :members:
     :member-order: bysource
 
 Third general unitary (U3)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.U3
     :members:
     :member-order: bysource
 
+Two qubit gates
+^^^^^^^^^^^^^^^
+
 Controlled-NOT (CNOT)
-^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CNOT
     :members:
     :member-order: bysource
 
 Controlled-phase (CZ)
-^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CZ
     :members:
     :member-order: bysource
 
 Controlled-rotation X-axis (CRX)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CRX
     :members:
     :member-order: bysource
 
 Controlled-rotation Y-axis (CRY)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CRY
     :members:
     :member-order: bysource
 
 Controlled-rotation Z-axis (CRZ)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CRZ
     :members:
     :member-order: bysource
 
 Controlled first general unitary (CU1)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CU1
     :members:
     :member-order: bysource
 
 Controlled second general unitary (CU2)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CU2
     :members:
     :member-order: bysource
 
 Controlled third general unitary (CU3)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CU3
     :members:
     :member-order: bysource
 
 Controlled third general unitary (CU3)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.CU3
     :members:
     :member-order: bysource
 
 Swap (SWAP)
-^^^^^^^^^^^
+"""""""""""
 
 .. autoclass:: qibo.abstractions.gates.SWAP
     :members:
     :member-order: bysource
 
 fSim
-^^^^
+""""
 
 .. autoclass:: qibo.abstractions.gates.fSim
     :members:
     :member-order: bysource
 
 fSim with general rotation
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""
 
 .. autoclass:: qibo.abstractions.gates.GeneralizedfSim
     :members:
     :member-order: bysource
+
 
 Toffoli
 ^^^^^^^

--- a/src/qibo/abstractions/abstract_gates.py
+++ b/src/qibo/abstractions/abstract_gates.py
@@ -450,7 +450,7 @@ class BaseBackendGate(Gate, ABC):
         self.original_gate = None
 
     @property
-    def unitary(self):
+    def matrix(self):
         """Unitary matrix representing the gate in the computational basis."""
         if len(self.qubits) > 2:
             raise_error(NotImplementedError, "Cannot calculate unitary matrix for "
@@ -460,11 +460,6 @@ class BaseBackendGate(Gate, ABC):
         if self.is_controlled_by and tuple(self._matrix.shape) == (2, 2):
             self._matrix = self.control_unitary(self._matrix)
         return self._matrix
-
-    @property
-    def matrix(self):
-        """Unitary matrix representing the gate in the computational basis."""
-        return self.unitary
 
     def __matmul__(self, other: "Gate") -> "Gate":
         """Gate multiplication."""
@@ -476,7 +471,7 @@ class BaseBackendGate(Gate, ABC):
             if self.__class__.__name__ in square_identity:
                 from qibo.gates import I
                 return I(*self.qubits)
-        return self.module.Unitary(self.unitary @ other.unitary, *self.qubits)
+        return self.module.Unitary(self.matrix @ other.matrix, *self.qubits)
 
     def __rmatmul__(self, other): # pragma: no cover
         # always falls back to left ``__matmul__``

--- a/src/qibo/abstractions/callbacks.py
+++ b/src/qibo/abstractions/callbacks.py
@@ -6,7 +6,7 @@ class Callback:
     """Base callback class.
 
     Callbacks should inherit this class and implement its
-    `state_vector_call` and `density_matrix_call` methods.
+    `_state_vector_call` and `_density_matrix_call` methods.
 
     Results of a callback can be accessed by indexing the corresponding object.
     """
@@ -15,7 +15,7 @@ class Callback:
         self._results = []
         self._nqubits = None
         self._density_matrix = False
-        self._active_call = "state_vector_call"
+        self._active_call = "_state_vector_call"
 
     @property
     def nqubits(self): # pragma: no cover
@@ -36,9 +36,9 @@ class Callback:
     def density_matrix(self, x):
         self._density_matrix = x
         if x:
-            self._active_call = "density_matrix_call"
+            self._active_call = "_density_matrix_call"
         else:
-            self._active_call = "state_vector_call"
+            self._active_call = "_state_vector_call"
 
     @property
     def results(self):

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -403,7 +403,7 @@ class AbstractCircuit(ABC):
         elif isinstance(gate, gates.VariationalLayer):
             self._add_layer(gate)
         else:
-            self.set_nqubits(gate)
+            self._set_nqubits(gate)
             self.queue.append(gate)
             if isinstance(gate, gates.M):
                 self.repeated_execution = True
@@ -415,7 +415,7 @@ class AbstractCircuit(ABC):
             if gate.trainable:
                 self.trainable_gates.append(gate)
 
-    def set_nqubits(self, gate: gates.Gate):
+    def _set_nqubits(self, gate: gates.Gate):
         """Sets the number of qubits and prepares all gates.
 
         Helper method for ``circuit.add(gate)``.

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -435,7 +435,7 @@ class AbstractBackend(ABC):
         raise_error(NotImplementedError)
 
     @abstractmethod
-    def state_vector_call(self, gate, state): # pragma: no cover
+    def _state_vector_call(self, gate, state): # pragma: no cover
         """Applies gate to state vector.
 
         Args:
@@ -468,7 +468,7 @@ class AbstractBackend(ABC):
         raise_error(NotImplementedError)
 
     @abstractmethod
-    def density_matrix_call(self, gate, state): # pragma: no cover
+    def _density_matrix_call(self, gate, state): # pragma: no cover
         """Applies gate to density matrix.
 
         Args:
@@ -501,7 +501,7 @@ class AbstractBackend(ABC):
         raise_error(NotImplementedError)
 
     @abstractmethod
-    def density_matrix_half_call(self, gate, state): # pragma: no cover
+    def _density_matrix_half_call(self, gate, state): # pragma: no cover
         """Half gate application to density matrix."""
         raise_error(NotImplementedError)
 

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -283,7 +283,7 @@ class NumpyBackend(abstract.AbstractBackend):
         rank = int(math.log2(int(matrix.shape[0])))
         return self.reshape(matrix, 2 * rank * (2,))
 
-    def state_vector_call(self, gate, state):
+    def _state_vector_call(self, gate, state):
         state = self.reshape(state, gate.cache.tensor_shape)
         matrix = self.reshape_matrix(gate.native_op_matrix)
         if gate.is_controlled_by:
@@ -306,9 +306,9 @@ class NumpyBackend(abstract.AbstractBackend):
         return self.reshape(state, gate.cache.flat_shape)
 
     def state_vector_matrix_call(self, gate, state):
-        return self.state_vector_call(gate, state)
+        return self._state_vector_call(gate, state)
 
-    def density_matrix_call(self, gate, state):
+    def _density_matrix_call(self, gate, state):
         state = self.reshape(state, gate.cache.tensor_shape)
         matrix = self.reshape_matrix(gate.native_op_matrix)
         matrixc = self.conj(matrix)
@@ -344,9 +344,9 @@ class NumpyBackend(abstract.AbstractBackend):
         return self.reshape(state, gate.cache.flat_shape)
 
     def density_matrix_matrix_call(self, gate, state):
-        return self.density_matrix_call(gate, state)
+        return self._density_matrix_call(gate, state)
 
-    def density_matrix_half_call(self, gate, state):
+    def _density_matrix_half_call(self, gate, state):
         if gate.is_controlled_by: # pragma: no cover
             raise_error(NotImplementedError, "Gate density matrix half call is "
                                              "not implemented for ``controlled_by``"
@@ -357,7 +357,7 @@ class NumpyBackend(abstract.AbstractBackend):
         return self.reshape(state, gate.cache.flat_shape)
 
     def density_matrix_half_matrix_call(self, gate, state):
-        return self.density_matrix_half_call(gate, state)
+        return self._density_matrix_half_call(gate, state)
 
     def _append_zeros(self, state, qubits, results):
         """Helper method for `state_vector_collapse` and `density_matrix_collapse`."""
@@ -565,7 +565,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
             cache.target_qubits_dm = [q + gate.nqubits for q in gate.target_qubits]
         return cache
 
-    def state_vector_call(self, gate, state):
+    def _state_vector_call(self, gate, state):
         return gate.gate_op(state, gate.nqubits, *gate.target_qubits,
                             gate.cache.qubits_tensor)
 
@@ -573,7 +573,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
         return gate.gate_op(state, gate.custom_op_matrix, gate.nqubits, *gate.target_qubits,
                             gate.cache.qubits_tensor)
 
-    def density_matrix_call(self, gate, state):
+    def _density_matrix_call(self, gate, state):
         qubits = tuple(x + gate.nqubits for x in gate.cache.qubits_tensor)
         shape = state.shape
         state = gate.gate_op(state.flatten(), 2 * gate.nqubits,
@@ -592,7 +592,7 @@ class JITCustomBackend(NumpyBackend): # pragma: no cover
                              gate.cache.qubits_tensor)
         return self.reshape(state, shape)
 
-    def density_matrix_half_call(self, gate, state):
+    def _density_matrix_half_call(self, gate, state):
         qubits = tuple(x + gate.nqubits for x in gate.cache.qubits_tensor)
         shape = state.shape
         state = gate.gate_op(state.flatten(), 2 * gate.nqubits,

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -267,7 +267,7 @@ class TensorflowCustomBackend(TensorflowBackend):
             cache.target_qubits_dm = [q + gate.nqubits for q in gate.target_qubits]
         return cache
 
-    def state_vector_call(self, gate, state):
+    def _state_vector_call(self, gate, state):
         return gate.gate_op(state, gate.cache.qubits_tensor, gate.nqubits,
                             *gate.target_qubits, self.nthreads)
 
@@ -276,7 +276,7 @@ class TensorflowCustomBackend(TensorflowBackend):
                             gate.nqubits, *gate.target_qubits,
                             self.nthreads)
 
-    def density_matrix_call(self, gate, state):
+    def _density_matrix_call(self, gate, state):
         state = gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
                              2 * gate.nqubits, *gate.target_qubits,
                              self.nthreads)
@@ -294,7 +294,7 @@ class TensorflowCustomBackend(TensorflowBackend):
                              self.nthreads)
         return state
 
-    def density_matrix_half_call(self, gate, state):
+    def _density_matrix_half_call(self, gate, state):
         return gate.gate_op(state, gate.cache.qubits_tensor + gate.nqubits,
                             2 * gate.nqubits, *gate.target_qubits,
                             self.nthreads)

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -31,7 +31,7 @@ class Circuit(circuit.AbstractCircuit):
         self._compiled_execute = None
         self.state_cls = states.VectorState
 
-    def set_nqubits(self, gate):
+    def _set_nqubits(self, gate):
         if gate._nqubits is not None and gate.nqubits != self.nqubits:
             raise_error(RuntimeError, "Cannot add gate {} that acts on {} "
                                       "qubits to circuit that contains {}"
@@ -41,10 +41,10 @@ class Circuit(circuit.AbstractCircuit):
 
     def _add_layer(self, gate):
         for unitary in gate.unitaries:
-            self.set_nqubits(unitary)
+            self._set_nqubits(unitary)
             self.queue.append(unitary)
         if gate.additional_unitary is not None:
-            self.set_nqubits(gate.additional_unitary)
+            self._set_nqubits(gate.additional_unitary)
             self.queue.append(gate.additional_unitary)
 
     def _fuse_copy(self):

--- a/src/qibo/core/distcircuit.py
+++ b/src/qibo/core/distcircuit.py
@@ -65,8 +65,8 @@ class DistributedCircuit(circuit.Circuit):
         self.calc_devices = accelerators
         self.queues = DistributedQueues(self, gate_module)
 
-    def set_nqubits(self, gate):
-        AbstractCircuit.set_nqubits(self, gate)
+    def _set_nqubits(self, gate):
+        AbstractCircuit._set_nqubits(self, gate)
 
     def on_qubits(self, *q):
         if self.queues.queues:

--- a/src/qibo/core/distutils.py
+++ b/src/qibo/core/distutils.py
@@ -155,7 +155,7 @@ class DistributedQueues:
         new_control_qubits = tuple(q - self.qubits.reduction_number(q)
                                    for q in devgate.control_qubits
                                    if q not in self.qubits.set)
-        devgate.set_targets_and_controls(new_target_qubits, new_control_qubits)
+        devgate._set_targets_and_controls(new_target_qubits, new_control_qubits)
         devgate.original_gate = gate
         devgate.device_gates = set()
         return devgate
@@ -234,7 +234,7 @@ class DistributedQueues:
                                        for q in gate.target_qubits)
             new_control_qubits = tuple(qubit_map[q] if q in qubit_map else q
                                         for q in gate.control_qubits)
-            gate.set_targets_and_controls(new_target_qubits, new_control_qubits)
+            gate._set_targets_and_controls(new_target_qubits, new_control_qubits)
 
         return self._transform(queue, new_remaining_queue, counter)
 

--- a/src/qibo/core/fusion.py
+++ b/src/qibo/core/fusion.py
@@ -259,9 +259,9 @@ class FusionGroup:
             gate matrices.
         """
         if K.op is not None:
-            return self.K.kron(gate0.unitary, gate1.unitary)
+            return self.K.kron(gate0.matrix, gate1.matrix)
         else:
-            matrix = self.K.tensordot(gate0.unitary, gate1.unitary, axes=0)
+            matrix = self.K.tensordot(gate0.matrix, gate1.matrix, axes=0)
             matrix = self.K.transpose(matrix, [0, 2, 1, 3])
             return self.K.reshape(matrix, (4, 4))
 
@@ -274,7 +274,7 @@ class FusionGroup:
         Returns:
             4x4 unitary matrix corresponding to the gate.
         """
-        matrix = gate.unitary
+        matrix = gate.matrix
         if gate.qubits == (self.qubit1, self.qubit0):
             matrix = self.K.reshape(matrix, 4 * (2,))
             matrix = self.K.transpose(matrix, [1, 0, 3, 2])

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -32,12 +32,12 @@ class BackendGate(BaseBackendGate):
         self._custom_op_matrix = None
 
     @staticmethod
-    def control_unitary(unitary):
+    def _control_unitary(unitary):
         shape = tuple(unitary.shape)
         if not isinstance(unitary, K.Tensor):
             unitary = K.cast(unitary)
         if shape != (2, 2):
-            raise_error(ValueError, "Cannot use ``control_unitary`` method for "
+            raise_error(ValueError, "Cannot use ``_control_unitary`` method for "
                                     "input matrix of shape {}.".format(shape))
         zeros = K.zeros((2, 2), dtype='DTYPECPX')
         part1 = K.concatenate([K.eye(2, dtype='DTYPECPX'), zeros], axis=0)
@@ -53,41 +53,41 @@ class BackendGate(BaseBackendGate):
     @property
     def native_op_matrix(self):
         if self._native_op_matrix is None:
-            self._native_op_matrix = self.construct_unitary()
+            self._native_op_matrix = self._construct_unitary()
         return self._native_op_matrix
 
     @property
     def custom_op_matrix(self):
         if self._custom_op_matrix is None:
-            self._custom_op_matrix = self.construct_unitary()
+            self._custom_op_matrix = self._construct_unitary()
         return self._custom_op_matrix
 
-    def set_nqubits(self, state):
+    def _set_nqubits(self, state):
         if self._nqubits is None:
             self.nqubits = int(math.log2(tuple(state.shape)[0]))
 
-    def state_vector_call(self, state):
-        return K.state_vector_call(self, state)
+    def _state_vector_call(self, state):
+        return K._state_vector_call(self, state)
 
-    def density_matrix_call(self, state):
-        return K.density_matrix_call(self, state)
+    def _density_matrix_call(self, state):
+        return K._density_matrix_call(self, state)
 
-    def density_matrix_half_call(self, state):
-        self.set_nqubits(state)
-        return K.density_matrix_half_call(self, state)
+    def _density_matrix_half_call(self, state):
+        self._set_nqubits(state)
+        return K._density_matrix_half_call(self, state)
 
 
 class MatrixGate(BackendGate):
     """Gate that uses matrix multiplication to be applied to states."""
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         return K.state_vector_matrix_call(self, state)
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         return K.density_matrix_matrix_call(self, state)
 
-    def density_matrix_half_call(self, state):
-        self.set_nqubits(state)
+    def _density_matrix_half_call(self, state):
+        self._set_nqubits(state)
         return K.density_matrix_half_matrix_call(self, state)
 
 
@@ -97,7 +97,7 @@ class H(MatrixGate, abstract_gates.H):
         MatrixGate.__init__(self)
         abstract_gates.H.__init__(self, q)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.H
 
 
@@ -109,7 +109,7 @@ class X(BackendGate, abstract_gates.X):
         if self.gate_op:
             self.gate_op = K.op.apply_x
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.X
 
 
@@ -120,13 +120,13 @@ class Y(BackendGate, abstract_gates.Y):
         abstract_gates.Y.__init__(self, q)
         if self.gate_op:
             self.gate_op = K.op.apply_y
-            self.density_matrix_call = lambda state: self._custom_density_matrix_call(state)
+            self._density_matrix_call = lambda state: self._custom_density_matrix_call(state)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.Y
 
     def _custom_density_matrix_call(self, state):
-        state = K.density_matrix_half_call(self, state)
+        state = K._density_matrix_half_call(self, state)
         matrix = K.conj(K.matrices.Y)
         shape = state.shape
         state = K.reshape(state, (K.np.prod(shape),))
@@ -151,7 +151,7 @@ class Z(BackendGate, abstract_gates.Z):
         if self.gate_op:
             self.gate_op = K.op.apply_z
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.Z
 
 
@@ -161,13 +161,13 @@ class I(BackendGate, abstract_gates.I):
         BackendGate.__init__(self)
         abstract_gates.I.__init__(self, *q)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.eye(2 ** len(self.target_qubits))
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         return state
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         return state
 
 
@@ -177,13 +177,13 @@ class Align(BackendGate, abstract_gates.Align):
         BackendGate.__init__(self)
         abstract_gates.Align.__init__(self, *q)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.eye(2 ** len(self.target_qubits))
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         return state
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         return state
 
 
@@ -239,7 +239,7 @@ class M(BackendGate, abstract_gates.M):
             self._cache = cache
         return self._cache
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         raise_error(ValueError, "Measurement gate does not have unitary "
                                 "representation.")
 
@@ -258,13 +258,13 @@ class M(BackendGate, abstract_gates.M):
 
     def measure(self, state, nshots):
         if isinstance(state, K.tensor_types):
-            self.set_nqubits(state)
+            self._set_nqubits(state)
             if self.density_matrix:
                 state = self.states.MatrixState.from_tensor(state)
             else:
                 state = self.states.VectorState.from_tensor(state)
         elif isinstance(state, self.states.AbstractState):
-            self.set_nqubits(state.tensor)
+            self._set_nqubits(state.tensor)
         else:
             raise_error(TypeError, "Measurement gate called on state of type "
                                    "{} that is not supported."
@@ -289,10 +289,10 @@ class M(BackendGate, abstract_gates.M):
             result = result.apply_bitflips(*self.bitflip_map)
         return result
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         return K.state_vector_collapse(self, state, self.result.binary[-1])
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         return K.density_matrix_collapse(self, state, self.result_list())
 
     def __call__(self, state, nshots=1):
@@ -311,7 +311,7 @@ class RX(MatrixGate, abstract_gates.RX):
         MatrixGate.__init__(self)
         abstract_gates.RX.__init__(self, q, theta, trainable)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         theta = self.parameters
         if isinstance(theta, K.native_types): # pragma: no cover
             p = K
@@ -328,7 +328,7 @@ class RY(MatrixGate, abstract_gates.RY):
         MatrixGate.__init__(self)
         abstract_gates.RY.__init__(self, q, theta, trainable)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         theta = self.parameters
         if isinstance(theta, K.native_types):
             p = K
@@ -345,7 +345,7 @@ class RZ(MatrixGate, abstract_gates.RZ):
         MatrixGate.__init__(self)
         abstract_gates.RZ.__init__(self, q, theta, trainable)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         if isinstance(self.parameters, K.native_types): # pragma: no cover
             p = K
             theta = K.cast(self.parameters)
@@ -370,7 +370,7 @@ class U1(MatrixGate, abstract_gates.U1):
             self._custom_op_matrix = K.cast(K.qnp.exp(1j * self.parameters))
         return self._custom_op_matrix
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         if isinstance(self.parameters, K.native_types): # pragma: no cover
             p = K
             theta = K.cast(self.parameters)
@@ -386,7 +386,7 @@ class U2(MatrixGate, abstract_gates.U2):
         MatrixGate.__init__(self)
         abstract_gates.U2.__init__(self, q, phi, lam, trainable)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         phi, lam = self.parameters
         if isinstance(phi, K.native_types) or isinstance(lam, K.native_types): # pragma: no cover
             p = K
@@ -404,7 +404,7 @@ class U3(MatrixGate, abstract_gates.U3):
         MatrixGate.__init__(self)
         abstract_gates.U3.__init__(self, q, theta, phi, lam, trainable)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         theta, phi, lam = self.parameters
         if isinstance(theta, K.native_types) or isinstance(phi, K.native_types) or isinstance(lam, K.native_types): # pragma: no cover
             p = K
@@ -424,7 +424,7 @@ class CNOT(BackendGate, abstract_gates.CNOT):
         if self.gate_op:
             self.gate_op = K.op.apply_x
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.CNOT
 
 
@@ -436,7 +436,7 @@ class CZ(BackendGate, abstract_gates.CZ):
         if self.gate_op:
             self.gate_op = K.op.apply_z
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.CZ
 
 
@@ -448,13 +448,13 @@ class _CUn_(MatrixGate):
         cbase = "C{}".format(self.base.__name__)
         getattr(abstract_gates, cbase).__init__(self, q0, q1, **params)
 
-    def construct_unitary(self):
-        return MatrixGate.control_unitary(self.base.construct_unitary(self))
+    def _construct_unitary(self):
+        return MatrixGate._control_unitary(self.base._construct_unitary(self))
 
     @property
     def custom_op_matrix(self):
         if self._custom_op_matrix is None:
-            self._custom_op_matrix = self.base.construct_unitary(self)
+            self._custom_op_matrix = self.base._construct_unitary(self)
         return self._custom_op_matrix
 
 
@@ -517,7 +517,7 @@ class SWAP(BackendGate, abstract_gates.SWAP):
         if self.gate_op:
             self.gate_op = K.op.apply_swap
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.SWAP
 
 
@@ -538,7 +538,7 @@ class fSim(MatrixGate, abstract_gates.fSim):
             self._custom_op_matrix = K.cast([cos, isin, isin, cos, phase])
         return self._custom_op_matrix
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         theta, phi = self.parameters
         if isinstance(theta, K.native_types) or isinstance(phi, K.native_types): # pragma: no cover
             p = K
@@ -570,7 +570,7 @@ class GeneralizedfSim(MatrixGate, abstract_gates.GeneralizedfSim):
             self._custom_op_matrix = K.cast(matrix)
         return self._custom_op_matrix
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         unitary, phi = self.parameters
         if isinstance(unitary, K.native_types) or isinstance(phi, K.native_types): # pragma: no cover
             p = K
@@ -599,13 +599,13 @@ class TOFFOLI(BackendGate, abstract_gates.TOFFOLI):
         if self.gate_op:
             self.gate_op = K.op.apply_x
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return K.matrices.TOFFOLI
 
     @property
     def matrix(self):
         if self._matrix is None:
-            self._matrix = self.construct_unitary()
+            self._matrix = self._construct_unitary()
         return self._matrix
 
 
@@ -632,7 +632,7 @@ class Unitary(MatrixGate, abstract_gates.Unitary):
                                                  "different backend to execute "
                                                  "this operation.".format(n))
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         return self.parameters
 
     def _dagger(self) -> "Unitary":
@@ -731,19 +731,19 @@ class VariationalLayer(BackendGate, abstract_gates.VariationalLayer):
             varlayer.additional_unitary = self.additional_unitary.dagger()
         return varlayer
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         raise_error(ValueError, "VariationalLayer gate does not have unitary "
                                 "representation.")
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         for i, unitary in enumerate(self.unitaries):
             state = unitary(state)
         if self.additional_unitary is not None:
             state = self.additional_unitary(state)
         return state
 
-    def density_matrix_call(self, state):
-        return self.state_vector_call(state)
+    def _density_matrix_call(self, state):
+        return self._state_vector_call(state)
 
 
 class Flatten(BackendGate, abstract_gates.Flatten):
@@ -753,17 +753,17 @@ class Flatten(BackendGate, abstract_gates.Flatten):
         abstract_gates.Flatten.__init__(self, coefficients)
         self.swap_reset = []
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         raise_error(ValueError, "Flatten gate does not have unitary "
                                  "representation.")
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         shape = tuple(state.shape)
         _state = K.qnp.reshape(K.qnp.cast(self.coefficients), shape)
         return K.cast(_state, dtype="DTYPECPX")
 
-    def density_matrix_call(self, state):
-        return self.state_vector_call(state)
+    def _density_matrix_call(self, state):
+        return self._state_vector_call(state)
 
 
 class CallbackGate(BackendGate, abstract_gates.CallbackGate):
@@ -778,16 +778,16 @@ class CallbackGate(BackendGate, abstract_gates.CallbackGate):
         BaseBackendGate.density_matrix.fset(self, x) # pylint: disable=no-member
         self.callback.density_matrix = x
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         raise_error(ValueError, "Callback gate does not have unitary "
                                 "representation.")
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         self.callback.append(self.callback(state))
         return state
 
-    def density_matrix_call(self, state):
-        return self.state_vector_call(state)
+    def _density_matrix_call(self, state):
+        return self._state_vector_call(state)
 
 
 class PartialTrace(BackendGate, abstract_gates.PartialTrace):
@@ -829,30 +829,30 @@ class PartialTrace(BackendGate, abstract_gates.PartialTrace):
             self._cache = cache
         return self._cache
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         raise_error(ValueError, "Partial trace gate does not have unitary "
                                 "representation.")
 
     def state_vector_partial_trace(self, state):
-        self.set_nqubits(state)
+        self._set_nqubits(state)
         state = K.reshape(state, self.nqubits * (2,))
         axes = 2 * [list(self.target_qubits)]
         rho = K.tensordot(state, K.conj(state), axes=axes)
         return K.reshape(rho, self.cache.reduced_shape)
 
     def density_matrix_partial_trace(self, state):
-        self.set_nqubits(state)
+        self._set_nqubits(state)
         state = K.reshape(state, 2 * self.nqubits * (2,))
         state = K.transpose(state, self.cache.einsum_order)
         state = K.reshape(state, self.cache.einsum_shape)
         return K.einsum("abac->bc", state)
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         raise_error(RuntimeError, "Partial trace gate cannot be used on state "
                                   "vectors. Please switch to density matrix "
                                   "simulation.")
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         substate = self.density_matrix_partial_trace(state)
         n = self.nqubits - len(self.target_qubits)
         substate = K.reshape(substate, 2 * n * (2,))
@@ -877,14 +877,14 @@ class KrausChannel(BackendGate, abstract_gates.KrausChannel):
         inv_gates.append(None)
         return tuple(inv_gates)
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         raise_error(ValueError, "Channels do not have unitary representation.")
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         raise_error(ValueError, "`KrausChannel` cannot be applied to state "
                                 "vectors. Please switch to density matrices.")
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         new_state = K.zeros_like(state)
         for gate, inv_gate in zip(self.gates, self.inverse_gates):
             new_state += gate(state)
@@ -909,13 +909,13 @@ class UnitaryChannel(KrausChannel, abstract_gates.UnitaryChannel):
         if self.seed is not None:
             K.qnp.random.seed(self.seed)
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         for p, gate in zip(self.probs, self.gates):
             if K.qnp.random.random() < p:
                 state = gate(state)
         return state
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         new_state = (1 - self.psum) * state
         for p, gate, inv_gate in zip(self.probs, self.gates, self.inverse_gates):
             state = gate(state)
@@ -950,7 +950,7 @@ class ResetChannel(UnitaryChannel, abstract_gates.ResetChannel):
                           for gate in self.gates[:-1])
         return inv_gates + (None,)
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         not_collapsed = True
         if K.qnp.random.random() < self.probs[-2]:
             state = K.state_vector_collapse(self.gates[-2], state, [0])
@@ -961,7 +961,7 @@ class ResetChannel(UnitaryChannel, abstract_gates.ResetChannel):
             state = self.gates[-1](state)
         return state
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         new_state = (1 - self.psum) * state
         for p, gate, inv_gate in zip(self.probs, self.gates, self.inverse_gates):
             if isinstance(gate, M):
@@ -1011,10 +1011,10 @@ class _ThermalRelaxationChannelA(ResetChannel, abstract_gates._ThermalRelaxation
             seed=seed)
         self.set_seed()
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         if K.qnp.random.random() < self.probs[0]:
             state = self.gates[0](state)
-        return ResetChannel.state_vector_call(self, state)
+        return ResetChannel._state_vector_call(self, state)
 
 
 class _ThermalRelaxationChannelB(MatrixGate, abstract_gates._ThermalRelaxationChannelB):
@@ -1049,18 +1049,18 @@ class _ThermalRelaxationChannelB(MatrixGate, abstract_gates._ThermalRelaxationCh
 
         return self._cache
 
-    def construct_unitary(self):
+    def _construct_unitary(self):
         matrix = K.qnp.diag([1 - self.preset1, self.exp_t2, self.exp_t2,
                              1 - self.preset0])
         matrix[0, -1] = self.preset1
         matrix[-1, 0] = self.preset0
         return K.cast(matrix)
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         raise_error(ValueError, "Thermal relaxation cannot be applied to "
                                 "state vectors when T1 < T2.")
 
-    def density_matrix_call(self, state):
+    def _density_matrix_call(self, state):
         if K.op is not None:
             shape = state.shape
             state = K.reshape(state, (K.np.prod(shape),))
@@ -1071,4 +1071,4 @@ class _ThermalRelaxationChannelB(MatrixGate, abstract_gates._ThermalRelaxationCh
             self._nqubits //= 2
             self._target_qubits = original_targets
             return K.reshape(state, shape)
-        return K.state_vector_call(self, state)
+        return K._state_vector_call(self, state)

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -603,7 +603,7 @@ class TOFFOLI(BackendGate, abstract_gates.TOFFOLI):
         return K.matrices.TOFFOLI
 
     @property
-    def unitary(self):
+    def matrix(self):
         if self._matrix is None:
             self._matrix = self.construct_unitary()
         return self._matrix
@@ -661,28 +661,28 @@ class VariationalLayer(BackendGate, abstract_gates.VariationalLayer):
 
     def _calculate_unitaries(self):
         matrices = K.qnp.stack([K.qnp.kron(
-            self.one_qubit_gate(q1, theta=self.params[q1]).unitary,
-            self.one_qubit_gate(q2, theta=self.params[q2]).unitary)
+            self.one_qubit_gate(q1, theta=self.params[q1]).matrix,
+            self.one_qubit_gate(q2, theta=self.params[q2]).matrix)
                              for q1, q2 in self.pairs], axis=0)
-        entangling_matrix = self.two_qubit_gate(0, 1).unitary
+        entangling_matrix = self.two_qubit_gate(0, 1).matrix
         matrices = entangling_matrix @ matrices
 
         additional_matrix = None
         q = self.additional_target
         if q is not None:
             additional_matrix = self.one_qubit_gate(
-                q, theta=self.params[q]).unitary
+                q, theta=self.params[q]).matrix
 
         if self.params2:
             matrices2 = K.qnp.stack([K.qnp.kron(
-                self.one_qubit_gate(q1, theta=self.params2[q1]).unitary,
-                self.one_qubit_gate(q2, theta=self.params2[q2]).unitary)
+                self.one_qubit_gate(q1, theta=self.params2[q1]).matrix,
+                self.one_qubit_gate(q2, theta=self.params2[q2]).matrix)
                                 for q1, q2 in self.pairs], axis=0)
             matrices = matrices2 @ matrices
 
             q = self.additional_target
             if q is not None:
-                _new = self.one_qubit_gate(q, theta=self.params2[q]).unitary
+                _new = self.one_qubit_gate(q, theta=self.params2[q]).matrix
                 additional_matrix = _new @ additional_matrix
         return matrices, additional_matrix
 

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -65,7 +65,7 @@ class VectorState(AbstractState):
                                             "should be given to calculate measurement "
                                             "probabilities.")
                 if not measurement_gate.is_prepared:
-                    measurement_gate.set_nqubits(self.tensor)
+                    measurement_gate._set_nqubits(self.tensor)
                 qubits = measurement_gate.target_qubits
             elif measurement_gate is not None:
                 raise_error(ValueError, "Cannot calculate measurement "

--- a/src/qibo/core/terms.py
+++ b/src/qibo/core/terms.py
@@ -93,7 +93,7 @@ class HamiltonianTerm:
         """Applies the term on a given state vector or density matrix."""
         if density_matrix:
             self.gate.density_matrix = True
-            return self.gate.density_matrix_half_call(state)
+            return self.gate._density_matrix_half_call(state)
         return self.gate(state) # pylint: disable=E1102
 
 
@@ -202,7 +202,7 @@ class SymbolicTerm(HamiltonianTerm):
         for factor in self.factors:
             if density_matrix:
                 factor.gate.density_matrix = True
-                state = factor.gate.density_matrix_half_call(state)
+                state = factor.gate._density_matrix_half_call(state)
             else:
                 state = factor.gate(state)
         return self.coefficient * state

--- a/src/qibo/tests/test_abstract_callbacks.py
+++ b/src/qibo/tests/test_abstract_callbacks.py
@@ -11,10 +11,10 @@ def test_abstract_callback_properties():
     assert callback.nqubits == 5
     assert callback.results == [1, 2, 3]
     assert not callback.density_matrix
-    assert callback._active_call == "state_vector_call"
+    assert callback._active_call == "_state_vector_call"
     callback.density_matrix = True
     assert callback.density_matrix
-    assert callback._active_call == "density_matrix_call"
+    assert callback._active_call == "_density_matrix_call"
 
 
 def test_creating_abstract_callbacks():

--- a/src/qibo/tests/test_abstract_gates.py
+++ b/src/qibo/tests/test_abstract_gates.py
@@ -310,9 +310,9 @@ def test_density_matrix_getter_and_setter():
     gate = abstract_gates.Gate()
     gate.target_qubits = (0, 1)
     gate.control_qubits = (2,)
-    assert gate._active_call == "state_vector_call"
+    assert gate._active_call == "_state_vector_call"
     gate.density_matrix = True
-    assert gate._active_call == "density_matrix_call"
+    assert gate._active_call == "_density_matrix_call"
 
     gate.nqubits = 4
     gate.is_prepared = True

--- a/src/qibo/tests/test_core_fusion.py
+++ b/src/qibo/tests/test_core_fusion.py
@@ -84,7 +84,7 @@ def test_fusion_group_calculate(backend):
     cnot = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1],
                      [0, 0, 1, 0]])
     target_matrix = np.kron(x, x) @ cnot @ np.kron(h, h)
-    K.assert_allclose(gate.unitary, target_matrix)
+    K.assert_allclose(gate.matrix, target_matrix)
 
     group = fusion.FusionGroup()
     with pytest.raises(RuntimeError):

--- a/src/qibo/tests/test_core_gates.py
+++ b/src/qibo/tests/test_core_gates.py
@@ -196,7 +196,7 @@ def test_cun(backend, name, params):
     initial_state = random_state(2)
     gate = getattr(gates, name)(0, 1, **params)
     final_state = apply_gates([gate], initial_state=initial_state)
-    target_state = np.dot(K.to_numpy(gate.unitary), initial_state)
+    target_state = np.dot(K.to_numpy(gate.matrix), initial_state)
     K.assert_allclose(final_state, target_state)
 
 

--- a/src/qibo/tests/test_core_gates.py
+++ b/src/qibo/tests/test_core_gates.py
@@ -26,15 +26,15 @@ def apply_gates(gatelist, nqubits=None, initial_state=None):
     return state
 
 
-def test_control_unitary(backend):
+def test__control_unitary(backend):
     matrix = K.cast(np.random.random((2, 2)))
     gate = gates.Unitary(matrix, 0)
-    unitary = gate.control_unitary(matrix)
+    unitary = gate._control_unitary(matrix)
     target_unitary = np.eye(4, dtype=K._dtypes.get('DTYPECPX'))
     target_unitary[2:, 2:] = K.to_numpy(matrix)
     K.assert_allclose(unitary, target_unitary)
     with pytest.raises(ValueError):
-        unitary = gate.control_unitary(np.random.random((16, 16)))
+        unitary = gate._control_unitary(np.random.random((16, 16)))
 
 
 def test_h(backend):
@@ -81,7 +81,7 @@ def test_align(backend):
     final_state = apply_gates(gatelist, nqubits=2)
     target_state = np.ones_like(final_state) / 2.0
     K.assert_allclose(final_state, target_state)
-    gate_matrix = gate.construct_unitary()
+    gate_matrix = gate._construct_unitary()
     K.assert_allclose(gate_matrix, np.eye(4))
 
 
@@ -335,12 +335,12 @@ def test_variational_layer(backend, nqubits):
     K.assert_allclose(target_state, final_state)
 
 
-def test_variational_layer_construct_unitary(backend):
+def test_variational_layer__construct_unitary(backend):
     pairs = list((i, i + 1) for i in range(0, 5, 2))
     theta = 2 * np.pi * np.random.random(6)
     gate = gates.VariationalLayer(range(6), pairs, gates.RY, gates.CZ, theta)
     with pytest.raises(ValueError):
-        gate.construct_unitary()
+        gate._construct_unitary()
 
 
 def test_flatten(backend):
@@ -351,7 +351,7 @@ def test_flatten(backend):
     target_state = np.ones(4) / 2.0
     gate = gates.Flatten(target_state)
     with pytest.raises(ValueError):
-        gate.construct_unitary()
+        gate._construct_unitary()
 
 
 def test_callback_gate_errors():
@@ -359,7 +359,7 @@ def test_callback_gate_errors():
     entropy = callbacks.EntanglementEntropy([0])
     gate = gates.CallbackGate(entropy)
     with pytest.raises(ValueError):
-        gate.construct_unitary()
+        gate._construct_unitary()
 
 
 def test_general_channel(backend):
@@ -386,10 +386,10 @@ def test_krauss_channel_errors(backend):
     # Using KrausChannel on state vectors
     channel = gates.KrausChannel([((0,), np.eye(2))])
     with pytest.raises(ValueError):
-        channel.state_vector_call(np.random.random(4))
+        channel._state_vector_call(np.random.random(4))
     # Attempt to construct unitary for KrausChannel
     with pytest.raises(ValueError):
-        channel.construct_unitary()
+        channel._construct_unitary()
 
 
 def test_controlled_by_channel_error():
@@ -511,7 +511,7 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
     # Try to apply to state vector if t1 < t2
     if t1 < t2:
         with pytest.raises(ValueError):
-            gate.state_vector_call(initial_rho) # pylint: disable=no-member
+            gate._state_vector_call(initial_rho) # pylint: disable=no-member
 
 
 @pytest.mark.parametrize("t1,t2,time,excpop",

--- a/src/qibo/tests/test_core_gates_controlled.py
+++ b/src/qibo/tests/test_core_gates_controlled.py
@@ -208,5 +208,5 @@ def test_controlled_unitary_matrix(backend):
     c = Circuit(2)
     c.add(gate)
     target_state = c(np.copy(initial_state))
-    final_state = np.dot(K.to_numpy(gate.unitary), initial_state)
+    final_state = np.dot(K.to_numpy(gate.matrix), initial_state)
     K.assert_allclose(final_state, target_state)

--- a/src/qibo/tests/test_core_gates_density_matrix.py
+++ b/src/qibo/tests/test_core_gates_density_matrix.py
@@ -246,7 +246,7 @@ def test_partial_trace_gate_errors(backend):
     gate = gates.PartialTrace(0, 1)
     # attempt to create unitary matrix
     with pytest.raises(ValueError):
-        gate.construct_unitary()
+        gate._construct_unitary()
     # attempt to call on state vector
     state = np.random.random(16) + 1j * np.random.random(16)
     with pytest.raises(RuntimeError):

--- a/src/qibo/tests/test_core_gates_density_matrix.py
+++ b/src/qibo/tests/test_core_gates_density_matrix.py
@@ -71,7 +71,7 @@ def test_one_qubit_gates(backend, gatename, gatekwargs):
     gate.density_matrix = True
     final_rho = gate(np.copy(initial_rho))
 
-    matrix = K.to_numpy(gate.unitary)
+    matrix = K.to_numpy(gate.matrix)
     target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
     K.assert_allclose(final_rho, target_rho)
 
@@ -105,7 +105,7 @@ def test_two_qubit_gates(backend, gatename, gatekwargs):
     gate.density_matrix = True
     final_rho = gate(np.copy(initial_rho))
 
-    matrix = K.to_numpy(gate.unitary)
+    matrix = K.to_numpy(gate.matrix)
     target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
     K.assert_allclose(final_rho, target_rho, atol=_atol)
 
@@ -117,7 +117,7 @@ def test_toffoli_gate(backend):
     gate.density_matrix = True
     final_rho = gate(np.copy(initial_rho))
 
-    matrix = K.to_numpy(gate.unitary)
+    matrix = K.to_numpy(gate.matrix)
     target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
     K.assert_allclose(final_rho, target_rho)
 

--- a/src/qibo/tests/test_core_gates_features.py
+++ b/src/qibo/tests/test_core_gates_features.py
@@ -31,7 +31,7 @@ GATES = [
 def test_construct_unitary(backend, gate, qubits, target_matrix):
     """Check that `construct_unitary` method constructs the proper matrix."""
     gate = getattr(gates, gate)(*qubits)
-    K.assert_allclose(gate.unitary, target_matrix)
+    K.assert_allclose(gate.matrix, target_matrix)
 
 
 GATES = [
@@ -51,7 +51,7 @@ def test_construct_unitary_rotations(backend, gate, target_matrix):
         gate = getattr(gates, gate)(0, 1, theta)
     else:
         gate = getattr(gates, gate)(0, theta)
-    K.assert_allclose(gate.unitary, target_matrix(theta))
+    K.assert_allclose(gate.matrix, target_matrix(theta))
     K.assert_allclose(gate.matrix, target_matrix(theta))
 
 
@@ -62,11 +62,11 @@ def test_construct_unitary_controlled(backend):
     target_matrix = np.eye(4, dtype=rotation.dtype)
     target_matrix[2:, 2:] = rotation
     gate = gates.RY(0, theta).controlled_by(1)
-    K.assert_allclose(gate.unitary, target_matrix)
+    K.assert_allclose(gate.matrix, target_matrix)
 
     gate = gates.RY(0, theta).controlled_by(1, 2)
     with pytest.raises(NotImplementedError):
-        unitary = gate.unitary
+        unitary = gate.matrix
 
 ###############################################################################
 
@@ -165,13 +165,13 @@ def test_one_qubit_gate_multiplication(backend):
     assert final_gate.__class__.__name__ == "Unitary"
     target_matrix = (np.array([[0, 1], [1, 0]]) @
                      np.array([[1, 1], [1, -1]]) / np.sqrt(2))
-    K.assert_allclose(final_gate.unitary, target_matrix)
+    K.assert_allclose(final_gate.matrix, target_matrix)
 
     final_gate = gate2 @ gate1
     assert final_gate.__class__.__name__ == "Unitary"
     target_matrix = (np.array([[1, 1], [1, -1]]) / np.sqrt(2) @
                      np.array([[0, 1], [1, 0]]))
-    K.assert_allclose(final_gate.unitary, target_matrix)
+    K.assert_allclose(final_gate.matrix, target_matrix)
 
     gate1 = gates.X(1)
     gate2 = gates.X(1)
@@ -190,7 +190,7 @@ def test_two_qubit_gate_multiplication(backend):
                                [0, 0, 0, np.exp(-1j * phi)]]) @
                      np.array([[1, 0, 0, 0], [0, 0, 1, 0],
                                [0, 1, 0, 0], [0, 0, 0, 1]]))
-    K.assert_allclose(final_gate.unitary, target_matrix)
+    K.assert_allclose(final_gate.matrix, target_matrix)
     # Check that error is raised when target qubits do not agree
     with pytest.raises(NotImplementedError):
         final_gate = gate1 @ gates.SWAP(0, 2)

--- a/src/qibo/tests/test_core_gates_features.py
+++ b/src/qibo/tests/test_core_gates_features.py
@@ -6,7 +6,7 @@ from qibo.models import Circuit
 from qibo.tests.utils import random_state
 
 
-####################### Test `construct_unitary` feature #######################
+####################### Test `_construct_unitary` feature #######################
 GATES = [
     ("H", (0,), np.array([[1, 1], [1, -1]]) / np.sqrt(2)),
     ("X", (0,), np.array([[0, 1], [1, 0]])),
@@ -28,8 +28,8 @@ GATES = [
                                      [0, 0, 0, 0, 0, 0, 1, 0]]))
 ]
 @pytest.mark.parametrize("gate,qubits,target_matrix", GATES)
-def test_construct_unitary(backend, gate, qubits, target_matrix):
-    """Check that `construct_unitary` method constructs the proper matrix."""
+def test__construct_unitary(backend, gate, qubits, target_matrix):
+    """Check that `_construct_unitary` method constructs the proper matrix."""
     gate = getattr(gates, gate)(*qubits)
     K.assert_allclose(gate.matrix, target_matrix)
 
@@ -44,8 +44,8 @@ GATES = [
     ("CU1", lambda x: np.diag([1, 1, 1, np.exp(1j * x)]))
 ]
 @pytest.mark.parametrize("gate,target_matrix", GATES)
-def test_construct_unitary_rotations(backend, gate, target_matrix):
-    """Check that `construct_unitary` method constructs the proper matrix."""
+def test__construct_unitary_rotations(backend, gate, target_matrix):
+    """Check that `_construct_unitary` method constructs the proper matrix."""
     theta = 0.1234
     if gate == "CU1":
         gate = getattr(gates, gate)(0, 1, theta)
@@ -55,7 +55,7 @@ def test_construct_unitary_rotations(backend, gate, target_matrix):
     K.assert_allclose(gate.matrix, target_matrix(theta))
 
 
-def test_construct_unitary_controlled(backend):
+def test__construct_unitary_controlled(backend):
     theta = 0.1234
     rotation = np.array([[np.cos(theta / 2.0), -np.sin(theta / 2.0)],
                          [np.sin(theta / 2.0), np.cos(theta / 2.0)]])

--- a/src/qibo/tests/test_measurement_gate.py
+++ b/src/qibo/tests/test_measurement_gate.py
@@ -43,7 +43,7 @@ def test_measurement_gate_errors(backend):
         gate.controlled_by(1)
     # attempting to construct unitary
     with pytest.raises(ValueError):
-        matrix = gate.unitary
+        matrix = gate.matrix
     # calling on bad state
     with pytest.raises(TypeError):
         gate("test", 100)

--- a/src/qibo/tests/test_models_evolution.py
+++ b/src/qibo/tests/test_models_evolution.py
@@ -19,10 +19,10 @@ class TimeStepChecker(callbacks.BackendCallback):
         self.target_states = iter(target_states)
         self.atol = atol
 
-    def state_vector_call(self, state):
+    def _state_vector_call(self, state):
         assert_states_equal(state, next(self.target_states), atol=self.atol)
 
-    def density_matrix_call(self, state): # pragma: no cover
+    def _density_matrix_call(self, state): # pragma: no cover
         raise_error(NotImplementedError)
 
 


### PR DESCRIPTION
Following #446 here we remove `.unitary` in favour of `.matrix`.