### PR TITLE
State in computational basis

### DIFF
--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -69,6 +69,14 @@ class AbstractState(ABC):
         self._tensor = x
 
     @abstractmethod
+    def symbolic(self, decimals=5):  # pragma: no cover
+        """Dirac notation representation of the state in the computational basis."""
+        raise_error(NotImplementedError)
+
+    def __repr__(self):
+        return self.symbolic()
+
+    @abstractmethod
     def __array__(self): # pragma: no cover
         """State's tensor representation as an array."""
         raise_error(NotImplementedError)
@@ -78,7 +86,7 @@ class AbstractState(ABC):
         """State's tensor representation as a numpy array."""
         raise_error(NotImplementedError)
 
-    def state(self, numpy=False):
+    def state(self, numpy=False, symbolic=False):
         """State's tensor representation as an backend tensor.
 
         Args:
@@ -86,6 +94,8 @@ class AbstractState(ABC):
                 otherwise it will follow the backend tensor type.
                 Default is ``False``.
         """
+        if symbolic:
+            return self.symbolic()
         if numpy:
             return self.numpy()
         return self.tensor

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -93,6 +93,9 @@ class AbstractState(ABC):
             numpy (bool): If ``True`` the returned tensor will be a numpy array,
                 otherwise it will follow the backend tensor type.
                 Default is ``False``.
+            symbolic (bool): If ``True`` it returns a string representing the
+                state in the computational basis.
+                Default is ``False``.
         """
         if symbolic:
             return self.symbolic()

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -69,8 +69,19 @@ class AbstractState(ABC):
         self._tensor = x
 
     @abstractmethod
-    def symbolic(self, decimals=5):  # pragma: no cover
-        """Dirac notation representation of the state in the computational basis."""
+    def symbolic(self, decimals=5, max_terms=20):  # pragma: no cover
+        """Dirac notation representation of the state in the computational basis.
+
+        Args:
+            decimals (int): Number of decimals for the amplitudes.
+                Default is 5.
+            max_terms (int): Maximum number of terms to print. If the state
+                contains more terms they will be ignored.
+                Default is 20.
+
+        Returns:
+            A string representing the state in the computational basis.
+        """
         raise_error(NotImplementedError)
 
     def __repr__(self):

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -100,19 +100,31 @@ class AbstractState(ABC):
         """State's tensor representation as a numpy array."""
         raise_error(NotImplementedError)
 
-    def state(self, numpy=False, symbolic=False):
+    def state(self, numpy=False, decimals=-1, cutoff=1e-10, max_terms=20):
         """State's tensor representation as an backend tensor.
 
         Args:
             numpy (bool): If ``True`` the returned tensor will be a numpy array,
                 otherwise it will follow the backend tensor type.
                 Default is ``False``.
-            symbolic (bool): If ``True`` it returns a string representing the
-                state in the computational basis.
-                Default is ``False``.
+            decimals (int): If positive the Diract representation of the state
+                in the computational basis will be returned as a string.
+                ``decimals`` will be the number of decimals of each amplitude.
+                Default is -1.
+            cutoff (float): Amplitudes with absolute value smaller than the
+                cutoff are ignored from the Dirac representation.
+                Ignored if ``decimals < 0``. Default is 1e-10.
+            max_terms (int): Maximum number of terms in the Dirac representation.
+                If the state contains more terms they will be ignored.
+                Ignored if ``decimals < 0``. Default is 20.
+
+        Returns:
+            If ``decimals < 0`` a tensor representing the state in the computational
+            basis, otherwise a string with the Dirac representation of the state
+            in the computational basis.
         """
-        if symbolic:
-            return self.symbolic()
+        if decimals >= 0:
+            return self.symbolic(decimals, cutoff, max_terms)
         if numpy:
             return self.numpy()
         return self.tensor

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -69,12 +69,15 @@ class AbstractState(ABC):
         self._tensor = x
 
     @abstractmethod
