### PR TITLE
Implement state deep copy

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -727,6 +727,17 @@ To that end, :class:`qibo.abstractions.states.AbstractState` provides the
 :meth:`qibo.abstractions.states.AbstractState.samples` and
 :meth:`qibo.abstractions.states.AbstractState.frequencies` methods.
 
+The state vector (or density matrix) is saved in memory as a tensor supported
+by the currently active backend (see :ref:`Backends <Backends>` for more information).
+A copy of the state can be created using :meth:`qibo.abstractions.states.AbstractState.copy`.
+The new state will point to the same tensor in memory as the original one unless
+the ``deep=True`` option was used during the ``copy`` call.
+Note that some backends (qibojit, qibotf) perform in-place updates when the
+state is used as input to a circuit or time evolution. This will modify the
+state's tensor and the tensor of all shallow copies and the current state vector
+values will be lost. If you intend to keep the current state values,
+we recommend creating a deep copy before using it as input to a qibo model.
+
 In order to perform measurements the user has to add the measurement gate
 :class:`qibo.core.gates.M` to the circuit and then execute providing a number
 of shots. If this is done, the :class:`qibo.abstractions.states.AbstractState`

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -169,7 +169,7 @@ class AbstractState(ABC):
         raise_error(NotImplementedError)
 
     @abstractmethod
-    def copy(self, deep=False):
+    def copy(self, deep=False): # pragma: no cover
         """Creates a copy of the state.
 
         Args:

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -177,6 +177,10 @@ class AbstractState(ABC):
                 duplicating the tensor in memory, otherwise the copied state
                 references the same tensor object.
                 Default is ``False`` for memory efficiency.
+
+        Returns:
+            A :class:`qibo.abstractions.states.AbstractState` object that
+            represents the same state as the original.
         """
         raise_error(NotImplementedError)
 

--- a/src/qibo/abstractions/states.py
+++ b/src/qibo/abstractions/states.py
@@ -168,17 +168,17 @@ class AbstractState(ABC):
         """
         raise_error(NotImplementedError)
 
-    def copy(self):
+    @abstractmethod
+    def copy(self, deep=False):
         """Creates a copy of the state.
 
-        Note that this does not create a deep copy. The new state references
-        to the same tensor representation for memory efficiency.
+        Args:
+            deep (bool): If ``True`` it creates a deep copy of the state by
+                duplicating the tensor in memory, otherwise the copied state
+                references the same tensor object.
+                Default is ``False`` for memory efficiency.
         """
-        new = self.__class__(self._nqubits)
-        if self._tensor is not None:
-            new.tensor = self.tensor
-        new.measurements = self.measurements
-        return new
+        raise_error(NotImplementedError)
 
     @abstractmethod
     def to_density_matrix(self): # pragma: no cover

--- a/src/qibo/tests/test_abstract_states.py
+++ b/src/qibo/tests/test_abstract_states.py
@@ -42,13 +42,3 @@ def test_abstract_state_getitem():
     assert state[2] == 0
     with pytest.raises(IndexError):
         state[5]
-
-
-def test_abstract_state_copy():
-    AbstractState.__abstractmethods__ = set()
-    state = AbstractState.from_tensor([0, 1])
-    cstate = state.copy()
-    assert cstate.nqubits == state.nqubits
-    assert len(cstate) == len(state)
-    assert cstate.tensor == state.tensor
-    assert cstate.measurements == state.measurements

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -67,6 +67,29 @@ def test_vector_state_state_copy(backend, deep):
 
 
 @pytest.mark.parametrize("deep", [False, True])
+def test_vector_state_state_deepcopy(deep):
+    """Check if deep copy is really deep."""
+    # use numpy backend as tensorflow tensors are immutable and cannot
+    # change their value for testing
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend("numpy")
+    vector = np.random.random(32) + 1j * np.random.random(32)
+    vector = vector / np.sqrt((np.abs(vector) ** 2).sum())
+    state = states.VectorState.from_tensor(vector)
+    cstate = state.copy(deep)
+    current_value = state.tensor[0]
+    state.tensor[0] = 0
+    if deep:
+        K.assert_allclose(state.tensor[0], 0)
+        K.assert_allclose(cstate.tensor[0], current_value)
+        K.assert_allclose(cstate.tensor[1:], state.tensor[1:])
+    else:
+        K.assert_allclose(cstate.tensor, state.tensor)
+    qibo.set_backend(original_backend)
+
+
+@pytest.mark.parametrize("deep", [False, True])
 def test_vector_state_state_copy_with_measurements(backend, deep):
     from qibo import gates
     vector = np.random.random(32) + 1j * np.random.random(32)

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -56,6 +56,31 @@ def test_plus_state_initialization(backend):
     K.assert_allclose(state.tensor, target_state)
 
 
+@pytest.mark.parametrize("deep", [False, True])
+def test_vector_state_state_copy(backend, deep):
+    vector = np.random.random(32) + 1j * np.random.random(32)
+    vector = vector / np.sqrt((np.abs(vector) ** 2).sum())
+    state = states.VectorState.from_tensor(vector)
+    cstate = state.copy(deep)
+    assert cstate.nqubits == state.nqubits
+    K.assert_allclose(cstate.tensor, state.tensor)
+
+
+@pytest.mark.parametrize("deep", [False, True])
+def test_vector_state_state_copy_with_measurements(backend, deep):
+    from qibo import gates
+    vector = np.random.random(32) + 1j * np.random.random(32)
+    vector = vector / np.sqrt((np.abs(vector) ** 2).sum())
+    state = states.VectorState.from_tensor(vector)
+    mgate = gates.M(0, 1, 3)
+    measurements = state.measure(mgate, nshots=50)
+    target_freqs = measurements.frequencies()
+    cstate = state.copy(deep)
+    assert cstate.nqubits == state.nqubits
+    assert state.measurements.__class__ == cstate.measurements.__class__
+    assert cstate.measurements.frequencies() == target_freqs
+
+
 def test_vector_state_to_density_matrix(backend):
     vector = np.random.random(32) + 1j * np.random.random(32)
     vector = vector / np.sqrt((np.abs(vector) ** 2).sum())

--- a/src/qibo/tests/test_core_states_distributed.py
+++ b/src/qibo/tests/test_core_states_distributed.py
@@ -51,11 +51,12 @@ def test_user_initialization(backend, accelerators, nqubits):
         K.assert_allclose(state.pieces[i], target_piece.ravel())
 
 
-def test_distributed_state_copy(backend, accelerators):
+@pytest.mark.parametrize("deep", [False, True])
+def test_distributed_state_copy(backend, deep, accelerators):
     c = Circuit(4, accelerators)
     c.queues.qubits = DistributedQubits(range(c.nglobal), c.nqubits) # pylint: disable=E1101
     state = states.DistributedState.zero_state(c)
-    cstate = state.copy()
+    cstate = state.copy(deep)
     K.assert_allclose(state.tensor, cstate.tensor)
 
 


### PR DESCRIPTION
Following #545, this implements the option to create a deep copy of a state using `VectorState.copy(deep=True)`. I also added in the docs (States section) that qibojit and qibotf perform in-place updates so the state (and all its shallow copies) will be modified if it is used as initial state in a circuit or time evolution.