### PR TITLE
Fix engine not renamed to platform in some tests

### DIFF
--- a/examples/benchmarks/main.py
+++ b/examples/benchmarks/main.py
@@ -178,7 +178,7 @@ def main(nqubits, circuit_name, backend="custom", precision="double",
         freqs = result.frequencies()
     logs[-1]["measurement_time"] = time.time() - start_time
 
-    if logs[-1]["backend"] == "qibojit" and qibo.K.engine.name == "numba":
+    if logs[-1]["backend"] == "qibojit" and qibo.K.platform.name == "numba":
         from numba import threading_layer
         logs[-1]["threading"] = threading_layer()
 

--- a/src/qibo/tests/test_backends_agreement.py
+++ b/src/qibo/tests/test_backends_agreement.py
@@ -50,7 +50,7 @@ def test_backend_methods_list(tested_backend, target_backend, method, args):
     tested_func = getattr(tested_backend, method)
     target_func = getattr(target_backend, method)
     target_result = target_func(*args)
-    if tested_backend.name == "qibojit" and tested_backend.engine.name in ["cupy", "cuquantum"]: # pragma: no cover
+    if tested_backend.name == "qibojit" and tested_backend.platform.name in ["cupy", "cuquantum"]: # pragma: no cover
         # cupy and cuquantum are not tested by CI!
         args = [tested_backend.cast(v) if isinstance(v, np.ndarray) else v
                 for v in args]


### PR DESCRIPTION
In some tests the old ``engine`` member of ``JitCustomBackend`` was still used. I renamed it to ``platform``.