### PR TITLE
Fix probabilities do not sum to 1

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -64,7 +64,7 @@ class NumpyBackend(abstract.AbstractBackend):
             dtype = self.dtypes(dtype)
         if isinstance(x, self.backend.ndarray):
             return x.astype(dtype, copy=False)
-        return self.backend.array(x, dtype=dtype)
+        return self.backend.array(x, dtype=dtype, copy=False)
 
     def diag(self, x, dtype='DTYPECPX'):
         if isinstance(dtype, str):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -63,7 +63,7 @@ class NumpyBackend(abstract.AbstractBackend):
         if isinstance(dtype, str):
             dtype = self.dtypes(dtype)
         if isinstance(x, self.backend.ndarray):
-            return x.astype(dtype)
+            return x.astype(dtype, copy=False)
         return self.backend.array(x, dtype=dtype)
 
     def diag(self, x, dtype='DTYPECPX'):
@@ -238,6 +238,8 @@ class NumpyBackend(abstract.AbstractBackend):
             res, counts = self.backend.unique(samples, return_counts=True)
             frequencies[res] += counts
             return frequencies
+
+        print(self.backend.sum(probs))
 
         frequencies = self.zeros(int(probs.shape[0]), dtype=self.dtypes('DTYPEINT'))
         for _ in range(nshots // SHOT_BATCH_SIZE):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -64,7 +64,7 @@ class NumpyBackend(abstract.AbstractBackend):
             dtype = self.dtypes(dtype)
         if isinstance(x, self.backend.ndarray):
             return x.astype(dtype, copy=False)
-        return self.backend.array(x, dtype=dtype, copy=False)
+        return self.backend.array(x, dtype=dtype)
 
     def diag(self, x, dtype='DTYPECPX'):
         if isinstance(dtype, str):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -239,8 +239,6 @@ class NumpyBackend(abstract.AbstractBackend):
             frequencies[res] += counts
             return frequencies
 
-        print(self.backend.sum(probs))
-
         frequencies = self.zeros(int(probs.shape[0]), dtype=self.dtypes('DTYPEINT'))
         for _ in range(nshots // SHOT_BATCH_SIZE):
             frequencies = update_frequencies(SHOT_BATCH_SIZE, frequencies)

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -92,7 +92,7 @@ class VectorState(AbstractState):
     def probabilities(self, qubits=None, measurement_gate=None):
         unmeasured_qubits = tuple(i for i in range(self.nqubits)
                                   if i not in qubits)
-        state = K.reshape(K.square(K.abs(K.cast(self.tensor))), self.nqubits * (2,))
+        state = K.reshape(K.square(K.abs(K.cast(self.tensor, dtype="complex128"))), self.nqubits * (2,))
         return K.sum(state, axis=unmeasured_qubits)
 
     def measure(self, gate, nshots, registers=None):

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -92,8 +92,8 @@ class VectorState(AbstractState):
     def probabilities(self, qubits=None, measurement_gate=None):
         unmeasured_qubits = tuple(i for i in range(self.nqubits)
                                   if i not in qubits)
-        state = K.reshape(K.square(K.abs(K.cast(self.tensor, dtype="complex128"))), self.nqubits * (2,))
-        return K.sum(state, axis=unmeasured_qubits)
+        state = K.reshape(K.square(K.abs(K.cast(self.tensor))), self.nqubits * (2,))
+        return K.sum(K.cast(state, dtype="float64"), axis=unmeasured_qubits)
 
     def measure(self, gate, nshots, registers=None):
         self.measurements = gate(self, nshots)


### PR DESCRIPTION
Closes #517. In this PR I fixed issue #517 by casting the state vector to double precision before computing the probabilities.
The memory overhead w.r.t. main should be around 33%.

In the meantime, I made a small change in the NumPy cast, to ensure that no arrays are duplicated if not needed. Let me know your opinion.