-    def symbolic(self, decimals=5, max_terms=20):  # pragma: no cover
+    def symbolic(self, decimals=5, cutoff=1e-10, max_terms=20):  # pragma: no cover
         """Dirac notation representation of the state in the computational basis.
 
         Args:
             decimals (int): Number of decimals for the amplitudes.
                 Default is 5.
+            cutoff (float): Amplitudes with absolute value smaller than the
+                cutoff are ignored from the representation.
+                Default is 1e-10.
             max_terms (int): Maximum number of terms to print. If the state
                 contains more terms they will be ignored.
                 Default is 20.

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -38,13 +38,14 @@ class VectorState(AbstractState):
     def numpy(self):
         return self.__array__()
 
-    def symbolic(self, decimals=5, max_terms=20):
+    def symbolic(self, decimals=5, cutoff=1e-10, max_terms=20):
         state = self.numpy()
         terms = []
         for i in K.np.nonzero(state)[0]:
             b = bin(i)[2:].zfill(self.nqubits)
-            x = round(state[i], decimals)
-            terms.append(f"{x}|{b}>")
+            if K.np.abs(state[i]) >= cutoff:
+                x = round(state[i], decimals)
+                terms.append(f"{x}|{b}>")
             if len(terms) >= max_terms:
                 terms.append("...")
                 break
@@ -144,15 +145,16 @@ class VectorState(AbstractState):
 
 class MatrixState(VectorState):
 
-    def symbolic(self, decimals=5, max_terms=20):
+    def symbolic(self, decimals=5, cutoff=1e-10, max_terms=20):
         state = self.numpy()
         terms = []
         indi, indj = K.np.nonzero(state)
         for i, j in zip(indi, indj):
             bi = bin(i)[2:].zfill(self.nqubits)
             bj = bin(j)[2:].zfill(self.nqubits)
-            x = round(state[i, j], decimals)
-            terms.append(f"{x}|{bi}><{bj}|")
+            if K.np.abs(state[i, j]) >= cutoff:
+                x = round(state[i, j], decimals)
+                terms.append(f"{x}|{bi}><{bj}|")
             if len(terms) >= max_terms:
                 terms.append("...")
                 break

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -144,6 +144,20 @@ class VectorState(AbstractState):
 
 class MatrixState(VectorState):
 
+    def symbolic(self, decimals=5, max_terms=20):
+        state = self.numpy()
+        terms = []
+        indi, indj = K.np.nonzero(state)
+        for i, j in zip(indi, indj):
+            bi = bin(i)[2:].zfill(self.nqubits)
+            bj = bin(j)[2:].zfill(self.nqubits)
+            x = round(state[i, j], decimals)
+            terms.append(f"{x}|{bi}><{bj}|")
+            if len(terms) >= max_terms:
+                terms.append("...")
+                break
+        return " + ".join(terms)
+
     @property
     def shape(self):
         return (self.nstates, self.nstates)

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -39,11 +39,12 @@ class VectorState(AbstractState):
         return self.__array__()
 
     def symbolic(self, decimals=5, max_terms=20):
+        state = self.numpy()
         terms = []
-        for i, x in enumerate(self.numpy()):
-            if not K.np.isclose(x, 0.0):
-                b = bin(i)[2:].zfill(self.nqubits)
-                terms.append(f"{round(x, decimals)}|{b}>")
+        for i in K.np.nonzero(state)[0]:
+            b = bin(i)[2:].zfill(self.nqubits)
+            x = round(state[i], decimals)
+            terms.append(f"{x}|{b}>")
             if len(terms) >= max_terms:
                 terms.append("...")
                 break

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -38,10 +38,15 @@ class VectorState(AbstractState):
     def numpy(self):
         return self.__array__()
 
-    def symbolic(self, decimals=5):
-        terms = (f"{round(x, decimals)}|{bin(i)[2:].zfill(self.nqubits)}>"
-                 for i, x in enumerate(self.numpy())
-                 if not K.np.isclose(x, 0.0))
+    def symbolic(self, decimals=5, max_terms=20):
+        terms = []
+        for i, x in enumerate(self.numpy()):
+            if not K.np.isclose(x, 0.0):
+                b = bin(i)[2:].zfill(self.nqubits)
+                terms.append(f"{round(x, decimals)}|{b}>")
+            if len(terms) >= max_terms:
+                terms.append("...")
+                break
         return " + ".join(terms)
 
     @classmethod

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -38,6 +38,12 @@ class VectorState(AbstractState):
     def numpy(self):
         return self.__array__()
 
+    def symbolic(self, decimals=5):
+        terms = (f"{round(x, decimals)}|{bin(i)[2:].zfill(self.nqubits)}>"
+                 for i, x in enumerate(self.numpy())
+                 if not K.np.isclose(x, 0.0))
+        return " + ".join(terms)
+
     @classmethod
     def zero_state(cls, nqubits):
         state = cls(nqubits)

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -82,6 +82,15 @@ def test_state_vector_representation(target):
     assert result.symbolic(decimals=2) == f"(0.71+0j)|00000> + (0.71+0j)|{bstring}>"
 
 
+def test_state_vector_representation_max_terms():
+    from qibo import models, gates
+    c = models.Circuit(5)
+    c.add(gates.H(i) for i in range(5))
+    result = c()
+    assert result.symbolic(max_terms=3) == "(0.17678+0j)|00000> + (0.17678+0j)|00001> + (0.17678+0j)|00010> + ..."
+    assert result.symbolic(max_terms=5) == "(0.17678+0j)|00000> + (0.17678+0j)|00001> + (0.17678+0j)|00010> + (0.17678+0j)|00011> + (0.17678+0j)|00100> + ..."
+
+
 @pytest.mark.parametrize("state_type", ["VectorState", "MatrixState"])
 @pytest.mark.parametrize("use_gate", [False, True])
 def test_state_probabilities(backend, state_type, use_gate):

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -70,7 +70,7 @@ def test_vector_state_to_density_matrix(backend):
 
 @pytest.mark.parametrize("target", range(5))
 @pytest.mark.parametrize("density_matrix", [False, True])
-def test_state_vector_representation(target, density_matrix):
+def test_state_representation(target, density_matrix):
     from qibo import models, gates
     c = models.Circuit(5, density_matrix=density_matrix)
     c.add(gates.H(target))
@@ -89,7 +89,7 @@ def test_state_vector_representation(target, density_matrix):
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
-def test_state_vector_representation_max_terms(density_matrix):
+def test_state_representation_max_terms(density_matrix):
     from qibo import models, gates
     c = models.Circuit(5, density_matrix=density_matrix)
     c.add(gates.H(i) for i in range(5))
@@ -100,6 +100,15 @@ def test_state_vector_representation_max_terms(density_matrix):
     else:
         assert result.symbolic(max_terms=3) == "(0.17678+0j)|00000> + (0.17678+0j)|00001> + (0.17678+0j)|00010> + ..."
         assert result.symbolic(max_terms=5) == "(0.17678+0j)|00000> + (0.17678+0j)|00001> + (0.17678+0j)|00010> + (0.17678+0j)|00011> + (0.17678+0j)|00100> + ..."
+
+
+def test_state_representation_cutoff():
+    from qibo import models, gates
+    c = models.Circuit(2)
+    c.add(gates.RX(0, theta=0.1))
+    result = c()
+    assert result.symbolic() == "(0.99875+0j)|00> + -0.04998j|10>"
+    assert result.symbolic(cutoff=0.1) == "(0.99875+0j)|00>"
 
 
 @pytest.mark.parametrize("state_type", ["VectorState", "MatrixState"])

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -83,7 +83,7 @@ def test_state_representation(target, density_matrix):
                       f"(0.7+0j)|00000> + (0.7+0j)|{bstring}>",
                       f"(0.71+0j)|00000> + (0.71+0j)|{bstring}>"]
     assert str(result) == target_str[0]
-    assert result.state(symbolic=True) == target_str[0]
+    assert result.state(decimals=5) == target_str[0]
     assert result.symbolic(decimals=1) == target_str[1]
     assert result.symbolic(decimals=2) == target_str[2]
 
@@ -107,8 +107,8 @@ def test_state_representation_cutoff():
     c = models.Circuit(2)
     c.add(gates.RX(0, theta=0.1))
     result = c()
-    assert result.symbolic() == "(0.99875+0j)|00> + -0.04998j|10>"
-    assert result.symbolic(cutoff=0.1) == "(0.99875+0j)|00>"
+    assert result.state(decimals=5) == "(0.99875+0j)|00> + -0.04998j|10>"
+    assert result.state(decimals=5, cutoff=0.1) == "(0.99875+0j)|00>"
 
 
 @pytest.mark.parametrize("state_type", ["VectorState", "MatrixState"])

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -68,6 +68,20 @@ def test_vector_state_to_density_matrix(backend):
         state.to_density_matrix()
 
 
+@pytest.mark.parametrize("target", range(5))
+def test_state_vector_representation(target):
+    from qibo import models, gates
+    c = models.Circuit(5)
+    c.add(gates.H(target))
+    result = c()
+    bstring = target * "0" + "1" + (4 - target) * "0"
+    target_str = f"(0.70711+0j)|00000> + (0.70711+0j)|{bstring}>"
+    assert str(result) == target_str
+    assert result.state(symbolic=True) == target_str
+    assert result.symbolic(decimals=1) == f"(0.7+0j)|00000> + (0.7+0j)|{bstring}>"
+    assert result.symbolic(decimals=2) == f"(0.71+0j)|00000> + (0.71+0j)|{bstring}>"
+
+
 @pytest.mark.parametrize("state_type", ["VectorState", "MatrixState"])
 @pytest.mark.parametrize("use_gate", [False, True])
 def test_state_probabilities(backend, state_type, use_gate):


### PR DESCRIPTION
Closes #519. We provide the following options:
```Python
c = models.Circuit(5)
c.add(gates.H(1))
result = c()

print(result) # (0.70711+0j)|00000> + (0.70711+0j)|01000>
print(result.state(symbolic=True)) # (0.70711+0j)|00000> + (0.70711+0j)|01000>
print(result.symbolic(decimals=1)) # (0.7+0j)|00000> + (0.7+0j)|01000> 
print(result.symbolic(decimals=2)) # (0.71+0j)|00000> + (0.71+0j)|01000>
```
The `decimals` argument controls the number of decimals and the default is 5. Zero amplitudes are ignored.

@scarrazza, @igres26 let me know if you agree. I will implement something similar for density matrices.