### PR TITLE
Fix `test_prints.py` when cuquantum is installed

### DIFF
--- a/src/qibo/tests/test_prints.py
+++ b/src/qibo/tests/test_prints.py
@@ -17,7 +17,7 @@ class CodeText:
     @classmethod
     def from_file(cls, filedir):
         assert filedir[-3:] == ".py"
-        with open(filedir, "r") as file:
+        with open(filedir, "r", encoding="utf-8") as file:
             code = file.read()
         return cls(code, filedir)
 


### PR DESCRIPTION
As mentioned in qiboteam/qibojit#57 `test_prints.py` fails when executed in environment with cuquantum installed and a GPU enabled. For me this happens for both Python 3.8 and 3.9 and only after installing cuqantum, even if I use the master/main branches of qibo and qibojit. This implements a simple fix.

@andrea-pasquale, let me know if it works for you.