### PR TITLE
Fix message error in distributed circuit

### DIFF
--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -813,7 +813,7 @@ possible to use :meth:`qibo.abstractions.circuit.AbstractCircuit.set_parameters`
 circuit needs to be defined inside the compiled ``tf.GradientTape()``.
 For example:
 
-.. code-block:: python
+.. testcode::
 
     import qibo
     qibo.set_backend("tensorflow")

--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -813,7 +813,7 @@ possible to use :meth:`qibo.abstractions.circuit.AbstractCircuit.set_parameters`
 circuit needs to be defined inside the compiled ``tf.GradientTape()``.
 For example:
 
-.. testcode::
+.. code-block:: python
 
     import qibo
     qibo.set_backend("tensorflow")
@@ -834,7 +834,7 @@ For example:
             final_state = c().state()
             fidelity = tf.math.abs(tf.reduce_sum(tf.math.conj(target_state) * final_state))
             loss = 1 - fidelity
-            grads = tape.gradient(loss, params)
+        grads = tape.gradient(loss, params)
         optimizer.apply_gradients(zip([grads], [params]))
 
     for _ in range(nepochs):

--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -108,7 +108,7 @@ Using multiple GPUs
 Qibo supports distributed circuit execution on multiple GPUs. This feature can
 be used as follows:
 
-.. testcode::
+.. code-block:: python
 
     from qibo.models import Circuit
     from qibo import gates
@@ -118,7 +118,7 @@ be used as follows:
     # this will use the first GPU three times and the second one time
     # leading to four total logical devices
     # construct the distributed circuit for 32 qubits
-    # c = Circuit(32, accelerators)
+    c = Circuit(32, accelerators)
 
 Gates can then be added normally using ``c.add`` and the circuit can be executed
 using ``c()``. Note that a ``memory_device`` is passed in the distributed circuit
@@ -757,7 +757,7 @@ When Trotter decomposition is used, it is possible to execute the QAOA circuit
 on multiple devices, by passing an ``accelerators`` dictionary when defining
 the model. For example the previous example would have to be modified as:
 
-.. testcode::
+.. code-block:: python
 
     from qibo import models, hamiltonians
 
@@ -801,7 +801,7 @@ function.
             final_state = c().state()
             fidelity = tf.math.abs(tf.reduce_sum(tf.math.conj(target_state) * final_state))
             loss = 1 - fidelity
-            grads = tape.gradient(loss, params)
+        grads = tape.gradient(loss, params)
         optimizer.apply_gradients(zip([grads], [params]))
 
 

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -411,16 +411,16 @@ class NumpyBackend(abstract.AbstractBackend):
     def on_cpu(self): # pragma: no cover
         return self.device()
 
-    def cpu_tensor(self, x, dtype=None):
+    def cpu_tensor(self, x, dtype=None): # pragma: no cover
         if dtype is None:
             dtype = x.dtype
         return self.np.asarray(x, dtype=dtype)
 
-    def cpu_cast(self, x, dtype='DTYPECPX'):
+    def cpu_cast(self, x, dtype='DTYPECPX'): # pragma: no cover
         dtype = self._dtypes.get(dtype)
         return self.np.array(x, dtype=dtype)
 
-    def cpu_assign(self, state, i, piece):
+    def cpu_assign(self, state, i, piece): # pragma: no cover
         state.pieces[i] = self.to_numpy(piece)
 
     def transpose_state(self, pieces, state, nqubits, order):

--- a/src/qibo/core/distcircuit.py
+++ b/src/qibo/core/distcircuit.py
@@ -47,8 +47,12 @@ class DistributedCircuit(circuit.Circuit):
 
     def __init__(self, nqubits: int, accelerators: Dict[str, int]):
         if not K.supports_multigpu:  # pragma: no cover
