### PR TITLE
Fix CPU fallback

### DIFF
--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -152,7 +152,7 @@ class MeasurementResult:
             measured shots.
         """
         if self._frequencies is None:
-            self._frequencies = K.cpu_fallback(self._calculate_frequencies)
+            self._frequencies = self._calculate_frequencies
         if binary:
             return collections.Counter(
                 {"{0:b}".format(k).zfill(self.nqubits): v

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -152,7 +152,7 @@ class MeasurementResult:
             measured shots.
         """
         if self._frequencies is None:
-            self._frequencies = self._calculate_frequencies
+            self._frequencies = self._calculate_frequencies()
         if binary:
             return collections.Counter(
                 {"{0:b}".format(k).zfill(self.nqubits): v

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -152,7 +152,7 @@ class MeasurementResult:
             measured shots.
         """
         if self._frequencies is None:
-            self._frequencies = self._calculate_frequencies()
+            self._frequencies = K.cpu_fallback(self._calculate_frequencies)
         if binary:
             return collections.Counter(
                 {"{0:b}".format(k).zfill(self.nqubits): v

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -79,7 +79,7 @@ class VectorState(AbstractState):
     def probabilities(self, qubits=None, measurement_gate=None):
         unmeasured_qubits = tuple(i for i in range(self.nqubits)
                                   if i not in qubits)
-        state = K.reshape(K.square(K.abs(self.tensor)), self.nqubits * (2,))
+        state = K.reshape(K.square(K.abs(K.cast(self.tensor))), self.nqubits * (2,))
         return K.sum(state, axis=unmeasured_qubits)
 
     def measure(self, gate, nshots, registers=None):


### PR DESCRIPTION
Linked to PR https://github.com/qiboteam/qibojit/pull/48 .

When using CuPy, the fallback to CPU doesn't work well because we change device but we don't cast the arrays to Numpy. A added a cast operation in ``core.states.VectorState.probabilities()`` to fix https://github.com/qiboteam/qibojit/issues/46, but I also needed to implement the fallback for the computation of frequencies, which has the same memory issue.

This PR is still work in progress, as I need to understand if everything works fine.

https://github.com/qiboteam/qibojit/blob/74733be84dcaa8753863df2efa1773ad6cf27110/src/qibojit/custom_operators/__init__.py#L197-L211

In ``JITCustomBackend`` we already have an automatic fallback to Numba + casting operation (see the link above), but there's an execution branch in which we call the method from Numpy backend, that will call CuPy for the random methods because there is not a change of device.
@stavros11 do you see a better method to solve this issue? Maybe it's better to properly force the fallback in ``JITCustomBackend`` and not change ``measurements.py`` at all.