### PR TITLE
Fix CI running twice

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
   release:
     types:
       - published
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,7 +1,7 @@
 # A single CI script with github workflow
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
In #475 a trigger on pull requests was added to the workflows.
I think we should remove it otherwise the CI runs twice for each push to a branch with an open PR.