### PR TITLE
Remove sympy.expand call when constructing SymbolicHamiltonian

### DIFF
--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -1427,3 +1427,20 @@ form is very close to the form of the Hamiltonian on paper. Note that when a
 :class:`qibo.core.hamiltonians.SymbolicHamiltonian` is used for time evolution,
 Qibo handles automatically automatically the Trotter decomposition by splitting
 to the appropriate terms.
+
+Qibo symbols support an additional ``commutative`` argument which is set to
+``False`` by default since quantum operators are non-commuting objects.
+When the user knows that the Hamiltonian consists of commuting terms only, such
+as products of Z operators, switching ``commutative`` to ``True`` may speed-up
+some symbolic calculations, such as the ``sympy.expand`` used when calculating
+the Trotter decomposition for the Hamiltonian. This option can be used when
+constructing each symbol:
+
+
+.. code-block::  python
+
+    from qibo import hamiltonians
+    from qibo.symbols import Z
+
+    form = Z(0, commutative=True) * Z(1, commutative=True) + Z(1, commutative=True) * Z(2, commutative=True)
+    ham = hamiltonians.SymbolicHamiltonian(form)

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -392,7 +392,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                 raise_error(RuntimeError, "Only hamiltonians with the same "
                                           "number of qubits can be added.")
             new_ham = self.__class__(symbol_map=self.symbol_map)
-            if self.form is not None and o.form is not None:
+            if self._form is not None and o._form is not None:
                 new_ham.form = self.form + o.form
                 new_ham.symbol_map.update(o.symbol_map)
             if self._terms is not None and o._terms is not None:
@@ -403,7 +403,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
         elif isinstance(o, K.numeric_types):
             new_ham = self.__class__(symbol_map=self.symbol_map)
-            if self.form is not None:
+            if self._form is not None:
                 new_ham.form = self.form + o
             if self._terms is not None:
                 new_ham.terms = self.terms
@@ -422,7 +422,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                 raise_error(RuntimeError, "Only hamiltonians with the same "
                                           "number of qubits can be subtracted.")
             new_ham = self.__class__(symbol_map=self.symbol_map)
-            if self.form is not None and o.form is not None:
+            if self._form is not None and o._form is not None:
                 new_ham.form = self.form - o.form
                 new_ham.symbol_map.update(o.symbol_map)
             if self._terms is not None and o._terms is not None:
@@ -433,7 +433,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
         elif isinstance(o, K.numeric_types):
             new_ham = self.__class__(symbol_map=self.symbol_map)
-            if self.form is not None:
+            if self._form is not None:
                 new_ham.form = self.form - o
             if self._terms is not None:
                 new_ham.terms = self.terms
@@ -448,10 +448,12 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
     def __rsub__(self, o):
         if isinstance(o, K.numeric_types):
-            new_ham = self.__class__.from_terms([-1 * x for x in self.terms])
-            new_ham.constant = o - self.constant
-            if self.form is not None:
+            new_ham = self.__class__(symbol_map=self.symbol_map)
+            if self._form is not None:
                 new_ham.form = o - self.form
+            if self._terms is not None:
+                new_ham.terms = [-1 * x for x in self.terms]
+                new_ham.constant = o - self.constant
             if self._dense is not None:
                 new_ham.dense = o - self.dense
         else:
@@ -464,10 +466,12 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             raise_error(NotImplementedError, "Hamiltonian multiplication to {} "
                                              "not implemented.".format(type(o)))
         o = complex(o)
-        new_ham = self.__class__.from_terms([o * x for x in self.terms])
-        new_ham.constant = self.constant * o
-        if self.form is not None:
+        new_ham = self.__class__(symbol_map=self.symbol_map)
+        if self._form is not None:
             new_ham.form = o * self.form
+        if self._terms is not None:
+            new_ham.terms = [o * x for x in self.terms]
+            new_ham.constant = self.constant * o
         if self._dense is not None:
             new_ham.dense = o * self._dense
         return new_ham

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -312,9 +312,6 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
     @terms.setter
     def terms(self, terms):
