### PR TITLE
disabling py36

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         pip install .[tests,docs]
         pip install qibojit --pre
     - name: Install qibotf
-      if: startsWith(matrix.os, 'windows') == 0 && matrix.python-version != '3.6'
+      if: startsWith(matrix.os, 'windows') == 0
       run: |
         pip install qibotf --pre
     - name: Install package on Windows
@@ -47,7 +47,7 @@ jobs:
       run: |
         pytest --cov=qibo --cov-report=xml --pyargs qibo --durations=60
     - name: Test documentation examples
-      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version != '3.6'
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt install pandoc
         make -C doc doctest

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -16,11 +16,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set numba version for macos
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        python -m pip install --upgrade pip
-        pip install numba==0.53.1
     - name: Install package
       if: startsWith(matrix.os, 'windows') == 0
       run: |

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -18,7 +18,7 @@ distributed with pypi* for the packages listed above.
 +------------------+------+---------+--------+------------+
 
 .. note::
-      All packages are supported for Python >= 3.6.
+      All packages are supported for Python >= 3.7.
 
 
 Backend installation
@@ -38,7 +38,7 @@ Installing with pip
 """""""""""""""""""
 
 The installation using ``pip`` is the recommended approach to install Qibo.
-Make sure you have Python 3.6 or greater, then use ``pip`` to install ``qibo`` with:
+Make sure you have Python 3.7 or greater, then use ``pip`` to install ``qibo`` with:
 
 .. code-block:: bash
 
@@ -104,7 +104,7 @@ In order to install the package use the following command:
 
 .. code-block:: bash
 
-      pip install qibo[qibojit]
+      pip install qibo qibojit
 
 .. note::
       The ``pip`` program will download and install all the required
@@ -174,13 +174,13 @@ Installing with pip
 
 The installation using ``pip`` is the recommended approach to install
 ``qibotf``. We provide precompiled packages for linux x86/64 and macosx 10.15 or
-greater for Python 3.6, 3.7, 3.8 and 3.9.
+greater for Python 3.7, 3.8 and 3.9.
 
 In order to install the package use the following command:
 
 .. code-block:: bash
 
-      pip install qibo[qibotf]
+      pip install qibo qibotf
 
 The ``pip`` program will download and install all the required
 dependencies.
@@ -285,7 +285,7 @@ In order to install the package, we recommend the installation using:
 
 .. code-block:: bash
 
-      pip install qibo[tensorflow]
+      pip install qibo tensorflow
 
 .. note::
       TensorFlow can be installed following its `documentation

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -50,14 +50,14 @@ dependencies for Qibo.
 Installing with conda
 """""""""""""""""""""
 
-We provide conda packages for ``qibo`` through the `conda-forge
+We provide conda packages for ``qibo`` and ``qibojit`` through the `conda-forge
 <https://anaconda.org/conda-forge>`_ channel.
 
-To install both packages ``qibo`` package with conda run:
+To install both packages with conda run:
 
 .. code-block:: bash
 
-      conda install -c conda-forge qibo
+      conda install -c conda-forge qibo qibojit
 
 
 Installing from source

--- a/doc/source/getting-started/quickstart.rst
+++ b/doc/source/getting-started/quickstart.rst
@@ -2,11 +2,11 @@ Quick start
 -----------
 
 To quickly install Qibo and a high performance simulator for CPU, open a
-terminal with python > 3.6 and type:
+terminal with python >= 3.7 and type:
 
 .. code-block:: bash
 
-      pip install qibo[qibojit]
+      pip install qibo qibojit
 
 This will install the basic primitives to start coding quantum applications.
 

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,8 @@ setup(
     extras_require={
         "docs": ["sphinx", "sphinx_rtd_theme", "recommonmark", "sphinxcontrib-bibtex", "sphinx_markdown_tables", "nbsphinx", "IPython"],
         "tests": ["pytest", "cirq", "ply", "sklearn"],
-        # Backends dependencies
-        "qibotf": ["qibotf"],
-        "qibojit": ["qibojit"],
-        "tensorflow": [f"tensorflow>=2.2.0"],
     },
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     long_description=long_description,
     long_description_content_type='text/markdown',
 )


### PR DESCRIPTION
Here we remove python3.6 support and simplify some installation targets.