### PR TITLE
Fix tests about `print` statements

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -46,6 +46,9 @@ The current code standards that are applied to any new changes:
 - **Coverage**: Test coverage should be maintained / be at least at the same level when new features are implemented.
 - **Pylint**: Test code for anomalies, such as bad coding practices, missing documentation, unused variables.
 
+Besides the linter, further custom rules are applied e.g. checks for ``print`` statements that bypass the logging system
+(such check can be excluded line by line with the ``# CodeText:skip`` flag).
+
 Documentation
 -------------
 

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -53,8 +53,8 @@ class ParallelResources:  # pragma: no cover
                     # if copy is not implemented just use the original object
                     copy = obj
                 except Exception as e:
-                    # use print otherwise the message will not appear
-                    print('Exception in ParallelResources', str(e))
+                    # use print otherwise the message will not appear # CodeText:skip
+                    print('Exception in ParallelResources', str(e)) # CodeText:skip
                 args.append(copy)
             args = tuple(args)
             self._objects_per_process[pname] = args

--- a/src/qibo/tests/test_prints.py
+++ b/src/qibo/tests/test_prints.py
@@ -69,15 +69,17 @@ class CodeText:
 
 def python_files():
     """Iterator that yields all python files (`.py`) in `/src/qibo/`."""
-    excluded_files = ["test_prints", "parallel"] # beware of files of the same name
+    excluded_files = ["tests/test_prints.py", "parallel.py"] # list with excluded files
     basedir = pathlib.Path(os.path.realpath(__file__)).parent.parent
     for subdir, _, files in os.walk(basedir):
         for file in files:
             pieces = file.split(".")
-            # skip non-`.py` files
-            # skip current file because it contains `print`
-            if len(pieces) == 2 and pieces[1] == "py" and (pieces[0] not in excluded_files):
-                yield os.path.join(subdir, file)
+            full_path = os.path.join(subdir, file) # get the absolute path
+            relative_path = full_path.split("/src/qibo/")[-1] # relative path from /src/qibo/
+            # skip non-`.py` files i.e. pieces should be ["filename", ".py"]
+            # skip excluded files i.e. relative path should not be in `excluded_files`
+            if len(pieces) == 2 and pieces[1] == "py" and (relative_path not in excluded_files):
+                yield full_path
 
 # Make sure the CodeText class works as intended
 text_examples = [

--- a/src/qibo/tests/test_prints.py
+++ b/src/qibo/tests/test_prints.py
@@ -69,13 +69,14 @@ class CodeText:
 
 def python_files():
     """Iterator that yields all python files (`.py`) in `/src/qibo/`."""
+    excluded_files = ["test_prints", "parallel"] # beware of files of the same name
     basedir = pathlib.Path(os.path.realpath(__file__)).parent.parent
     for subdir, _, files in os.walk(basedir):
         for file in files:
             pieces = file.split(".")
             # skip non-`.py` files
             # skip current file because it contains `print`
-            if len(pieces) == 2 and pieces[1] == "py" and pieces[0] != "test_prints":
+            if len(pieces) == 2 and pieces[1] == "py" and (pieces[0] not in excluded_files):
                 yield os.path.join(subdir, file)
 
 # Make sure the CodeText class works as intended

--- a/src/qibo/tests/test_prints.py
+++ b/src/qibo/tests/test_prints.py
@@ -12,7 +12,6 @@ class CodeText:
         self.filedir = filedir
         self.line_counter = 0
         self.piece_counter = 0
-        self.starts_with_docstring = (code[:3] == '"""')
         self.pieces = None
 
     @classmethod
@@ -38,14 +37,14 @@ class CodeText:
 
         if self.piece_counter < len(self.pieces):
             # skip docstrings
-            if self.piece_counter % 2 == self.starts_with_docstring:
+            if self.piece_counter % 2 == 0:
                 return self.pieces[self.piece_counter]
             else:
                 return self.__next__()
 
         raise StopIteration
 
-    def get_line(self, i): # pragma: no cover
+    def get_line(self, i):
         """Calculates line number of the identified `print`.
 
         Args:
@@ -61,9 +60,8 @@ class CodeText:
         """Checks if a word exists in the code text."""
         for piece in self:
             i = piece.find(target_word)
-            if i > 0:
+            if i >= 0:
                 # This should not execute if the code does not contain `print` statements
-                from qibo.config import raise_error
                 line = self.get_line(i)
                 raise_error(ValueError, f"Found `{target_word}` in line {line} "
                                         f"of {self.filedir}.")


### PR DESCRIPTION
If I understand correctly, the code in ``src/qibo/tests/test_prints.py`` implements a test that checks if the source code contains `print` statement. If this is so, such test is not working properly. In fact, the `print` statement occurs twice:
https://github.com/qiboteam/qibo/blob/28171d29c8654748d2b436338f1fa99de8ae7f92/src/qibo/parallel.py#L56-L57
but no error is raised.

I found two issues in the CodeText class:
- If the code starts with `"""`,  then the first piece will be an empty string, the second will be the content of a docstring, the third will be code, and so on.
  https://github.com/qiboteam/qibo/blob/28171d29c8654748d2b436338f1fa99de8ae7f92/src/qibo/tests/test_prints.py#L28
  On the other hand, if the code doesn't start with `"""`, the first piece will contain proper code, the second will contain a docstring, and so on.
  In both cases, docstrings are in odd position, so
  https://github.com/qiboteam/qibo/blob/28171d29c8654748d2b436338f1fa99de8ae7f92/src/qibo/tests/test_prints.py#L40-L44
  inverts docstrings with code (in files that starts with a docstring).
- If `print` occurs at the beginning of `piece`, than `i=0` but the code checks for `i>0`.
  https://github.com/qiboteam/qibo/blob/28171d29c8654748d2b436338f1fa99de8ae7f92/src/qibo/tests/test_prints.py#L62-L69

I edited the script accordingly and I added some tests to cover the CodeText class.