-        if self.form is not None:
-            raise_error(RuntimeError, "Cannot set the terms of ``SymbolicHamiltonian``"
-                                      "with defined form.")
         self._terms = terms
         self.nqubits = max(q for term in self._terms for q in term.target_qubits) + 1
 

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -244,7 +244,6 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             however we would like to avoid constructing and diagonalizing the
             full Hamiltonian matrix only to find the ground state.
     """
-    # TODO: Improve this docstring with more explanations on the `terms` and `form` representations.
 
     def __init__(self, form=None, symbol_map={}, ground_state=None):
         super().__init__(ground_state)

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -391,7 +391,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             if self.nqubits != o.nqubits:
                 raise_error(RuntimeError, "Only hamiltonians with the same "
                                           "number of qubits can be added.")
-            new_ham = self.__class__(symbol_map=self.symbol_map)
+            new_ham = self.__class__(symbol_map=dict(self.symbol_map))
             if self._form is not None and o._form is not None:
                 new_ham.form = self.form + o.form
                 new_ham.symbol_map.update(o.symbol_map)
@@ -402,7 +402,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                 new_ham.dense = self.dense + o.dense
 
         elif isinstance(o, K.numeric_types):
-            new_ham = self.__class__(symbol_map=self.symbol_map)
+            new_ham = self.__class__(symbol_map=dict(self.symbol_map))
             if self._form is not None:
                 new_ham.form = self.form + o
             if self._terms is not None:
@@ -421,7 +421,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             if self.nqubits != o.nqubits:
                 raise_error(RuntimeError, "Only hamiltonians with the same "
                                           "number of qubits can be subtracted.")
-            new_ham = self.__class__(symbol_map=self.symbol_map)
+            new_ham = self.__class__(symbol_map=dict(self.symbol_map))
             if self._form is not None and o._form is not None:
                 new_ham.form = self.form - o.form
                 new_ham.symbol_map.update(o.symbol_map)
@@ -432,7 +432,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                 new_ham.dense = self.dense - o.dense
 
         elif isinstance(o, K.numeric_types):
-            new_ham = self.__class__(symbol_map=self.symbol_map)
+            new_ham = self.__class__(symbol_map=dict(self.symbol_map))
             if self._form is not None:
                 new_ham.form = self.form - o
             if self._terms is not None:
@@ -448,7 +448,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
 
     def __rsub__(self, o):
         if isinstance(o, K.numeric_types):
-            new_ham = self.__class__(symbol_map=self.symbol_map)
+            new_ham = self.__class__(symbol_map=dict(self.symbol_map))
             if self._form is not None:
                 new_ham.form = o - self.form
             if self._terms is not None:
@@ -466,7 +466,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
             raise_error(NotImplementedError, "Hamiltonian multiplication to {} "
                                              "not implemented.".format(type(o)))
         o = complex(o)
-        new_ham = self.__class__(symbol_map=self.symbol_map)
+        new_ham = self.__class__(symbol_map=dict(self.symbol_map))
         if self._form is not None:
             new_ham.form = o * self.form
         if self._terms is not None:
@@ -491,11 +491,13 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
     def __matmul__(self, o):
         """Matrix multiplication with other Hamiltonians or state vectors."""
         if isinstance(o, self.__class__):
-            if self.form is None or o.form is None:
+            if self._form is None or o._form is None:
                 raise_error(NotImplementedError, "Multiplication of symbolic Hamiltonians "
                                                  "without symbolic form is not implemented.")
             new_form = self.form * o.form
-            new_ham = self.__class__(new_form)
+            new_symbol_map = dict(self.symbol_map)
+            new_symbol_map.update(o.symbol_map)
+            new_ham = self.__class__(new_form, symbol_map=new_symbol_map)
             if self._dense is not None and o._dense is not None:
                 new_ham.dense = self.dense @ o.dense
             return new_ham

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -248,7 +248,7 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
     @form.setter
     def form(self, form):
         # Check that given form is a ``sympy`` expression
-        if not issubclass(form.__class__, sympy.Expr):
+        if not isinstance(form, sympy.Expr):
             raise_error(TypeError, "Symbolic Hamiltonian should be a ``sympy`` "
                                    "expression but is {}.".format(type(form)))
         # Calculate number of qubits in the system described by the given
@@ -266,9 +266,6 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
                     # ignore symbols that do not correspond to quantum operators
                     # for example parameters in the MaxCut Hamiltonian
                     q = 0
-            else:
-                raise_error(TypeError, "Invalid symbol type {} found in "
-                                       "Hamiltonian.".format(type(symbol)))
             if q > nqubits:
                 nqubits = q
 

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -301,14 +301,6 @@ class SymbolicHamiltonian(hamiltonians.SymbolicHamiltonian):
         self._terms = terms
         self.nqubits = max(q for term in self._terms for q in term.target_qubits) + 1
 
-    @classmethod
-    def from_terms(cls, terms, ground_state=None):
-        """Constructs a symbolic Hamiltonian directly from a list of terms."""
-        # TODO: Remove this constructor as we can set terms directly
-        ham = cls(ground_state=ground_state)
-        ham.terms = terms
-        return ham
-
     def _get_symbol_matrix(self, term):
         """Helper method for ``_calculate_dense_from_form``."""
         # TODO: Add comments here

--- a/src/qibo/core/terms.py
+++ b/src/qibo/core/terms.py
@@ -171,6 +171,8 @@ class SymbolicTerm(HamiltonianTerm):
                         self.coefficient *= factor.matrix
                 elif factor == sympy.I:
                     self.coefficient *= 1j
+                elif factor.is_number:
+                    self.coefficient *= complex(factor)
                 else: # pragma: no cover
                     raise_error(TypeError, "Cannot parse factor {}.".format(factor))
 

--- a/src/qibo/core/terms.py
+++ b/src/qibo/core/terms.py
@@ -124,7 +124,7 @@ class SymbolicTerm(HamiltonianTerm):
             symbols were not available.
     """
 
-    def __init__(self, coefficient, factors=1, symbol_map=None):
+    def __init__(self, coefficient, factors=1, symbol_map={}):
         self.coefficient = complex(coefficient)
         self._matrix = None
         self._gate = None
@@ -148,7 +148,7 @@ class SymbolicTerm(HamiltonianTerm):
 
                 # if the user is using ``symbol_map`` instead of qibo symbols,
                 # create the corresponding symbols
