### PR TITLE
Remove some coverage exceptions

### DIFF
--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -72,7 +72,7 @@ def QFT(nqubits: int, with_swaps: bool = True,
     return circuit
 
 
-def _DistributedQFT(nqubits, accelerators=None): # pragma: no cover
+def _DistributedQFT(nqubits, accelerators=None):
     """QFT with the order of gates optimized for reduced multi-device communication."""
     from qibo import gates
     circuit = Circuit(nqubits, accelerators)

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -6,14 +6,14 @@ from qibo import gates, models, K
 from qibo.tests.utils import random_state
 
 
-def test_circuit_constructor():
+def test_circuit_constructor(backend):
     from qibo.core.circuit import Circuit, DensityMatrixCircuit
     from qibo.core.distcircuit import DistributedCircuit
     c = models.Circuit(5)
     assert isinstance(c, Circuit)
     c = models.Circuit(5, density_matrix=True)
     assert isinstance(c, DensityMatrixCircuit)
-    if not K.supports_multigpu:  # pragma: no cover
+    if not K.supports_multigpu:
         with pytest.raises(NotImplementedError):
             c = models.Circuit(5, accelerators={"/GPU:0": 2})
     else:
@@ -66,10 +66,11 @@ def test_qft_execution(backend, accelerators, nqubits, random):
     K.assert_allclose(final_state, target_state)
 
 
-def test_qft_errors():
+def test_qft_errors(backend):
     """Check that ``_DistributedQFT`` raises error if not sufficient qubits."""
     from qibo.models.circuit import _DistributedQFT
     with pytest.raises(NotImplementedError):
-        c = _DistributedQFT(2, accelerators={"/GPU:0": 4})
-    with pytest.raises(NotImplementedError):
         c = models.QFT(10, with_swaps=False, accelerators={"/GPU:0": 2})
+    if K.supports_multigpu:
+        with pytest.raises(NotImplementedError):
+            c = _DistributedQFT(2, accelerators={"/GPU:0": 4})

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -16,7 +16,7 @@ def test_circuit_constructor():
     if not K.supports_multigpu:  # pragma: no cover
         with pytest.raises(NotImplementedError):
             c = models.Circuit(5, accelerators={"/GPU:0": 2})
-    else: # pragma: no cover
+    else:
         c = models.Circuit(5, accelerators={"/GPU:0": 2})
         assert isinstance(c, DistributedCircuit)
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Removes some coverage exceptions for #543. @andrea-pasquale, the issue was that these tests were only testing for the default backend (qibojit numba) for which the multigpu is now disabled. I enabled them for all available backends so that the multigpu code is tested virtually from qibotf. Let me know if you agree.

Btw, if at some point we disable/remove qibotf from the test we will have several coverage issues with the distributed circuit.