### PR TITLE
Adding channels to circuit.draw()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "psutil",
         "pyyaml",
         "importlib_metadata",
+        "tabulate"
     ],
     extras_require={
         "docs": ["sphinx", "sphinx_rtd_theme", "recommonmark", "sphinxcontrib-bibtex", "sphinx_markdown_tables", "nbsphinx", "IPython"],

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -943,6 +943,8 @@ class AbstractCircuit(ABC):
         Args:
             line_wrap (int): maximum number of characters per line. This option
                 split the circuit text diagram in chunks of line_wrap characters.
+            legend (bool): If ``True`` prints a legend below the circuit for
+                callbacks and channels. Default is ``False``.
 
         Return:
             String containing text circuit diagram.

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -955,7 +955,10 @@ class AbstractCircuit(ABC):
                   "crx": "RX", "cry": "RY", "crz": "RZ",
                   "cu1": "U1", "cu3": "U3", "ccx": "X",
                   "id": "I", "measure": "M", "fsim": "f",
-                  "generalizedfsim": "gf", "Unitary": "U", "fswap":"fx"}
+                  "generalizedfsim": "gf", "Unitary": "U", "fswap":"fx",
+                  "PauliNoiseChannel": "Pc", "KrausChannel": "Kc",
+                  "UnitaryChannel": "Uc", "ThermalRelaxationChannel": "Tc",
+                  "ResetChannel": "Rc", "PartialTrace": "Pt"}
 
         # build string representation of gates
         matrix = [[] for _ in range(self.nqubits)]

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -1030,7 +1030,7 @@ class AbstractCircuit(ABC):
             table = tabulate([[i, labels[i]] for i in names],
                               headers=['Gate', 'Symbol'],
                               tablefmt='orgtbl')
-            table = '\n Legend: \n' + table
+            table = '\n Legend for callbacks and channels: \n' + table
 
         # line wrap
         if line_wrap:

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -956,11 +956,11 @@ class AbstractCircuit(ABC):
                   "cu1": "U1", "cu3": "U3", "ccx": "X",
                   "id": "I", "measure": "M", "fsim": "f",
                   "generalizedfsim": "gf", "Unitary": "U", "fswap":"fx",
-                  "PauliNoiseChannel": "Pc", "KrausChannel": "Kc",
-                  "UnitaryChannel": "Uc", "ThermalRelaxationChannel": "Tc",
-                  "ResetChannel": "Rc", "PartialTrace": "Pt",
-                  "EntanglementEntropy": "EE", "Norm": "N",
-                  "Overlap": "O", "Energy": "E", "Gap": "G"}
+                  "PauliNoiseChannel": "PNCh", "KrausChannel": "KCh",
+                  "UnitaryChannel": "UCh", "ThermalRelaxationChannel": "TRCh",
+                  "ResetChannel": "RCh", "PartialTrace": "PTCh",
+                  "EntanglementEntropy": "EECb", "Norm": "NCb",
+                  "Overlap": "OCb", "Energy": "ECb"}
 
         # build string representation of gates
         matrix = [[] for _ in range(self.nqubits)]

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -937,7 +937,7 @@ class AbstractCircuit(ABC):
 
         return len(qubits), gate_list
 