-                if symbol_map is not None and factor in symbol_map:
+                if factor in symbol_map:
                     from qibo.symbols import Symbol
                     q, matrix = symbol_map.get(factor)
                     factor = Symbol(q, matrix, name=factor.name)

--- a/src/qibo/hamiltonians.py
+++ b/src/qibo/hamiltonians.py
@@ -61,7 +61,9 @@ def XXZ(nqubits, delta=0.5, dense=True):
     matrix = hx + hy + delta * hz
     terms = [HamiltonianTerm(matrix, i, i + 1) for i in range(nqubits - 1)]
     terms.append(HamiltonianTerm(matrix, nqubits - 1, 0))
-    return SymbolicHamiltonian.from_terms(terms)
+    ham = SymbolicHamiltonian()
+    ham.terms = terms
+    return ham
 
 
 def _OneBodyPauli(nqubits, matrix, dense=True, ground_state=None):
@@ -73,7 +75,9 @@ def _OneBodyPauli(nqubits, matrix, dense=True, ground_state=None):
 
     matrix = - matrix
     terms = [HamiltonianTerm(matrix, i) for i in range(nqubits)]
-    return SymbolicHamiltonian.from_terms(terms, ground_state)
+    ham = SymbolicHamiltonian(ground_state=ground_state)
+    ham.terms = terms
+    return ham
 
 
 def X(nqubits, dense=True):
@@ -150,7 +154,9 @@ def TFIM(nqubits, h=0.0, dense=True):
     matrix = -(K.np.kron(matrices.Z, matrices.Z) + h * K.np.kron(matrices.X, matrices.I))
     terms = [HamiltonianTerm(matrix, i, i + 1) for i in range(nqubits - 1)]
     terms.append(HamiltonianTerm(matrix, nqubits - 1, 0))
