### PR TITLE
Remove some hard-coded ``np.linalg`` calls from tests

### DIFF
--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -323,7 +323,7 @@ def test_gap(backend, dense, check_degenerate):
     ham = lambda t: (1 - t) * h0.matrix + t * h1.matrix
     targets = {"ground": [], "excited": [], "gap": []}
     for t in np.linspace(0, 1, 11):
-        eigvals = np.linalg.eigvalsh(ham(t)).real
+        eigvals = K.eigvalsh(ham(t)).real
         targets["ground"].append(eigvals[0])
         targets["excited"].append(eigvals[1])
         targets["gap"].append(eigvals[1] - eigvals[0])

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -323,7 +323,7 @@ def test_gap(backend, dense, check_degenerate):
     ham = lambda t: (1 - t) * h0.matrix + t * h1.matrix
     targets = {"ground": [], "excited": [], "gap": []}
     for t in np.linspace(0, 1, 11):
-        eigvals = K.eigvalsh(ham(t)).real
+        eigvals = K.real(K.eigvalsh(ham(t)))
         targets["ground"].append(eigvals[0])
         targets["excited"].append(eigvals[1])
         targets["gap"].append(eigvals[1] - eigvals[0])

--- a/src/qibo/tests/test_core_hamiltonians.py
+++ b/src/qibo/tests/test_core_hamiltonians.py
@@ -173,17 +173,17 @@ def test_hamiltonian_eigenvalues(dtype, dense):
     H1 = hamiltonians.XXZ(nqubits=2, delta=0.5, dense=dense)
 
     H1_eigen = H1.eigenvalues()
-    hH1_eigen = np.linalg.eigvalsh(H1.matrix)
+    hH1_eigen = K.eigvalsh(H1.matrix)
     K.assert_allclose(H1_eigen, hH1_eigen)
 
     c1 = dtype(2.5)
     H2 = c1 * H1
-    hH2_eigen = np.linalg.eigvalsh(c1 * H1.matrix)
+    hH2_eigen = K.eigvalsh(c1 * H1.matrix)
     K.assert_allclose(H2._eigenvalues, hH2_eigen)
 
     c2 = dtype(-11.1)
     H3 = H1 * c2
-    hH3_eigen = np.linalg.eigvalsh(H1.matrix * c2)
+    hH3_eigen = K.eigvalsh(H1.matrix * c2)
     K.assert_allclose(H3._eigenvalues, hH3_eigen)
 
 


### PR DESCRIPTION
In this PR and in https://github.com/qiboteam/qibojit/pull/36 I am trying to fix issue https://github.com/qiboteam/qibojit/issues/34 concerning tests with AMD GPUs.

In particular, there are two tests in Qibo with calls to ``np.linalg.eigh`` and ``np.linalg.eigvalsh``.
When these calls are performed with a CuPy object as argument, it seems that somehow there is a automatic call to ``cp.linalg.eigh`` or ``cp.linalg.eigvalsh`` (I think that this behavior is very confusing).
The problem is that this behavior bypasses the fallback mechanism implemented in https://github.com/qiboteam/qibojit/pull/36 and a ``rocblas_not_implemented_status`` error is raised.

The easiest fix is to replace the hard-coded call to NumPy with the backend ``K`` in these tests.
However, I wonder if there was a specific reason to use NumPy in these tests, e.g. to compare the results with ``K``.
@scarrazza @stavros11 what do you think?