-            raise_error(NotImplementedError, "Distributed circuit is not supported "
-                                            f"by the {K.name} backend.")
+            if K.platform is None:
+                raise_error(NotImplementedError, "Distributed circuit is not supported "
+                                                f"by the {K.name} backend.")
+            else:
+                raise_error(NotImplementedError, "Distributed circuit is not supported "
+                                                f"by the {K.name} ({K.get_platform()}) backend.")
         super().__init__(nqubits)
         self.init_kwargs["accelerators"] = accelerators
         self.ndevices = sum(accelerators.values())

--- a/src/qibo/core/distcircuit.py
+++ b/src/qibo/core/distcircuit.py
@@ -28,7 +28,7 @@ class DistributedCircuit(circuit.Circuit):
     compilation and callbacks.
 
     Example:
-        .. testcode::
+        .. code-block:: python
 
             from qibo.models import Circuit
             # The system has two GPUs and we would like to use each GPU twice

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -72,7 +72,7 @@ def QFT(nqubits: int, with_swaps: bool = True,
     return circuit
 
 
-def _DistributedQFT(nqubits, accelerators=None):
+def _DistributedQFT(nqubits, accelerators=None): # pragma: no cover
     """QFT with the order of gates optimized for reduced multi-device communication."""
     from qibo import gates
     circuit = Circuit(nqubits, accelerators)

--- a/src/qibo/models/qgan.py
+++ b/src/qibo/models/qgan.py
@@ -69,9 +69,9 @@ class StyleQGAN(object):
 
     def define_discriminator(self, alpha=0.2, dropout=0.2):
         """Define the standalone discriminator model."""
-        from tensorflow.keras.models import Sequential  # pylint: disable=E0611
-        from tensorflow.keras.optimizers import Adadelta  # pylint: disable=E0611
-        from tensorflow.keras.layers import Dense, Conv2D, Dropout, Reshape, LeakyReLU, Flatten  # pylint: disable=E0611
+        from tensorflow.keras.models import Sequential  # pylint: disable=E0611,E0401
+        from tensorflow.keras.optimizers import Adadelta  # pylint: disable=E0611,E0401
+        from tensorflow.keras.layers import Dense, Conv2D, Dropout, Reshape, LeakyReLU, Flatten  # pylint: disable=E0611,E0401
 
         model = Sequential()
         model.add(Dense(200, use_bias=False, input_dim=self.nqubits))

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -16,7 +16,7 @@ def test_circuit_constructor():
     if not K.supports_multigpu:  # pragma: no cover
         with pytest.raises(NotImplementedError):
             c = models.Circuit(5, accelerators={"/GPU:0": 2})
-    else:
+    else: # pragma: no cover
         c = models.Circuit(5, accelerators={"/GPU:0": 2})
         assert isinstance(c, DistributedCircuit)
     with pytest.raises(NotImplementedError):

--- a/src/qibo/tests/test_models_qgan.py
+++ b/src/qibo/tests/test_models_qgan.py
@@ -124,8 +124,8 @@ def test_qgan_custom_discriminator():
     if not K.check_availability("tensorflow"):  # pragma: no cover
         pytest.skip("Skipping StyleQGAN test because tensorflow backend is not available.")
 
-    from tensorflow.keras.models import Sequential  # pylint: disable=E0611
-    from tensorflow.keras.layers import Dense  # pylint: disable=E0611
+    from tensorflow.keras.models import Sequential  # pylint: disable=E0611,E0401
+    from tensorflow.keras.layers import Dense  # pylint: disable=E0611,E0401
     original_backend = qibo.get_backend()
     qibo.set_backend("tensorflow")
     reference_distribution = generate_distribution(10)


### PR DESCRIPTION
In this PR I fixed the error message for the distributed circuit according to the renaming of the backends implemented in #533. The error shown now in the case of cuquantum is the following
```
NotImplementedError: Distributed circuit is not supported by the qibojit (cuquantum) backend.
```
The same mechanism is applied when using the numba backend.