-    return SymbolicHamiltonian.from_terms(terms)
+    ham = SymbolicHamiltonian()
+    ham.terms = terms
+    return ham
 
 
 def MaxCut(nqubits, dense=True):

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -7,12 +7,31 @@ class Symbol(sympy.Symbol):
     """Qibo specialization for ``sympy`` symbols.
 
     These symbols can be used to create :class:`qibo.core.hamiltonians.SymbolicHamiltonian`.
+    See :ref:`How to define custom Hamiltonians using symbols? <symbolicham-example>`
+    for more details.
+
+    Example:
+        ::
+
+            from qibo import hamiltonians
+            from qibo.symbols import X, Y, Z
+            # consturct an XYZ Hamiltonian on two qubits using Qibo symbols
+            form = X(0) * X(1) + Y(0) * Y(1) + Z(0) * Z(1)
+            ham = hamiltonians.SymbolicHamiltonian(form)
 
     Args:
         q (int): Target qubit id.
         matrix (np.ndarray): 2x2 matrix represented by this symbol.
         name (str): Name of the symbol which defines how it is represented in
             symbolic expressions.
+        commutative (bool): If ``True`` the constructed symbols commute with
+            each other. Default is ``False``.
+            This argument should be used with caution because quantum operators
+            are not commutative objects and therefore switching this to ``True``
+            may lead to wrong results. It is useful for improving performance
+            in symbolic calculations in cases where the user is sure that
+            the operators participating in the Hamiltonian form are commuting
+            (for example when the Hamiltonian consists of Z terms only).
     """
 
     def __new__(cls, q, matrix=None, name="Symbol", commutative=False):

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -15,11 +15,11 @@ class Symbol(sympy.Symbol):
             symbolic expressions.
     """
 
-    def __new__(cls, q, matrix=None, name="Symbol"):
+    def __new__(cls, q, matrix=None, name="Symbol", commutative=False):
         name = "{}{}".format(name, q)
-        return super().__new__(cls=cls, name=name, commutative=False)
+        return super().__new__(cls=cls, name=name, commutative=commutative)
 
-    def __init__(self, q, matrix=None, name="Symbol"):
+    def __init__(self, q, matrix=None, name="Symbol", commutative=False):
         self.target_qubit = q
         self._gate = None
         if not (matrix is None or isinstance(matrix, K.qnp.numeric_types) or
@@ -41,13 +41,14 @@ class Symbol(sympy.Symbol):
 
 class PauliSymbol(Symbol):
 
-    def __new__(cls, q):
-        return super().__new__(cls=cls, q=q, name=cls.__name__)
+    def __new__(cls, q, commutative=False):
+        matrix = getattr(matrices, cls.__name__)
+        return super().__new__(cls, q, matrix, cls.__name__, commutative)
 
-    def __init__(self, q):
-        self.target_qubit = q
-        self._gate = None
-        self.matrix = getattr(matrices, self.__class__.__name__)
+    def __init__(self, q, commutative=False):
+        name = self.__class__.__name__
+        matrix = getattr(matrices, name)
+        super().__init__(q, matrix, name, commutative)
 
     def calculate_gate(self):
         name = self.__class__.__name__

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -15,7 +15,7 @@ class Symbol(sympy.Symbol):
 
             from qibo import hamiltonians
             from qibo.symbols import X, Y, Z
-            # consturct an XYZ Hamiltonian on two qubits using Qibo symbols
+            # construct a XYZ Hamiltonian on two qubits using Qibo symbols
             form = X(0) * X(1) + Y(0) * Y(1) + Z(0) * Z(1)
             ham = hamiltonians.SymbolicHamiltonian(form)
 

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -38,6 +38,23 @@ class Symbol(sympy.Symbol):
     def calculate_gate(self):
         return gates.Unitary(self.matrix, self.target_qubit)
 
+    def full_matrix(self, nqubits):
+        """Calculates the full dense matrix corresponding to the symbol as part of a bigger system.
+
+        Args:
+            nqubits (int): Total number of qubits in the system.
+
+        Returns:
+            Matrix of dimension (2^nqubits, 2^nqubits) composed of the Kronecker
+            product between identities and the symbol's single-qubit matrix.
+        """
+        from qibo.hamiltonians import multikron
+        matrix_list = self.target_qubit * [matrices.I]
+        matrix_list.append(self.matrix)
+        n = nqubits - self.target_qubit - 1
+        matrix_list.extend(matrices.I for _ in range(n))
+        return multikron(matrix_list)
+
 
 class PauliSymbol(Symbol):
 

--- a/src/qibo/tests/test_core_hamiltonians_from_symbols.py
+++ b/src/qibo/tests/test_core_hamiltonians_from_symbols.py
@@ -8,7 +8,8 @@ from qibo.tests.utils import random_hermitian
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 @pytest.mark.parametrize("hamtype", ["normal", "symbolic"])
-def test_tfim_hamiltonian_from_symbols(nqubits, hamtype):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_tfim_hamiltonian_from_symbols(nqubits, hamtype, calcterms):
     """Check creating TFIM Hamiltonian using sympy."""
     if hamtype == "symbolic":
         from qibo.symbols import X, Z
@@ -29,13 +30,16 @@ def test_tfim_hamiltonian_from_symbols(nqubits, hamtype):
         symmap.update({x: (i, matrices.X) for i, x in enumerate(x_symbols)})
         ham = hamiltonians.Hamiltonian.from_symbolic(-symham, symmap)
 
+    if calcterms:
+        _ = ham.terms
     final_matrix = ham.matrix
     target_matrix = hamiltonians.TFIM(nqubits, h=h).matrix
     K.assert_allclose(final_matrix, target_matrix)
 
 
 @pytest.mark.parametrize("hamtype", ["normal", "symbolic"])
-def test_from_symbolic_with_power(hamtype):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_from_symbolic_with_power(hamtype, calcterms):
     """Check ``from_symbolic`` when the expression contains powers."""
     if hamtype == "symbolic":
         from qibo.symbols import Symbol
@@ -50,6 +54,8 @@ def test_from_symbolic_with_power(hamtype):
         symmap = {x: (i, matrix) for i, x in enumerate(z)}
         ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
 
+    if calcterms:
+        _ = ham.terms
     final_matrix = ham.matrix
     matrix2 = matrix.dot(matrix)
     eye = np.eye(2, dtype=matrix.dtype)
@@ -62,7 +68,8 @@ def test_from_symbolic_with_power(hamtype):
 
 
 @pytest.mark.parametrize("hamtype", ["normal", "symbolic"])
-def test_from_symbolic_with_complex_numbers(hamtype):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_from_symbolic_with_complex_numbers(hamtype, calcterms):
     """Check ``from_symbolic`` when the expression contains imaginary unit."""
     if hamtype == "symbolic":
         from qibo.symbols import X, Y
@@ -76,6 +83,8 @@ def test_from_symbolic_with_complex_numbers(hamtype):
         symmap.update({s: (i, matrices.Y) for i, s in enumerate(y)})
         ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
 
+    if calcterms:
+        _ = ham.terms
     final_matrix = ham.matrix
     target_matrix = (1 + 2j) * np.kron(matrices.X, matrices.X)
     target_matrix += 2 * np.kron(matrices.Y, matrices.Y)
@@ -84,7 +93,8 @@ def test_from_symbolic_with_complex_numbers(hamtype):
     K.assert_allclose(final_matrix, target_matrix)
 
 
-def test_from_symbolic_application_hamiltonian():
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_from_symbolic_application_hamiltonian(calcterms):
     """Check ``from_symbolic`` for a specific four-qubit Hamiltonian."""
     z1, z2, z3, z4 = sympy.symbols("z1 z2 z3 z4")
     symmap = {z: (i, matrices.Z) for i, z in enumerate([z1, z2, z3, z4])}
@@ -96,12 +106,15 @@ def test_from_symbolic_application_hamiltonian():
     symham = (Z(0) * Z(1) - 0.5 * Z(0) * Z(2) + 2 * Z(1) * Z(2) + 0.35 * Z(1)
               + 0.25 * Z(2) * Z(3) + 0.5 * Z(2) + Z(3) - Z(0))
     sham = hamiltonians.SymbolicHamiltonian(symham)
+    if calcterms:
+        _ = sham.terms
     K.assert_allclose(sham.matrix, fham.matrix)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 @pytest.mark.parametrize("hamtype", ["normal", "symbolic"])
-def test_x_hamiltonian_from_symbols(nqubits, hamtype):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_x_hamiltonian_from_symbols(nqubits, hamtype, calcterms):
     """Check creating sum(X) Hamiltonian using sympy."""
     if hamtype == "symbolic":
         from qibo.symbols import X
@@ -112,13 +125,16 @@ def test_x_hamiltonian_from_symbols(nqubits, hamtype):
         symham =  -sum(x_symbols)
         symmap = {x: (i, matrices.X) for i, x in enumerate(x_symbols)}
         ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
+    if calcterms:
+        _ = ham.terms
     final_matrix = ham.matrix
     target_matrix = hamiltonians.X(nqubits).matrix
     K.assert_allclose(final_matrix, target_matrix)
 
 
 @pytest.mark.parametrize("hamtype", ["normal", "symbolic"])
-def test_three_qubit_term_hamiltonian_from_symbols(hamtype):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_three_qubit_term_hamiltonian_from_symbols(hamtype, calcterms):
     """Check creating Hamiltonian with three-qubit interaction using sympy."""
     if hamtype == "symbolic":
         from qibo.symbols import X, Y, Z
@@ -142,8 +158,9 @@ def test_three_qubit_term_hamiltonian_from_symbols(hamtype):
         symham -= 2
         ham = hamiltonians.Hamiltonian.from_symbolic(symham, symmap)
 
+    if calcterms:
+        _ = ham.terms
     final_matrix = ham.matrix
-
     target_matrix = np.kron(np.kron(matrices.X, matrices.Y),
                             np.kron(matrices.Z, matrices.I))
     target_matrix += 0.5 * np.kron(np.kron(matrices.Y, matrices.Z),

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -108,8 +108,8 @@ def test_symbolic_hamiltonian_scalar_add(backend, nqubits, calcterms, calcdense)
 
 
 @pytest.mark.parametrize("nqubits", [3])
-@pytest.mark.parametrize("calcdense", [False, True])
 @pytest.mark.parametrize("calcterms", [False, True])
+@pytest.mark.parametrize("calcdense", [False, True])
 def test_symbolic_hamiltonian_scalar_sub(backend, nqubits, calcterms, calcdense):
     """Test subtraction of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
