### PR TITLE
Fix sampling when using `circuit.add()`

### DIFF
--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -148,6 +148,10 @@ class AbstractCircuit(ABC):
                 newcircuit.check_measured(v)
                 newcircuit.measurement_tuples[k] = v
             newcircuit.measurement_gate.add(circuit.measurement_gate)
+
+        # Re-execute full circuit when sampling if one of the circuit has repeated_execution True
+        newcircuit.repeated_execution = self.repeated_execution or circuit.repeated_execution
+
         return newcircuit
 
     def on_qubits(self, *q):

--- a/src/qibo/tests/test_abstract_circuit.py
+++ b/src/qibo/tests/test_abstract_circuit.py
@@ -117,19 +117,6 @@ def test_circuit_add_nested_generator():
     assert isinstance(c.queue[5], gates.CNOT)
     assert isinstance(c.queue[7], gates.H)
 
-def test_circuit_add_repeated_execution():
-    c = Circuit(1)
-    c.add(gates.H(0))
-    c.add(gates.PauliNoiseChannel(0, px=0.2))
-
-    c1 = Circuit(1)
-    c1.add(gates.X(0))
-
-    c2 = c + c1
-
-    assert c.repeated_execution
-    assert not c1.repeated_execution
-    assert c2.repeated_execution
 
 def test_set_nqubits():
     c = Circuit(2)

--- a/src/qibo/tests/test_abstract_circuit.py
+++ b/src/qibo/tests/test_abstract_circuit.py
@@ -117,6 +117,19 @@ def test_circuit_add_nested_generator():
     assert isinstance(c.queue[5], gates.CNOT)
     assert isinstance(c.queue[7], gates.H)
 
+def test_circuit_add_repeated_execution():
+    c = Circuit(1)
+    c.add(gates.H(0))
+    c.add(gates.PauliNoiseChannel(0, px=0.2))
+
+    c1 = Circuit(1)
+    c1.add(gates.X(0))
+
+    c2 = c + c1
+
+    assert c.repeated_execution
+    assert not c1.repeated_execution
+    assert c2.repeated_execution
 
 def test_set_nqubits():
     c = Circuit(2)

--- a/src/qibo/tests/test_core_circuit_noise.py
+++ b/src/qibo/tests/test_core_circuit_noise.py
@@ -180,12 +180,14 @@ def test_circuit_add_sampling(backend):
     circ.add(gates.M(0))
 
     # Sampling using 10 shots
+    np.random.seed(123)
     K.set_seed(123)
     samples = circ(nshots=10).samples()
 
     # Sampling using 1 shot in for loop
     target_samples = []
     K.set_seed(123)
+    np.random.seed(123)
     for _ in range(10):
         target_samples.append(circ(nshots=1).samples())
 

--- a/src/qibo/tests/test_core_circuit_noise.py
+++ b/src/qibo/tests/test_core_circuit_noise.py
@@ -162,7 +162,7 @@ def test_density_matrix_circuit_errors():
         c.add(gates.KrausChannel([((0,), np.eye(2))]))
 
 
-def test_circuit_add_sampling():
+def test_circuit_add_sampling(backend):
     """Check measurements when simulating added circuits with noise"""
     # Create random noisy circuit and add noiseless inverted circuit
     gates_set = [gates.X, gates.Y, gates.Z, gates.H, gates.S, gates.SDG, gates.I]
@@ -189,4 +189,4 @@ def test_circuit_add_sampling():
     for _ in range(10):
         target_samples.append(circ(nshots=1).samples())
 
-    K.assert_allclose(np.array(target_samples).flatten(), samples.flatten())
+    K.assert_allclose(samples[:, 0], target_samples[:, 0, 0])

--- a/src/qibo/tests/test_core_circuit_noise.py
+++ b/src/qibo/tests/test_core_circuit_noise.py
@@ -160,3 +160,31 @@ def test_density_matrix_circuit_errors():
     c = Circuit(5)
     with pytest.raises(ValueError):
         c.add(gates.KrausChannel([((0,), np.eye(2))]))
+
+
+def test_circuit_add_sampling():
+    """Check measurements when simulating added circuits with noise"""
+    # Create random noisy circuit and add noiseless inverted circuit
+    gates_set = [gates.X, gates.Y, gates.Z, gates.H, gates.S, gates.SDG, gates.I]
+    circ = Circuit(1)
+    circ_no_noise = Circuit(1)
+    for _ in range(100):
+        new_gate = np.random.choice(gates_set)(0)
+        circ.add(gates.PauliNoiseChannel(0, pz=0.01))
+        circ.add(new_gate)
+        circ_no_noise.add(new_gate)
+        circ.add(gates.PauliNoiseChannel(0, pz=0.01))
+    circ += circ_no_noise.invert()
+    circ.add(gates.M(0))
+
+    # Sampling using 10 shots
+    K.set_seed(123)
+    samples = circ(nshots=10).samples()
+
+    # Sampling using 1 shot in for loop
+    target_samples = []
+    K.set_seed(123)
+    for _ in range(10):
+        target_samples.append(circ(nshots=1).samples())
+
+    K.assert_allclose(np.array(target_samples).flatten(), samples.flatten())

--- a/src/qibo/tests/test_core_circuit_noise.py
+++ b/src/qibo/tests/test_core_circuit_noise.py
@@ -168,12 +168,14 @@ def test_circuit_add_sampling():
     gates_set = [gates.X, gates.Y, gates.Z, gates.H, gates.S, gates.SDG, gates.I]
     circ = Circuit(1)
     circ_no_noise = Circuit(1)
-    for _ in range(100):
+
+    for _ in range(10):
         new_gate = np.random.choice(gates_set)(0)
         circ.add(gates.PauliNoiseChannel(0, pz=0.01))
         circ.add(new_gate)
         circ_no_noise.add(new_gate)
-        circ.add(gates.PauliNoiseChannel(0, pz=0.01))
+
+    circ.add(gates.PauliNoiseChannel(0, pz=0.01))
     circ += circ_no_noise.invert()
     circ.add(gates.M(0))
 

--- a/src/qibo/tests/test_core_circuit_noise.py
+++ b/src/qibo/tests/test_core_circuit_noise.py
@@ -189,4 +189,6 @@ def test_circuit_add_sampling(backend):
     for _ in range(10):
         target_samples.append(circ(nshots=1).samples())
 
-    K.assert_allclose(samples[:, 0], target_samples[:, 0, 0])
+    target_samples = np.stack(target_samples)
+
+    K.assert_allclose(samples, target_samples[:, 0])


### PR DESCRIPTION
Closes #563.
As already discussed in today's meeting, the problem was related to the `add` method of `AbstractCircuit`.
When the new circuit is created the `repeated_execution` attribute, which allows to re-execute the circuit for every
shot, was set by default to `False`. This is why when adding the noisy circuit with its inverse the sampling was odd.
Now `repeated_execution` is set to:
```python
newcircuit.repeated_execution = old_circuit.repeated_execution or circuit_to_add.repeated_execution
```
Therefore if one of the two circuits requires to re-execute the circuit the new circuit will also be re-executed for every shot. 
I've also added tests about this.
Let me know what you think @igres26 @scarrazza @stavros11. 