### PR TITLE
Relax probability sum check in `UnitaryChannel`

### DIFF
--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1467,10 +1467,6 @@ class UnitaryChannel(KrausChannel):
         self.name = "UnitaryChannel"
         self.probs = p
         self.psum = sum(p)
-        if self.psum > 1 or self.psum <= 0:
-            raise_error(ValueError, "UnitaryChannel probability sum should be "
-                                    "between 0 and 1 but is {}."
-                                    "".format(self.psum))
         self.seed = seed
         self.density_matrix = False
         self.init_args = [p, self.gates]

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -15,6 +15,8 @@ class AbstractBackend(ABC):
         self.available_platforms = [None]
 
         self.precision = 'double'
+        from qibo.config import PRECISION_TOL_DOUBLE
+        self.precision_tol = PRECISION_TOL_DOUBLE
         self._dtypes = {'DTYPEINT': 'int64', 'DTYPE': 'float64',
                         'DTYPECPX': 'complex128'}
 
@@ -56,11 +58,15 @@ class AbstractBackend(ABC):
 
     def set_precision(self, dtype):
         if dtype == 'single':
+            from qibo.config import PRECISION_TOL_DOUBLE
             self._dtypes['DTYPE'] = 'float32'
             self._dtypes['DTYPECPX'] = 'complex64'
+            self.precision_tol = PRECISION_TOL_DOUBLE
         elif dtype == 'double':
+            from qibo.config import PRECISION_TOL_SINGLE
             self._dtypes['DTYPE'] = 'float64'
             self._dtypes['DTYPECPX'] = 'complex128'
+            self.precision_tol = PRECISION_TOL_SINGLE
         else:
             raise_error(ValueError, f'dtype {dtype} not supported.')
         self.precision = dtype

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -58,15 +58,15 @@ class AbstractBackend(ABC):
 
     def set_precision(self, dtype):
         if dtype == 'single':
-            from qibo.config import PRECISION_TOL_DOUBLE
+            from qibo.config import PRECISION_TOL_SINGLE
             self._dtypes['DTYPE'] = 'float32'
             self._dtypes['DTYPECPX'] = 'complex64'
-            self.precision_tol = PRECISION_TOL_DOUBLE
+            self.precision_tol = PRECISION_TOL_SINGLE
         elif dtype == 'double':
-            from qibo.config import PRECISION_TOL_SINGLE
+            from qibo.config import PRECISION_TOL_DOUBLE
             self._dtypes['DTYPE'] = 'float64'
             self._dtypes['DTYPECPX'] = 'complex128'
-            self.precision_tol = PRECISION_TOL_SINGLE
+            self.precision_tol = PRECISION_TOL_DOUBLE
         else:
             raise_error(ValueError, f'dtype {dtype} not supported.')
         self.precision = dtype

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -21,6 +21,10 @@ EINSUM_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 # Eigenvalues smaller than this cut-off are ignored in entropy calculation
 EIGVAL_CUTOFF = 1e-14
 
+# Tolerance for the probability sum check in the unitary channel
+PRECISION_TOL_SINGLE = 1e-8
+PRECISION_TOL_DOUBLE = 1e-12
+
 # Batch size for sampling shots in measurement frequencies calculation
 SHOT_BATCH_SIZE = 2 ** 18
 

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -927,6 +927,10 @@ class UnitaryChannel(KrausChannel, abstract_gates.UnitaryChannel):
                  seed: Optional[int] = None):
         BackendGate.__init__(self)
         abstract_gates.UnitaryChannel.__init__(self, p, ops, seed=seed)
+        if self.psum > 1 + K.precision_tol or self.psum <= 0:
+            raise_error(ValueError, "UnitaryChannel probability sum should be "
+                                    "between 0 and 1 but is {}."
+                                    "".format(self.psum))
         self.set_seed()
 
     def calculate_inverse_gates(self):

--- a/src/qibo/tests/test_abstract_gates.py
+++ b/src/qibo/tests/test_abstract_gates.py
@@ -247,8 +247,6 @@ def test_unitary_channel_init():
         gate = gates.UnitaryChannel(2 * [0.1], ops)
     with pytest.raises(ValueError):
         gate = gates.UnitaryChannel(4 * [-0.1], ops)
-    with pytest.raises(ValueError):
-        gate = gates.UnitaryChannel(4 * [0.5], ops)
 
 
 def test_pauli_noise_channel_init():

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -52,10 +52,10 @@ def test_set_precision(backend, precision):
     backends.set_precision(precision)
     if precision == "single":
         expected_dtype = K.backend.complex64
-        expected_tol = 1e-12
+        expected_tol = 1e-8
     else:
         expected_dtype = K.backend.complex128
-        expected_tol = 1e-8
+        expected_tol = 1e-12
     assert backends.get_precision() == precision
     assert K.dtypes('DTYPECPX') == expected_dtype
     assert K.precision_tol == expected_tol

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -52,10 +52,13 @@ def test_set_precision(backend, precision):
     backends.set_precision(precision)
     if precision == "single":
         expected_dtype = K.backend.complex64
+        expected_tol = 1e-12
     else:
         expected_dtype = K.backend.complex128
+        expected_tol = 1e-8
     assert backends.get_precision() == precision
     assert K.dtypes('DTYPECPX') == expected_dtype
+    assert K.precision_tol == expected_tol
     # Test that circuits use proper precision
     circuit = models.Circuit(2)
     circuit.add([gates.H(0), gates.H(1)])

--- a/src/qibo/tests/test_core_gates.py
+++ b/src/qibo/tests/test_core_gates.py
@@ -489,6 +489,10 @@ def test_unitary_channel_probability_tolerance(backend, precision):
     prob_identity = 1 - param / max_param
     prob_pauli = param / num_terms
     probs = [prob_identity] + [prob_pauli] * (num_terms - 1)
+    if precision == "double":
+        probs = np.array(probs, dtype="float64")
+    else:
+        probs = np.array(probs, dtype="float32")
     matrices = len(probs) * [((0, 1), np.random.random((4, 4)))]
     gate = gates.UnitaryChannel(probs, matrices)
     qibo.set_precision(original_precision)


### PR DESCRIPTION
Fixes #562 by using a tolerance when checking the probability sum. Now the error is raised when
```Python
sum(p) > 1 + K.precision_tol
```
instead of 
```Python
sum(p) > 1
```
where `K.precision_tol` is defined in config.py for single and double precision.