@@ -131,11 +131,16 @@ def test_symbolic_hamiltonian_scalar_sub(backend, nqubits, calcterms, calcdense)
     K.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
+@pytest.mark.parametrize("nqubits", [3])
+@pytest.mark.parametrize("calcterms", [False, True])
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_operator_add_and_sub(backend, calcdense, nqubits=3):
+def test_symbolic_hamiltonian_operator_add_and_sub(backend, nqubits, calcterms, calcdense):
     """Test addition and subtraction between Trotter Hamiltonians."""
     local_ham1 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_ham2 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5))
+    if calcterms:
+        _ = local_ham1.terms
+        _ = local_ham2.terms
     if calcdense:
         _ = local_ham1.dense
         _ = local_ham2.dense
@@ -147,6 +152,9 @@ def test_symbolic_hamiltonian_operator_add_and_sub(backend, calcdense, nqubits=3
 
     local_ham1 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_ham2 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5))
+    if calcterms:
+        _ = local_ham1.terms
+        _ = local_ham2.terms
     if calcdense:
         _ = local_ham1.dense
         _ = local_ham2.dense
@@ -157,12 +165,17 @@ def test_symbolic_hamiltonian_operator_add_and_sub(backend, calcdense, nqubits=3
     K.assert_allclose(dense.matrix, target_ham.matrix)
 
 
+@pytest.mark.parametrize("nqubits", [5])
+@pytest.mark.parametrize("calcterms", [False, True])
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_hamiltonianmatmul(backend, calcdense, nqubits=5):
+def test_symbolic_hamiltonian_hamiltonianmatmul(backend, nqubits, calcterms, calcdense):
     local_ham1 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     local_ham2 = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=0.5))
     dense_ham1 = hamiltonians.TFIM(nqubits, h=1.0)
     dense_ham2 = hamiltonians.TFIM(nqubits, h=0.5)
+    if calcterms:
+        _ = local_ham1.terms
+        _ = local_ham2.terms
     if calcdense:
         _ = local_ham1.dense
         _ = local_ham2.dense
@@ -171,9 +184,10 @@ def test_symbolic_hamiltonian_hamiltonianmatmul(backend, calcdense, nqubits=5):
     K.assert_allclose(local_matmul.matrix, target_matmul.matrix)
 
 
-@pytest.mark.parametrize("density_matrix", [False, True])
 @pytest.mark.parametrize("nqubits", [3, 4])
-def test_symbolic_hamiltonian_matmul(backend, density_matrix, nqubits):
+@pytest.mark.parametrize("density_matrix", [False, True])
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_symbolic_hamiltonian_matmul(backend, nqubits, density_matrix, calcterms):
     if density_matrix:
         from qibo.core.states import MatrixState
         shape = (2 ** nqubits, 2 ** nqubits)
@@ -184,15 +198,20 @@ def test_symbolic_hamiltonian_matmul(backend, density_matrix, nqubits):
         state = VectorState.from_tensor(random_complex(shape))
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     dense_ham = hamiltonians.TFIM(nqubits, h=1.0)
+    if calcterms:
+        _ = local_ham.terms
     local_matmul = local_ham @ state
     target_matmul = dense_ham @ state
     K.assert_allclose(local_matmul, target_matmul)
 
 
