### PR TITLE
Full state callback

### DIFF
--- a/src/qibo/abstractions/callbacks.py
+++ b/src/qibo/abstractions/callbacks.py
@@ -101,6 +101,9 @@ class EntanglementEntropy(Callback):
 
 class State(Callback):
     """Callback to keeps track of the full state during circuit execution.
+
+    Warning: Keeping many copies of states in memory requires a lot of memory
+    for circuits with many qubits.
     
     Args:
         copy (bool): If ``True`` the state vector or density matrix is 

--- a/src/qibo/abstractions/callbacks.py
+++ b/src/qibo/abstractions/callbacks.py
@@ -99,6 +99,24 @@ class EntanglementEntropy(Callback):
         self.spectrum = list()
 
 
+class State(Callback):
+    """Callback to keeps track of the full state during circuit execution.
+    
+    Args:
+        copy (bool): If ``True`` the state vector or density matrix is 
+            copied in memory. Otherwise a reference to the existing array
+            is stored in the callback. 
+            The callback will not work as expected if ``copy=False`` 
+            is used with a backend that performs in-place updates, 
+            such as qibojit or qibotf.
+            Default is True
+    """
+
+    def __init__(self, copy=True):
+        super().__init__()
+        self.copy = copy
+
+
 class Norm(Callback):
     """State norm callback.
 

--- a/src/qibo/core/callbacks.py
+++ b/src/qibo/core/callbacks.py
@@ -93,6 +93,18 @@ class EntanglementEntropy(BackendCallback, abstract_callbacks.EntanglementEntrop
         return self.entropy(rho)
 
 
+class State(BackendCallback, abstract_callbacks.State):
+
+    def _state_vector_call(self, state):
+        if self.copy:
+            return K.copy(state)
+        else:
+            return state
+
+    def _density_matrix_call(self, state):
+        return self._state_vector_call(state)
+
+
 class Norm(BackendCallback, abstract_callbacks.Norm):
 
     def _state_vector_call(self, state):

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -278,7 +278,7 @@ def test_state_callback(backend, density_matrix, copy):
     
     target_state0 = np.array([1, 0, 1, 0]) / np.sqrt(2)
     target_state1 = np.ones(4) / 2.0
-    if not copy and ((K.name == "qibojit" and not density_matrix) or K.name == "qibotf"):
+    if not copy and K.name in ("qibojit", "qibotf"):
         # when copy is disabled in the callback and in-place updates are used
         target_state0 = target_state1
     if density_matrix:

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -278,7 +278,7 @@ def test_state_callback(backend, density_matrix, copy):
     
     target_state0 = np.array([1, 0, 1, 0]) / np.sqrt(2)
     target_state1 = np.ones(4) / 2.0
-    if not copy and K.name in ("qibojit", "qibotf"):
+    if not copy and ((K.name == "qibojit" and not density_matrix) or K.name == "qibotf"):
         # when copy is disabled in the callback and in-place updates are used
         target_state0 = target_state1
     if density_matrix:


### PR DESCRIPTION
Implements a callback that keeps track of the full state vector or density matrix during circuit simulation. This was requested by @igres26 in #555. Usage is similar to existing callbacks, one can add this to a circuit, in the place which a stamp of the state is required, using a `CallbackGate`.

This PR is complete, I just mark it as do not merge because the test will change if we merge qiboteam/qibojit#74.