### PR TITLE
Move CPU fallback for frequencies

### DIFF
--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -107,7 +107,7 @@ class AbstractBackend(ABC):
         except self.oom_error: # pragma: no cover
             # case not covered by GitHub workflows because it requires OOM
             # Force using CPU to perform sampling
-            log.warn("Falling back to CPU because the GPU is out-of-memory.")
+            log.warn(f"Falling back to CPU for '{func.__name__}' because the GPU is out-of-memory.")
             with self.device(self.get_cpu()):
                 return func(*args)
 

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -152,7 +152,7 @@ class MeasurementResult:
             measured shots.
         """
         if self._frequencies is None:
-            self._frequencies = K.cpu_fallback(self._calculate_frequencies)
+            self._frequencies = self._calculate_frequencies()
         if binary:
             return collections.Counter(
                 {"{0:b}".format(k).zfill(self.nqubits): v
@@ -192,7 +192,7 @@ class MeasurementResult:
                 raise_error(RuntimeError, "Cannot calculate measurement "
                                           "frequencies without a probability "
                                           "distribution or  samples.")
-            freqs = K.sample_frequencies(self.probabilities, self.nshots)
+            freqs = K.cpu_fallback(K.sample_frequencies, self.probabilities, self.nshots)
             freqs = K.to_numpy(freqs)
             return collections.Counter(
                 {k: v for k, v in enumerate(freqs) if v > 0})


### PR DESCRIPTION
I moved the CPU fallback from ``qibo.core.measurements.frequencies`` to ``qibo.core.measurements._calculate_frequencies``, so that we call it with arguments and the CPU fallback implemented in PR https://github.com/qiboteam/qibojit/pull/54 converts them, if needed.