-@pytest.mark.parametrize("calcdense", [False, True])
 @pytest.mark.parametrize("nqubits,normalize", [(3, False), (4, False)])
-def test_symbolic_hamiltonian_state_ev(backend, calcdense, nqubits, normalize):
+@pytest.mark.parametrize("calcterms", [False, True])
+@pytest.mark.parametrize("calcdense", [False, True])
+def test_symbolic_hamiltonian_state_ev(backend, nqubits, normalize, calcterms, calcdense):
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0)) + 2
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     dense_ham = hamiltonians.TFIM(nqubits, h=1.0) + 2
@@ -209,11 +228,14 @@ def test_symbolic_hamiltonian_state_ev(backend, calcdense, nqubits, normalize):
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
-def test_symbolic_hamiltonian_abstract_symbol_ev(backend, density_matrix):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_symbolic_hamiltonian_abstract_symbol_ev(backend, density_matrix, calcterms):
     from qibo.symbols import X, Symbol
     matrix = np.random.random((2, 2))
     form = X(0) * Symbol(1, matrix) + Symbol(0, matrix) * X(1)
     local_ham = hamiltonians.SymbolicHamiltonian(form)
+    if calcterms:
+        _ = local_ham.terms
     if density_matrix:
         state = K.cast(random_complex((4, 4)))
     else:

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -16,29 +16,24 @@ def symbolic_tfim(nqubits, h=1.0):
     return sham
 
 
-def test_symbolic_hamiltonian_init():
-    # Wrong type of symbolic expression
-    with pytest.raises(TypeError):
-        ham = hamiltonians.SymbolicHamiltonian("test")
+def test_symbolic_hamiltonian_errors():
     # Wrong type of Symbol matrix
     from qibo.symbols import Symbol
     with pytest.raises(TypeError):
         s = Symbol(0, "test")
-    # Wrong HamiltonianTerm matrix
-    from qibo.core.terms import HamiltonianTerm
+    # Wrong type of symbolic expression
     with pytest.raises(TypeError):
-        t = HamiltonianTerm("test", 0, 1)
-    # Passing negative target qubits in HamiltonianTerm
+        ham = hamiltonians.SymbolicHamiltonian("test")
+    # Passing form with symbol that is not in ``symbol_map``
+    from qibo import matrices
+    Z, X = sympy.Symbol("Z"), sympy.Symbol("X")
+    symbol_map = {Z: (0, matrices.Z)}
     with pytest.raises(ValueError):
-        t = HamiltonianTerm("test", 0, -1)
-    # Passing matrix shape incompatible with number of qubits
-    with pytest.raises(ValueError):
-        t = HamiltonianTerm(np.random.random((4, 4)), 0, 1, 2)
-    # Merging terms with invalid qubits
-    t1 = HamiltonianTerm(np.random.random((4, 4)), 0, 1)
-    t2 = HamiltonianTerm(np.random.random((4, 4)), 1, 2)
-    with pytest.raises(ValueError):
-        t = t1.merge(t2)
+        ham = hamiltonians.SymbolicHamiltonian(Z * X, symbol_map)
+    # Invalid operation in Hamiltonian expresion
+    ham = hamiltonians.SymbolicHamiltonian(sympy.cos(Z), symbol_map)
+    with pytest.raises(TypeError):
+        dense = ham.dense
 
 
 @pytest.mark.parametrize("nqubits", [3, 4])

--- a/src/qibo/tests/test_core_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_core_hamiltonians_symbolic.py
@@ -37,14 +37,18 @@ def test_symbolic_hamiltonian_errors():
 
 
 @pytest.mark.parametrize("nqubits", [3, 4])
-def test_symbolictfim_hamiltonian_to_dense(backend, nqubits):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_symbolictfim_hamiltonian_to_dense(backend, nqubits, calcterms):
     final_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1))
     target_ham = hamiltonians.TFIM(nqubits, h=1)
+    if calcterms:
+        _ = final_ham.terms
     K.assert_allclose(final_ham.matrix, target_ham.matrix, atol=1e-15)
 
 
 @pytest.mark.parametrize("nqubits", [3, 4])
-def test_symbolicxxz_hamiltonian_to_dense(backend, nqubits):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_symbolicxxz_hamiltonian_to_dense(backend, nqubits, calcterms):
     from qibo.symbols import X, Y, Z
     sham = sum(X(i) * X(i + 1) for i in range(nqubits - 1))
     sham += sum(Y(i) * Y(i + 1) for i in range(nqubits - 1))
@@ -52,48 +56,66 @@ def test_symbolicxxz_hamiltonian_to_dense(backend, nqubits):
     sham += X(0) * X(nqubits - 1) + Y(0) * Y(nqubits - 1) + 0.5 * Z(0) * Z(nqubits - 1)
     final_ham = hamiltonians.SymbolicHamiltonian(sham)
     target_ham = hamiltonians.XXZ(nqubits)
+    if calcterms:
+        _ = final_ham.terms
     K.assert_allclose(final_ham.matrix, target_ham.matrix, atol=1e-15)
 
 
