### PR TITLE
EntanglementEntropy use circuits with fixed nqubits

### DIFF
--- a/src/qibo/core/callbacks.py
+++ b/src/qibo/core/callbacks.py
@@ -52,7 +52,7 @@ class EntanglementEntropy(BackendCallback, abstract_callbacks.EntanglementEntrop
         from qibo import gates
         if self._nqubits is not None and self._nqubits != n:
             raise_error(RuntimeError,
-                        "Changing nqubits for EntanglementEntropy is not supported.")
+                        f"Changing EntanglementEntropy nqubits from {self._nqubits} to {n}.")
         self._nqubits = n
         if self.partition is None:
             self.partition = list(range(n // 2 + n % 2))
@@ -80,8 +80,7 @@ class EntanglementEntropy(BackendCallback, abstract_callbacks.EntanglementEntrop
         if not isinstance(state, K.tensor_types):
             raise_error(TypeError, "State of unknown type {} was given in callback "
                                    "calculation.".format(type(state)))
-        if self._nqubits is None:
-            self.nqubits = int(math.log2(tuple(state.shape)[0]))
+        self.nqubits = int(math.log2(tuple(state.shape)[0]))
 
     def state_vector_call(self, state):
         self.set_nqubits(state)

--- a/src/qibo/core/callbacks.py
+++ b/src/qibo/core/callbacks.py
@@ -50,6 +50,9 @@ class EntanglementEntropy(BackendCallback, abstract_callbacks.EntanglementEntrop
     @abstract_callbacks.Callback.nqubits.setter
     def nqubits(self, n: int):
         from qibo import gates
+        if self._nqubits is not None and self._nqubits != n:
+            raise_error(RuntimeError,
+                        "Changing nqubits for EntanglementEntropy is not supported.")
         self._nqubits = n
         if self.partition is None:
             self.partition = list(range(n // 2 + n % 2))
@@ -79,7 +82,6 @@ class EntanglementEntropy(BackendCallback, abstract_callbacks.EntanglementEntrop
                                    "calculation.".format(type(state)))
         if self._nqubits is None:
             self.nqubits = int(math.log2(tuple(state.shape)[0]))
-
 
     def state_vector_call(self, state):
         self.set_nqubits(state)

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -195,6 +195,11 @@ def test_entropy_multiple_executions(backend, accelerators):
     target = [0, target_entropy(0.1234), 0, target_entropy(0.4321)]
     K.assert_allclose(entropy[:], target, atol=_atol)
 
+    c = Circuit(8, accelerators)
+    with pytest.raises(RuntimeError):
+        c.add(gates.CallbackGate(entropy))
+        state = c()
+
 
 def test_entropy_large_circuit(backend, accelerators):
     """Check that entropy calculation works for variational like circuit."""


### PR DESCRIPTION
This PR raises an error if the user allocates multiple circuits using different number of qubits but sharing the same `EntanglementEntropy` object. @igres26 could you please check if this PR raises a proper error in your example?