### PR TITLE
fixing CI with numba and py3.7

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -20,6 +20,11 @@ jobs:
       uses: mstksg/get-package@v1
       with:
         brew: libomp
+    # workaround until this solved https://github.com/numba/numba/issues/7339
+    - name: Fixing numba for py37 on linux
+      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.7'
+      run: |
+        pip install numba==0.53.1
     - name: Install package
       if: startsWith(matrix.os, 'windows') == 0
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,6 +34,11 @@ jobs:
       with:
         name: wheels
         path: dist
+    # workaround until this solved https://github.com/numba/numba/issues/7339
+    - name: Fixing numba for py37 on linux
+      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.7'
+      run: |
+        pip install numba==0.53.1
     - name: Test wheels
       if: startsWith(matrix.os, 'windows') == 0
       run: |


### PR DESCRIPTION
There is an [issue](https://github.com/numba/numba/issues/7339) in the latest wheels for numba with python 3.7 and linux.
Here we propose an workaround until this issue is solved.