+@pytest.mark.parametrize("nqubits", [3])
+@pytest.mark.parametrize("calcterms", [False, True])
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_scalar_mul(backend, calcdense, nqubits=3):
+def test_symbolic_hamiltonian_scalar_mul(backend, nqubits, calcterms, calcdense):
     """Test multiplication of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 * hamiltonians.TFIM(nqubits, h=1.0)
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     local_dense = (2 * local_ham).dense
     K.assert_allclose(local_dense.matrix, target_ham.matrix)
 
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     local_dense = (local_ham * 2).dense
     K.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
+@pytest.mark.parametrize("nqubits", [4])
+@pytest.mark.parametrize("calcterms", [False, True])
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_scalar_add(backend, calcdense, nqubits=4):
+def test_symbolic_hamiltonian_scalar_add(backend, nqubits, calcterms, calcdense):
     """Test addition of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 + hamiltonians.TFIM(nqubits, h=1.0)
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     local_dense = (2 + local_ham).dense
     K.assert_allclose(local_dense.matrix, target_ham.matrix)
 
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     local_dense = (local_ham + 2).dense
     K.assert_allclose(local_dense.matrix, target_ham.matrix)
 
 
+@pytest.mark.parametrize("nqubits", [3])
 @pytest.mark.parametrize("calcdense", [False, True])
-def test_symbolic_hamiltonian_scalar_sub(backend, calcdense, nqubits=3):
+@pytest.mark.parametrize("calcterms", [False, True])
+def test_symbolic_hamiltonian_scalar_sub(backend, nqubits, calcterms, calcdense):
     """Test subtraction of Trotter Hamiltonian with scalar."""
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
     target_ham = 2 - hamiltonians.TFIM(nqubits, h=1.0)
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     local_dense = (2 - local_ham).dense
@@ -101,6 +123,8 @@ def test_symbolic_hamiltonian_scalar_sub(backend, calcdense, nqubits=3):
 
     target_ham = hamiltonians.TFIM(nqubits, h=1.0) - 2
     local_ham = hamiltonians.SymbolicHamiltonian(symbolic_tfim(nqubits, h=1.0))
+    if calcterms:
+        _ = local_ham.terms
     if calcdense:
         _ = local_ham.dense
     local_dense = (local_ham - 2).dense

--- a/src/qibo/tests/test_core_hamiltonians_trotter.py
+++ b/src/qibo/tests/test_core_hamiltonians_trotter.py
@@ -104,7 +104,8 @@ def test_trotter_hamiltonian_three_qubit_term(backend):
 
     terms = [HamiltonianTerm(m1, 0, 1, 2), HamiltonianTerm(m2, 2, 3),
              HamiltonianTerm(m3, 1)]
-    ham = hamiltonians.SymbolicHamiltonian.from_terms(terms)
+    ham = hamiltonians.SymbolicHamiltonian()
+    ham.terms = terms
 
     # Test that the `TrotterHamiltonian` dense matrix is correct
     eye = np.eye(2, dtype=m1.dtype)

--- a/src/qibo/tests/test_core_terms.py
+++ b/src/qibo/tests/test_core_terms.py
@@ -18,6 +18,24 @@ def test_hamiltonian_term_initialization(backend):
     K.assert_allclose(term.matrix, matrix)
 
 
+def test_hamiltonian_term_initialization_errors():
+    """Test initializing ``HamiltonianTerm`` with wrong parameters."""
+    # Wrong HamiltonianTerm matrix
+    with pytest.raises(TypeError):
+        t = terms.HamiltonianTerm("test", 0, 1)
+    # Passing negative target qubits in HamiltonianTerm
+    with pytest.raises(ValueError):
+        t = terms.HamiltonianTerm("test", 0, -1)
+    # Passing matrix shape incompatible with number of qubits
+    with pytest.raises(ValueError):
+        t = terms.HamiltonianTerm(np.random.random((4, 4)), 0, 1, 2)
+    # Merging terms with invalid qubits
+    t1 = terms.HamiltonianTerm(np.random.random((4, 4)), 0, 1)
+    t2 = terms.HamiltonianTerm(np.random.random((4, 4)), 1, 2)
+    with pytest.raises(ValueError):
+        t = t1.merge(t2)
+
+
 def test_hamiltonian_term_gates(backend):
     """Test gate application of ``HamiltonianTerm``."""
     matrix = np.random.random((4, 4))

--- a/src/qibo/tests/test_core_terms.py
+++ b/src/qibo/tests/test_core_terms.py
@@ -81,7 +81,7 @@ def test_symbolic_term_creation(use_symbols):
     if use_symbols:
         from qibo.symbols import X, Y
         expression = X(0) * Y(1) * X(1)
-        symbol_map = None
+        symbol_map = {}
     else:
         import sympy
         x0, x1, y1 = sympy.symbols("X0 X1 Y1", commutative=False)

--- a/src/qibo/tests/test_core_terms.py
+++ b/src/qibo/tests/test_core_terms.py
@@ -96,6 +96,28 @@ def test_symbolic_term_creation(use_symbols):
     K.assert_allclose(term.matrix_map.get(1)[1], matrices.X)
 
 
