### PR TITLE
Fix qibo tests to support CuQuantum Backend

### DIFF
--- a/src/qibo/tests/test_backends_agreement.py
+++ b/src/qibo/tests/test_backends_agreement.py
@@ -50,8 +50,8 @@ def test_backend_methods_list(tested_backend, target_backend, method, args):
     tested_func = getattr(tested_backend, method)
     target_func = getattr(target_backend, method)
     target_result = target_func(*args)
-    if tested_backend.name == "qibojit" and tested_backend.engine.name == "cupy": # pragma: no cover
-        # cupy is not tested by CI!
+    if tested_backend.name == "qibojit" and tested_backend.engine.name in ["cupy", "cuquantum"]: # pragma: no cover
+        # cupy and cuquantum are not tested by CI!
         args = [tested_backend.cast(v) if isinstance(v, np.ndarray) else v
                 for v in args]
     try:


### PR DESCRIPTION
This PR contains a minor fix on the qibo tests in order to support a new backend for `qibojit` on GPU based on the NVIDIA [CuQuantum](https://github.com/NVIDIA/cuQuantum) library which is currently under-development in PR qiboteam/qibojit#57.

