### PR TITLE
Raise error if QAOA Hamiltonians have different nqubits

### DIFF
--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -236,6 +236,7 @@ class QAOA(object):
         hamiltonian (:class:`qibo.abstractions.hamiltonians.Hamiltonian`): problem Hamiltonian
             whose ground state is sought.
         mixer (:class:`qibo.abstractions.hamiltonians.Hamiltonian`): mixer Hamiltonian.
+            Must be of the same type and act on the same number of qubits as ``hamiltonian``.
             If ``None``, :class:`qibo.hamiltonians.X` is used.
         solver (str): solver used to apply the exponential operators.
             Default solver is 'exp' (:class:`qibo.solvers.Exponential`).

--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -284,6 +284,11 @@ class QAOA(object):
                                          "while mixer is of type {}."
                                          "".format(type(hamiltonian),
                                                    type(mixer)))
+            if mixer.nqubits != hamiltonian.nqubits:
+                  raise_error(ValueError, "Given Hamiltonian acts on {} qubits "
+                                          "while mixer acts on {}."
+                                          "".format(hamiltonian.nqubits,
+                                                    mixer.nqubits))
             self.mixer = mixer
 
         # create circuits for Trotter Hamiltonians

--- a/src/qibo/tests/test_models_variational.py
+++ b/src/qibo/tests/test_models_variational.py
@@ -250,6 +250,11 @@ def test_qaoa_errors():
     m = hamiltonians.X(4, dense=True)
     with pytest.raises(TypeError):
         qaoa = models.QAOA(h, mixer=m)
+    # Hamiltonians acting on different qubit numbers
+    h = hamiltonians.TFIM(6, h=1.0)
+    m = hamiltonians.X(4)
+    with pytest.raises(ValueError):
+        qaoa = models.QAOA(h, mixer=m)
     # distributed execution with RK solver
     with pytest.raises(NotImplementedError):
         qaoa = models.QAOA(h, solver="rk4", accelerators={"/GPU:0": 2})


### PR DESCRIPTION
Temporary fix for #558 until we make the model more flexible to allow applying operators of different sizes.