### PR TITLE
using abstract backend attributes

### DIFF
--- a/examples/reuploading_classifier/qlassifier.py
+++ b/examples/reuploading_classifier/qlassifier.py
@@ -117,12 +117,10 @@ class single_qubit_classifier:
         elif method == 'sgd':
             circuit = self.circuit(self.training_set[0])
             for gate in circuit.queue:
-                if K.name != "tensorflow":
+                if not K.supports_gradients:
                     from qibo.config import raise_error
                     raise_error(RuntimeError,
-                                'SGD VQE requires native Tensorflow '
-                                'gates because gradients are not '
-                                'supported in the custom kernels.')
+                                'Use tensorflow backend in order to compute gradients.')
 
             sgd_options = {"nepochs": 5001,
                            "nmessage": 1000,

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -31,7 +31,10 @@ class AbstractBackend(ABC):
         self.newaxis = None
         self.oom_error = None
         self.optimization = None
+        self.supports_multigpu = False
+        self.supports_gradients = False
 
+        self.is_hardware = False
         self.hardware_module = None
         self.hardware_circuit = None
         self.hardware_gates = None

--- a/src/qibo/backends/hardware.py
+++ b/src/qibo/backends/hardware.py
@@ -9,9 +9,10 @@ class IcarusQBackend(NumpyBackend): # pragma: no cover
 
     def __init__(self):
         super().__init__()
-        self.name = "icarusq"
+        self.name = "qiboicarusq"
         self.custom_gates = True
         import qiboicarusq # pylint: disable=E0401
+        self.is_hardware = True
         self.hardware_module = qiboicarusq
         self.hardware_gates = qiboicarusq.gates
         self.hardware_circuit = qiboicarusq.circuit.HardwareCircuit

--- a/src/qibo/backends/jit.py
+++ b/src/qibo/backends/jit.py
@@ -57,6 +57,11 @@ class JITCustomBackend(NumpyBackend):
             self.set_threads(self.nthreads)
         self.cupy_cpu_device = CupyCpuDevice(self)
 
+        # enable multi-GPU if no macos
+        import sys
+        if sys.platform != "darwin":
+            self.supports_multigpu = True
+
     def set_engine(self, name): # pragma: no cover
         """Switcher between ``cupy`` for GPU and ``numba`` for CPU."""
         if name == "numba":

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -46,6 +46,8 @@ class TensorflowBackend(numpy.NumpyBackend):
         self._seed = None
         # seed can be modified using ``K.set_seed``
 
+        self.supports_gradients = True
+
     def set_device(self, name):
         abstract.AbstractBackend.set_device(self, name)
 
@@ -237,6 +239,14 @@ class TensorflowCustomBackend(TensorflowBackend):
         import os
         if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
             self.set_threads(int(os.environ.get("OMP_NUM_THREADS")))
+
+        # enable multi-GPU if no macos
+        import sys
+        if sys.platform != "darwin":
+            self.supports_multigpu = True
+
+        # no gradient support for custom operators
+        self.supports_gradients = False
 
     def set_threads(self, nthreads):
         abstract.AbstractBackend.set_threads(self, nthreads)

--- a/src/qibo/core/distcircuit.py
+++ b/src/qibo/core/distcircuit.py
@@ -94,10 +94,9 @@ class DistributedCircuit(circuit.Circuit):
 
         Also checks that there are sufficient qubits to use as global.
         """
-        if K.name not in {"qibotf", "qibojit"}:
-            raise_error(NotImplementedError, "Distributed circuit is implemented "
-                                             "only for the qibotf and qibojit "
-                                             "backends.")
+        if not K.supports_multigpu:
+            raise_error(NotImplementedError, f"Distributed circuit is not supported "
+                                              "by the {K.name} backend.")
         if isinstance(gate, gates.KrausChannel):
             raise_error(NotImplementedError, "Distributed circuits do not "
                                              "support channels.")

--- a/src/qibo/core/distcircuit.py
+++ b/src/qibo/core/distcircuit.py
@@ -46,9 +46,9 @@ class DistributedCircuit(circuit.Circuit):
     """
 
     def __init__(self, nqubits: int, accelerators: Dict[str, int]):
-        if sys.platform == "darwin":  # pragma: no cover
-            raise_error(NotImplementedError, "Distributed circuits are not "
-                                             "implemented for macos.")
+        if not K.supports_multigpu:  # pragma: no cover
+            raise_error(NotImplementedError, f"Distributed circuit is not supported "
+                                              "by the {K.name} backend.")
         super().__init__(nqubits)
         self.init_kwargs["accelerators"] = accelerators
         self.ndevices = sum(accelerators.values())
@@ -94,9 +94,6 @@ class DistributedCircuit(circuit.Circuit):
 
         Also checks that there are sufficient qubits to use as global.
         """
-        if not K.supports_multigpu:
-            raise_error(NotImplementedError, f"Distributed circuit is not supported "
-                                              "by the {K.name} backend.")
         if isinstance(gate, gates.KrausChannel):
             raise_error(NotImplementedError, "Distributed circuits do not "
                                              "support channels.")

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -16,14 +16,14 @@ class Circuit(StateCircuit):
                 raise_error(NotImplementedError,
                             "Distributed circuits are not implemented for "
                             "density matrices.")
-            if K.hardware_module:
+            if K.is_hardware:
                 raise_error(NotImplementedError,
                             "Hardware backend does not support density matrix "
                             "simulation.")
             from qibo.core.circuit import DensityMatrixCircuit as circuit_cls
             kwargs = {}
         elif kwargs["accelerators"] is not None:
-            if K.hardware_module:
+            if K.is_hardware:
                 raise_error(NotImplementedError,
                             "Hardware backend does not support multi-GPU "
                             "configuration.")
@@ -38,7 +38,7 @@ class Circuit(StateCircuit):
             kwargs.pop("density_matrix")
         else:
             kwargs = {}
-            if K.hardware_module: # pragma: no cover
+            if K.is_hardware: # pragma: no cover
                 # hardware backend is not tested until `qiboicarusq` is available
                 circuit_cls = K.hardware_circuit
             else:

--- a/src/qibo/optimizers.py
+++ b/src/qibo/optimizers.py
@@ -166,7 +166,7 @@ def sgd(loss, initial_parameters, args=(), options=None, compile=False):
     """
     from qibo import K
     from qibo.config import log, raise_error
-    if K.name != "tensorflow":
+    if not K.supports_gradients:
         raise_error(RuntimeError, "SGD optimizer requires Tensorflow backend.")
 
     sgd_options = {"nepochs": 1000000,

--- a/src/qibo/tests/conftest.py
+++ b/src/qibo/tests/conftest.py
@@ -9,8 +9,8 @@ import qibo
 
 _available_backends = set(qibo.K.available_backends.keys()) - set(qibo.K.hardware_backends.keys())
 _ACCELERATORS = None
-for backend in qibo.K.available_backends:
-    if backend.supports_multigpu:
+for bkd in qibo.K.available_backends:
+    if bkd.supports_multigpu:
         _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
 _BACKENDS = ",".join(_available_backends)
 

--- a/src/qibo/tests/conftest.py
+++ b/src/qibo/tests/conftest.py
@@ -9,8 +9,8 @@ import qibo
 
 _available_backends = set(qibo.K.available_backends.keys()) - set(qibo.K.hardware_backends.keys())
 _ACCELERATORS = None
-for bkd in qibo.K.available_backends:
-    if bkd.supports_multigpu:
+for bkd in _available_backends:
+    if qibo.K.available_backends[bkd]().supports_multigpu:
         _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
 _BACKENDS = ",".join(_available_backends)
 

--- a/src/qibo/tests/conftest.py
+++ b/src/qibo/tests/conftest.py
@@ -9,8 +9,9 @@ import qibo
 
 _available_backends = set(qibo.K.available_backends.keys()) - set(qibo.K.hardware_backends.keys())
 _ACCELERATORS = None
-if ("qibotf" in _available_backends or "qibojit" in _available_backends):
-    _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
+for backend in _available_backends:
+    if backend.supports_multigpu:
+        _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
 _BACKENDS = ",".join(_available_backends)
 
 

--- a/src/qibo/tests/conftest.py
+++ b/src/qibo/tests/conftest.py
@@ -9,7 +9,7 @@ import qibo
 
 _available_backends = set(qibo.K.available_backends.keys()) - set(qibo.K.hardware_backends.keys())
 _ACCELERATORS = None
-for backend in _available_backends:
+for backend in qibo.K.available_backends:
     if backend.supports_multigpu:
         _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
 _BACKENDS = ",".join(_available_backends)

--- a/src/qibo/tests/test_cirq.py
+++ b/src/qibo/tests/test_cirq.py
@@ -54,7 +54,7 @@ def assert_gates_equivalent(qibo_gate, cirq_gates, nqubits,
     if ndevices is not None:
         accelerators = {"/GPU:0": ndevices}
 
-    if accelerators and (K.name not in {"qibotf", "qibojit"} or sys.platform == "darwin"):
+    if accelerators and not K.supports_multigpu:
         with pytest.raises(NotImplementedError):
             c = models.Circuit(nqubits, accelerators)
             c.add(qibo_gate)

--- a/src/qibo/tests/test_cirq.py
+++ b/src/qibo/tests/test_cirq.py
@@ -57,7 +57,6 @@ def assert_gates_equivalent(qibo_gate, cirq_gates, nqubits,
     if accelerators and not K.supports_multigpu:
         with pytest.raises(NotImplementedError):
             c = models.Circuit(nqubits, accelerators)
-            c.add(qibo_gate)
     else:
         c = models.Circuit(nqubits, accelerators)
         c.add(qibo_gate)

--- a/src/qibo/tests/test_core_circuit.py
+++ b/src/qibo/tests/test_core_circuit.py
@@ -68,8 +68,6 @@ def test_compiled_execute(backend):
 
 def test_compiling_twice_exception(backend):
     """Check that compiling a circuit a second time raises error."""
-    if K.name != "tensorflow": # pragma: no cover
-        pytest.skip("Skipping compilation test because Tensorflow is not available.")
     c = Circuit(2)
     c.add([gates.H(0), gates.H(1)])
     c.compile()

--- a/src/qibo/tests/test_core_circuit_backpropagation.py
+++ b/src/qibo/tests/test_core_circuit_backpropagation.py
@@ -6,7 +6,7 @@ from qibo.models import Circuit
 
 
 def test_variable_backpropagation(backend):
-    if K.name != "tensorflow":
+    if not K.supports_gradients:
         pytest.skip("Backpropagation is not supported by {}.".format(K.name))
 
     theta = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
@@ -27,7 +27,7 @@ def test_variable_backpropagation(backend):
 
 
 def test_two_variables_backpropagation(backend):
-    if K.name != "tensorflow":
+    if not K.supports_gradients:
         pytest.skip("Backpropagation is not supported by {}.".format(K.name))
 
     theta = K.optimization.Variable([0.1234, 0.4321], dtype=K.dtypes('DTYPE'))

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -13,7 +13,7 @@ def test_circuit_constructor():
     assert isinstance(c, Circuit)
     c = models.Circuit(5, density_matrix=True)
     assert isinstance(c, DensityMatrixCircuit)
-    if K.name not in {"qibotf", "qibojit"} or sys.platform == "darwin":  # pragma: no cover
+    if not K.supports_multigpu:  # pragma: no cover
         with pytest.raises(NotImplementedError):
             c = models.Circuit(5, accelerators={"/GPU:0": 2})
     else:
@@ -24,12 +24,12 @@ def test_circuit_constructor():
 
 
 def test_circuit_constructor_hardware_errors():
-    K.hardware_module = "test"
+    K.is_hardware = True
     with pytest.raises(NotImplementedError):
         c = models.Circuit(5, accelerators={"/GPU:0": 2})
     with pytest.raises(NotImplementedError):
         c = models.Circuit(5, density_matrix=True)
-    K.hardware_module = None
+    K.is_hardware = False
 
 
 def qft_matrix(dimension: int, inverse: bool = False) -> np.ndarray:

--- a/src/qibo/tests/test_models_evolution.py
+++ b/src/qibo/tests/test_models_evolution.py
@@ -310,7 +310,7 @@ def test_scheduling_optimization(method, options, messages, dense, filename):
 
     if method == "sgd":
         from qibo import K
-        if K.name != "tensorflow":
+        if not K.supports_gradients:
             with pytest.raises(RuntimeError):
                 best, params, _ = adevp.minimize([0.5, 1], method=method, options=options,
                                 messages=messages)


### PR DESCRIPTION
Minor changes to avoid hardcoding backend names.

We should complete the docs about the implementation of a new backend.
In principle we could remove the .compile method, however the mechanism might be useful for hardware optimization so I am keeping this feature.

@stavros11 please let me know if you see some extra generalization that makes sense at this point. Here I decided to keep the profiles.yml as light as possible, given that we are already exposing the backend class inheritance, so we can use that directly instead of reading and setting from the profile.