+def test_symbolic_term_with_power_creation():
+    """Test creating ``SymbolicTerm`` from sympy expression that contains powers."""
+    from qibo.symbols import X, Z
+    expression = X(0) ** 4 * Z(1) ** 2 * X(2)
+    term = terms.SymbolicTerm(2, expression)
+    assert term.target_qubits == (0, 1, 2)
+    assert len(term.matrix_map) == 3
+    assert term.coefficient == 2
+    K.assert_allclose(term.matrix_map.get(0), 4 * [matrices.X])
+    K.assert_allclose(term.matrix_map.get(1), 2 * [matrices.Z])
+    K.assert_allclose(term.matrix_map.get(2), [matrices.X])
+
+
+def test_symbolic_term_with_imag_creation():
+    """Test creating ``SymbolicTerm`` from sympy expression that contains imaginary coefficients."""
+    from qibo.symbols import Y
+    expression = 3j * Y(0)
+    term = terms.SymbolicTerm(2, expression)
+    assert term.target_qubits == (0,)
+    assert term.coefficient == 6j
+
+
 def test_symbolic_term_matrix(backend):
     """Test matrix calculation of ``SymbolicTerm``."""
     from qibo.symbols import X, Y, Z

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -19,7 +19,7 @@ models_config = [
     ("MaxCut", {"nqubits": 5}, "maxcut_N5.out"),
 ]
 @pytest.mark.parametrize(("model", "kwargs", "filename"), models_config)
-def test_tfim_model_hamiltonian(model, kwargs, filename):
+def test_hamiltonian_models(model, kwargs, filename):
     """Test pre-coded Hamiltonian models generate the proper matrices."""
     from qibo.tests.test_models_variational import assert_regression_fixture
     H = getattr(hamiltonians, model)(**kwargs)
@@ -28,7 +28,8 @@ def test_tfim_model_hamiltonian(model, kwargs, filename):
 
 
 @pytest.mark.parametrize("nqubits", [3, 4])
-def test_maxcut(nqubits):
+@pytest.mark.parametrize("dense,calcterms", [(True, False), (False, False), (False, True)])
+def test_maxcut(nqubits, dense, calcterms):
     size = 2 ** nqubits
     ham = np.zeros(shape=(size, size), dtype=np.complex128)
     for i in range(nqubits):
@@ -42,5 +43,7 @@ def test_maxcut(nqubits):
             M = np.eye(2**nqubits) - h
             ham += M
     target_ham = K.cast(- ham / 2)
-    final_ham = hamiltonians.MaxCut(nqubits)
+    final_ham = hamiltonians.MaxCut(nqubits, dense)
+    if (not dense) and calcterms:
+        _ = final_ham.terms
     K.assert_allclose(final_ham.matrix, target_ham)


### PR DESCRIPTION
Fixes #469. As discussed in the issue, the main bottleneck comes from the `sympy.expand` call that is used on the given sympy expression of the Hamiltonian form when a `SymbolicHamiltonian` is constructed. This call is useful when parsing the symbolic terms to [Qibo terms](https://github.com/qiboteam/qibo/blob/sympyexpand/src/qibo/core/terms.py). Given that the Qibo term representation of Hamiltonian is only useful when trotterizing, here I disable this calculation unless it is required (eg. when the user asks for trotterization). The idea is that Hamiltonians that cause #469 are non-local and therefore trotterization won't be useful for them anyway, so it will be unlikely that the user will get this performance issue.

The second part implemented here is a function that calulates the full Hamiltonian matrix directly from the given expression without the need to expand, because in the current implementation the Qibo terms are used which need the expanded form. In principle this should be straightforward as all we need is the `sympy.Expr.subs` method to substitute symbols with the corresponding matrices (numpy arrays), however this does not seem to work well when using `sympy.Symbol` instead of `sympy.MatrixSymbol`. I have been playing around a bit with sympy and trying to inherit Qibo symbols from `MatrixSymbol` instead of `Symbol` as it is now and here is a short summary of my understanding:

Pros of `MatrixSymbol`:
* Given that quantum operators have the properties of matrices (eg. are non-commuting), strictly speaking, this should be the correct way to go.
* Sympy algebra behaves better when substituting with arrays.

Cons of `MatrixSymbol`:
* New objects are created when used in operations. For example
```Python
import sympy

n = sympy.Symbol("n")
X = sympy.MatrixSymbol("X", n, n)
Y = sympy.MatrixSymbol("Y", n, n)
Z = X * Y
print(id(X), id(Y))
for t in Z.free_terms:
    print(id(t))
```
will print different ids if `MatrixSymbol` is used and same ids if `Symbol` is used. Not creating new objects is important when inheriting in Qibo.
* We would need to use an identity symbol instead of just `1` as `MatrixSymbol` do not like operations with numbers. This would break our current API, for example `2 + Z(0)` will no longer work and we would need to do something like `2 * I + Z(0)`.
* `MatrixSymbol` is non-commutative by default, while in `Symbol` we can select this property during creation.

Taking into account this, I ended up leaving the `Symbol` as it is and just writing [a function that does the substitution](https://github.com/qiboteam/qibo/blob/e5086b90b6dd7818b6113fecb5fc74d3e2b52bc5/src/qibo/core/hamiltonians.py#L317) with numpy arrays myself. This is kind of reinventing the wheel as this should have been possible using just `.subs`, but unfortunately is the cleanest solution I could find.

Following the last comment from #469, I also added the option to make Qibo symbols commutative using `commutative=True` during creation, although this is generally not recommended.