-    def draw(self, line_wrap=70) -> str:
+    def draw(self, line_wrap=70, legend=False) -> str:
         """Draw text circuit using unicode symbols.
 
         Args:
@@ -956,11 +956,11 @@ class AbstractCircuit(ABC):
                   "cu1": "U1", "cu3": "U3", "ccx": "X",
                   "id": "I", "measure": "M", "fsim": "f",
                   "generalizedfsim": "gf", "Unitary": "U", "fswap":"fx",
-                  "PauliNoiseChannel": "PNCh", "KrausChannel": "KCh",
-                  "UnitaryChannel": "UCh", "ThermalRelaxationChannel": "TRCh",
-                  "ResetChannel": "RCh", "PartialTrace": "PTCh",
-                  "EntanglementEntropy": "EECb", "Norm": "NCb",
-                  "Overlap": "OCb", "Energy": "ECb"}
+                  "PauliNoiseChannel": "PN", "KrausChannel": "K",
+                  "UnitaryChannel": "U", "ThermalRelaxationChannel": "TR",
+                  "ResetChannel": "R", "PartialTrace": "PT",
+                  "EntanglementEntropy": "EE", "Norm": "N",
+                  "Overlap": "O", "Energy": "E"}
 
         # build string representation of gates
         matrix = [[] for _ in range(self.nqubits)]
@@ -1021,6 +1021,17 @@ class AbstractCircuit(ABC):
             output += f'q{q}' + ' ' * (len(str(self.nqubits))-len(str(q))) + \
                        ': ─' + ''.join(matrix[q]) + '\n'
 
+        # legend
+        if legend:
+            from tabulate import tabulate
+            names = [i.name for i in self.queue \
+                     if isinstance(i,gates.CallbackGate) or "Channel" in i.name]
+            names = list(dict.fromkeys(names))
+            table = tabulate([[i, labels[i]] for i in names],
+                              headers=['Gate', 'Symbol'],
+                              tablefmt='orgtbl')
+            table = '\n Legend: \n' + table
+
         # line wrap
         if line_wrap:
             loutput = output.splitlines()
@@ -1047,5 +1058,8 @@ class AbstractCircuit(ABC):
                     loutput[row + i * self.nqubits] = prefix + c + suffix
             if loutput is not None:
                 output = ''.join(loutput)
+
+        if legend:
+            output += table
 
         return output.rstrip('\n')

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -958,7 +958,9 @@ class AbstractCircuit(ABC):
                   "generalizedfsim": "gf", "Unitary": "U", "fswap":"fx",
                   "PauliNoiseChannel": "Pc", "KrausChannel": "Kc",
                   "UnitaryChannel": "Uc", "ThermalRelaxationChannel": "Tc",
-                  "ResetChannel": "Rc", "PartialTrace": "Pt"}
+                  "ResetChannel": "Rc", "PartialTrace": "Pt",
+                  "EntanglementEntropy": "EE", "Norm": "N",
+                  "Overlap": "O", "Energy": "E", "Gap": "G"}
 
         # build string representation of gates
         matrix = [[] for _ in range(self.nqubits)]
@@ -968,7 +970,10 @@ class AbstractCircuit(ABC):
             if gate.name not in labels:
                 raise_error(NotImplementedError, f"{gate.name} gate is not supported by `circuit.draw`")
             gate_name = labels.get(gate.name)
-            targets = list(gate.target_qubits)
+            if isinstance(gate, gates.CallbackGate):
+                targets = list(range(self.nqubits))
+            else:
+                targets = list(gate.target_qubits)
             controls = list(gate.control_qubits)
 
             # identify boundaries

--- a/src/qibo/tests/test_abstract_circuit.py
+++ b/src/qibo/tests/test_abstract_circuit.py
@@ -566,7 +566,7 @@ def test_circuit_draw_channels(legend):
           'q1: ─H─PN─X─PN─'
 
     if legend:
-        ref += '\n\n Legend: \n' \
+        ref += '\n\n Legend for callbacks and channels: \n' \
                '| Gate              | Symbol   |\n' \
                '|-------------------+----------|\n' \
                '| PauliNoiseChannel | PN       |'
@@ -589,7 +589,7 @@ def test_circuit_draw_callbacks(legend):
           'q1: ─EE───EE─X─EE─'
 
     if legend:
-        ref += '\n\n Legend: \n' \
+        ref += '\n\n Legend for callbacks and channels: \n' \
                '| Gate                | Symbol   |\n'\
                '|---------------------+----------|\n'\
                '| EntanglementEntropy | EE       |'

--- a/src/qibo/tests/test_abstract_circuit.py
+++ b/src/qibo/tests/test_abstract_circuit.py
@@ -549,3 +549,32 @@ def test_circuit_draw_not_supported_gates():
     c.add(gates.Flatten(1))
     with pytest.raises(NotImplementedError):
         c.draw()
+
+def test_circuit_draw_channels():
+    """Check that channels are drawn correctly"""
+    from qibo.models import Circuit as circuit
+    c = circuit(2, density_matrix=True)
+    c.add(gates.H(0))
+    c.add(gates.PauliNoiseChannel(0, 0.1, 0.0, 0.2))
+    c.add(gates.H(1))
+    c.add(gates.PauliNoiseChannel(1, 0.0, 0.2, 0.1))
+    c.add(gates.CNOT(0, 1))
+    c.add(gates.PauliNoiseChannel(0, 0.1, 0.0, 0.2))
+    c.add(gates.PauliNoiseChannel(1, 0.0, 0.2, 0.1))
+    ref = 'q0: ─H─PNCh─o─PNCh─\n' \
+          'q1: ─H─PNCh─X─PNCh─'
+    assert c.draw() == ref
+
+def test_circuit_draw_callbacks():
+    """Check that callbacks are drawn correcly"""
+    from qibo.callbacks import EntanglementEntropy
+    entropy = EntanglementEntropy([0])
+    c = Circuit(2)
+    c.add(gates.CallbackGate(entropy))
+    c.add(gates.H(0))
+    c.add(gates.CallbackGate(entropy))
+    c.add(gates.CNOT(0, 1))
+    c.add(gates.CallbackGate(entropy))
+    ref = 'q0: ─EECb─H─EECb─o─EECb─\n' \
+          'q1: ─EECb───EECb─X─EECb─'
+    assert c.draw() == ref

--- a/src/qibo/tests/test_abstract_circuit.py
+++ b/src/qibo/tests/test_abstract_circuit.py
@@ -549,8 +549,8 @@ def test_circuit_draw_not_supported_gates():
     c.add(gates.Flatten(1))
     with pytest.raises(NotImplementedError):
         c.draw()
-
-def test_circuit_draw_channels():
+@pytest.mark.parametrize("legend", [True, False])
+def test_circuit_draw_channels(legend):
     """Check that channels are drawn correctly"""
     from qibo.models import Circuit as circuit
     c = circuit(2, density_matrix=True)
@@ -561,11 +561,20 @@ def test_circuit_draw_channels():
     c.add(gates.CNOT(0, 1))
     c.add(gates.PauliNoiseChannel(0, 0.1, 0.0, 0.2))
     c.add(gates.PauliNoiseChannel(1, 0.0, 0.2, 0.1))
-    ref = 'q0: ─H─PNCh─o─PNCh─\n' \
-          'q1: ─H─PNCh─X─PNCh─'
-    assert c.draw() == ref
 
-def test_circuit_draw_callbacks():
+    ref = 'q0: ─H─PN─o─PN─\n' \
+          'q1: ─H─PN─X─PN─'
+
+    if legend:
+        ref += '\n\n Legend: \n' \
+               '| Gate              | Symbol   |\n' \
+               '|-------------------+----------|\n' \
+               '| PauliNoiseChannel | PN       |'
+
+    assert c.draw(legend=legend) == ref
+
+@pytest.mark.parametrize("legend", [True, False])
+def test_circuit_draw_callbacks(legend):
     """Check that callbacks are drawn correcly"""
     from qibo.callbacks import EntanglementEntropy
     entropy = EntanglementEntropy([0])
@@ -575,6 +584,14 @@ def test_circuit_draw_callbacks():
     c.add(gates.CallbackGate(entropy))
     c.add(gates.CNOT(0, 1))
     c.add(gates.CallbackGate(entropy))
-    ref = 'q0: ─EECb─H─EECb─o─EECb─\n' \
-          'q1: ─EECb───EECb─X─EECb─'
-    assert c.draw() == ref
+
+    ref = 'q0: ─EE─H─EE─o─EE─\n' \
+          'q1: ─EE───EE─X─EE─'
+
+    if legend:
+        ref += '\n\n Legend: \n' \
+               '| Gate                | Symbol   |\n'\
+               '|---------------------+----------|\n'\
+               '| EntanglementEntropy | EE       |'
+
+    assert c.draw(legend=legend) == ref


### PR DESCRIPTION
This PR fixes #546. The current version of qibo does not allow to draw circuits where there are channel gates.
I've added a few labels to identify these channels. In order to differentiate those from the usuale gates I've added a `c` at the end. For example in the case of the `PauliNoiseChannel` the output should be the following:
```python
from qibo import models, gates

c = models.Circuit(2, density_matrix=True)
c.add(gates.X(1))
c.add(gates.PauliNoiseChannel(0, px=0.3))
result = c()
print(c.draw())
# q0: ─Pc─
# q1: ─X──
```
The same mechanism using different labels is applied for all the other channels.
We can also change the name of the labels that I've chosen.
Let me know what you think.
