### PR TITLE
Fix some examples in docstrings

### DIFF
--- a/src/qibo/abstractions/callbacks.py
+++ b/src/qibo/abstractions/callbacks.py
@@ -166,7 +166,8 @@ class Gap(Callback):
     Example:
         ::
 
-            from qibo import models, callbacks
+            from qibo import callbacks, hamiltonians
+            from qibo.models import AdiabaticEvolution
             # define easy and hard Hamiltonians for adiabatic evolution
             h0 = hamiltonians.X(3)
             h1 = hamiltonians.TFIM(3, h=1.0)

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1114,14 +1114,11 @@ class VariationalLayer(ParametrizedGate):
             from qibo import gates
             # generate an array of variational parameters for 8 qubits
             theta = 2 * np.pi * np.random.random(8)
-
             # define qubit pairs that two qubit gates will act
             pairs = [(i, i + 1) for i in range(0, 7, 2)]
-            # map variational parameters to qubit IDs
-            theta_map = {i: th for i, th in enumerate(theta}
             # define a circuit of 8 qubits and add the variational layer
             c = Circuit(8)
-            c.add(gates.VariationalLayer(pairs, gates.RY, gates.CZ, theta_map))
+            c.add(gates.VariationalLayer(range(8), pairs, gates.RY, gates.CZ, theta))
             # this will create an optimized version of the following circuit
             c2 = Circuit(8)
             c.add((gates.RY(i, th) for i, th in enumerate(theta)))
@@ -1272,17 +1269,18 @@ class KrausChannel(Channel):
     Example:
         ::
 
+            import numpy as np
             from qibo.models import Circuit
             from qibo import gates
             # initialize circuit with 3 qubits
-            c = Circuit(3)
+            c = Circuit(3, density_matrix=True)
             # define a sqrt(0.4) * X gate
             a1 = np.sqrt(0.4) * np.array([[0, 1], [1, 0]])
             # define a sqrt(0.6) * CNOT gate
             a2 = np.sqrt(0.6) * np.array([[1, 0, 0, 0], [0, 1, 0, 0],
                                           [0, 0, 0, 1], [0, 0, 1, 0]])
             # define the channel rho -> 0.4 X{1} rho X{1} + 0.6 CNOT{0, 2} rho CNOT{0, 2}
-            channel = gates.GeneralChannel([((1,), a1), ((0, 2), a2)])
+            channel = gates.KrausChannel([((1,), a1), ((0, 2), a2)])
             # add the channel to the circuit
             c.add(channel)
     """

--- a/src/qibo/models/evolution.py
+++ b/src/qibo/models/evolution.py
@@ -44,7 +44,7 @@ class StateEvolution:
             # initialize state to |+++>
             initial_state = np.ones(8) / np.sqrt(8)
             # execute evolution for total time T=2
-            final_state2 = evolve(T=2, initial_state)
+            final_state2 = evolve(final_time=2, initial_state=initial_state)
     """
 
     def __init__(self, hamiltonian, dt, solver="exp", callbacks=[],

--- a/src/qibo/models/grover.py
+++ b/src/qibo/models/grover.py
@@ -40,6 +40,7 @@ class Grover(object):
 
             import numpy as np
             from qibo import gates
+            from qibo.models import Circuit
             from qibo.models.grover import Grover
             # Create an oracle. Ex: Oracle that detects state |11111>
             oracle = Circuit(5 + 1)
@@ -48,7 +49,7 @@ class Grover(object):
             superposition = Circuit(5)
             superposition.add([gates.H(i) for i in range(5)])
             # Generate and execute Grover class
-            grover = Grover(oracle, superposition_circuit=superposition, number_solution=1)
+            grover = Grover(oracle, superposition_circuit=superposition, number_solutions=1)
             solution, iterations = grover()
     """
 

--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -126,7 +126,7 @@ class QAOA(object):
             # optimize using random initial variational parameters
             # and default options and initial state
             initial_parameters = 0.01 * np.random.random(4)
-            best_energy, final_parameters = qaoa.minimize(initial_parameters, method="BFGS")
+            best_energy, final_parameters, extra = qaoa.minimize(initial_parameters, method="BFGS")
     """
     from qibo import hamiltonians, optimizers
     from qibo.core import states
@@ -318,6 +318,7 @@ class FALQON(QAOA):
             # optimize using random initial variational parameters
             # and default options and initial state
             delta_t = 0.01
+            max_layers = 3
             best_energy, final_parameters, extra = falqon.minimize(delta_t, max_layers)
     """
 


### PR DESCRIPTION
In this PR I fixed some broken examples in the docstrings. I haven't made an exhaustive search so some examples may still be broken.

Let me know if it is all ok, in particular with the ``VariationalLayer`` (I had to change a lot to fix it)