### PR TITLE
Multi-qubit fusion

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -87,12 +87,21 @@ circuit as groups of gates have been fused to a single
 is equivalent to simulating the original one but in most cases more efficient
 since less gates need to be applied to the state vector.
 
-All one-qubit gates acting on the same qubit in a row are fused together.
-Once a two-qubit gate acting on a specific pair ``(q0, q1)`` is found then it is
-fused together with the existing fused one-qubit gates on ``q0`` and ``q1``.
-If a new two-qubit gate is found which acts on either ``q0`` or ``q1`` but not
-both then the fusion round for the pair ``(q0, q1)`` stops and a new fusion
-round starts for the target qubits of the new two-qubit gate.
+The fusion algorithm works as follows: First all gates in the circuit are 
+transformed to unmarked :class:`qibo.abstractions.gates.FusedGate`. The gates
+are then processed in the order they were added in the circuit. For each gate
+we identify the neighbors forth and back in time and attempt to fuse them to 
+the gate. Two gates can be fused if their total number of target qubits is 
+smaller than the fusion maximum qubits (specified by the user) and there are 
+no other gates between acting on the same target qubits. Gates that are fused 
+to others are marked. The new circuit queue contains the gates that remain 
+unmarked after the above operations finish.
+
+Gates are processed in the original order given by user. There are no
+additional simplifications performed such as commuting gates acting on the same
+qubit or canceling gates even when such simplifications are mathematically possible. 
+The user can specify the maximum number of qubits in a fused gate using 
+the ``max_qubits`` flag in :meth:`qibo.core.circuit.Circuit.fuse`.
 
 For example the following:
 
@@ -133,16 +142,6 @@ and the second will act to ``(1, 2)`` corresponding to
 .. code-block::  python
 
     [Y(1), Z(2), CNOT(1, 2), H(1), H(2)]
-
-Currently the maximum number of qubits in a fused gate is two. If a gate acting
-on more qubits is found it is applied as it is without participating in the
-fusion and new fusion groups are created for the gates that follow and act on
-its target qubits.
-
-The fusion algorithm fuses gates in the original order given by user. There
-are no additional simplifications performed such as commuting gates acting
-on the same qubit or canceling gates even when such simplifications are
-mathematically possible.
 
 
 Density matrix circuit

--- a/src/qibo/abstractions/abstract_gates.py
+++ b/src/qibo/abstractions/abstract_gates.py
@@ -482,14 +482,15 @@ class BaseBackendGate(Gate, ABC):
 
     @property
     def matrix(self):
-        """Unitary matrix representing the gate in the computational basis."""
-        if len(self.qubits) > 2:
-            raise_error(NotImplementedError, "Cannot calculate unitary matrix for "
-                                             "gates that target more than two qubits.")
+        """Unitary matrix representing the gate in the computational basis."""        
         if self._matrix is None:
             self._matrix = self._construct_unitary()
-        if self.is_controlled_by and tuple(self._matrix.shape) == (2, 2):
-            self._matrix = self._control_unitary(self._matrix)
+        if self.is_controlled_by:
+            if len(self.qubits) > 2:
+                raise_error(NotImplementedError, "Cannot calculate control matrix for "
+                                                 "gates that target more than two qubits.")
+            if tuple(self._matrix.shape) == (2, 2):
+                self._matrix = self._control_unitary(self._matrix)
         return self._matrix
 
     def __matmul__(self, other: "Gate") -> "Gate":

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -54,6 +54,14 @@ class _Queue(list):
             self.moments[idx][q] = gate
             self.moment_index[q] = idx + 1
 
+    def next_neighbor(self, qubit, imoment):
+        """Finds nearest neighbor gate forward in time."""
+        for i in range(imoment + 1, len(self.moments)):
+            gate = self.moments[i][qubit]
+            if gate is not None:
+                return i, gate
+        return None, None
+
 
 class AbstractCircuit(ABC):
     """Circuit object which holds a list of gates.

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -54,6 +54,13 @@ class _Queue(list):
             self.moments[idx][q] = gate
             self.moment_index[q] = idx + 1
 
+    def find_moment(self, gate):
+        """Finds index of the moment that the given gate belongs."""
+        for i, moment in enumerate(self.moments):
+            if gate in moment:
+                return i
+        raise_error(ValueError, "Gate is not part of queue.")
+
     def next_neighbor(self, qubit, imoment):
         """Finds nearest neighbor gate forward in time."""
         for i in range(imoment + 1, len(self.moments)):

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -92,9 +92,10 @@ class _Queue(list):
             parent, child = gate1, gate2
         else:
             parent, child = gate2, gate1
-        
         mparent = self.find_moment(parent)
         mchild = self.find_moment(child)
+
+        to_print = gate2.gates[0].name == "cz" and gate2.gates[0].qubits == (3, 1)
 
         # check if gates can be fused
         # this can be done when:
@@ -106,17 +107,23 @@ class _Queue(list):
             if mchild < mparent:
                 for q in child.qubits:
                     between = self.next_neighbor(q, mchild)
-                    mbetween = self.find_moment(between)
-                    if between is not None and between != parent and mbetween > mchild and mbetween <= mparent:
-                        fuse = False
-                        break
+                    if between is not None and between != parent:
+                        mbetween = self.find_moment(between)
+                        if mbetween > mchild and mbetween <= mparent:
+                            fuse = False
+                            break
             else:
                 for q in child.qubits:
                     between = self.previous_neighbor(q, mchild)
-                    mbetween = self.find_moment(between)
-                    if between is not None and between != parent and mbetween < mchild and mbetween >= mparent:
-                        fuse = False
-                        break
+                    if between is not None and between != parent:
+                        mbetween = self.find_moment(between)
+                        if to_print:
+                            print(parent.gates, mparent)
+                            print(between.gates, mbetween)
+                            print(child.gates, mchild)
+                        if mbetween < mchild and mbetween >= mparent:
+                            fuse = False
+                            break
 
         if fuse:
             child.marked = True

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -62,6 +62,14 @@ class _Queue(list):
                 return i, gate
         return None, None
 
+    def previous_neighbor(self, qubit, imoment):
+        """Finds nearest neighbor gate backward in time."""
+        for i in range(imoment - 1, -1, -1):
+            gate = self.moments[i][qubit]
+            if gate is not None:
+                return i, gate
+        return None, None
+
 
 class AbstractCircuit(ABC):
     """Circuit object which holds a list of gates.

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -54,6 +54,10 @@ class _Queue(list):
             self.moments[idx][q] = gate
             self.moment_index[q] = idx + 1
 
+    def extend(self, iterable):
+        for gate in iterable:
+            self.append(gate)
+
     def find_moment(self, gate):
         """Finds index of the moment that the given gate belongs."""
         for i, moment in enumerate(self.moments):

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -45,10 +45,14 @@ class _Queue(list):
 
     def append(self, gate: gates.Gate):
         super(_Queue, self).append(gate)
-        # Calculate moment index for this gate
         if gate.qubits:
-            idx = max(self.moment_index[q] for q in gate.qubits)
-        for q in gate.qubits:
+            qubits = gate.qubits
+        else: # special gate acting on all qubits
+            qubits = tuple(range(self.nqubits))
+
+        # calculate moment index for this gate
+        idx = max(self.moment_index[q] for q in qubits)
+        for q in qubits:
             if idx >= len(self.moments):
                 # Add a moment
                 self.moments.append(len(self.moments[-1]) * [None])

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -41,6 +41,7 @@ class _Queue(list):
         self.nqubits = nqubits
         self.moments = [nqubits * [None]]
         self.moment_index = nqubits * [0]
+        self.gate_moment = {} # mapping from ``gate`` to its moment
 
     def append(self, gate: gates.Gate):
         super(_Queue, self).append(gate)
@@ -52,6 +53,7 @@ class _Queue(list):
                 # Add a moment
                 self.moments.append(len(self.moments[-1]) * [None])
             self.moments[idx][q] = gate
+            self.gate_moment[gate] = idx
             self.moment_index[q] = idx + 1
 
     def extend(self, iterable):
@@ -60,10 +62,9 @@ class _Queue(list):
 
     def find_moment(self, gate):
         """Finds index of the moment that the given gate belongs."""
-        for i, moment in enumerate(self.moments):
-            if gate in moment:
-                return i
-        raise_error(ValueError, "Gate is not part of queue.")
+        if gate not in self.gate_moment:
+            raise_error(ValueError, "Gate is not part of queue.")
+        return self.gate_moment.get(gate)
 
     def next_neighbor(self, qubit, imoment):
         """Finds nearest neighbor gate forward in time."""
@@ -122,6 +123,7 @@ class _Queue(list):
             for q in child.qubits:
                 self.moments[mparent][q] = parent
                 self.moments[mchild][q] = None
+            self.gate_moment.pop(child)
 
 
 class AbstractCircuit(ABC):

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -102,14 +102,14 @@ class _Queue(list):
                 for q in child.qubits:
                     between = self.next_neighbor(q, mchild)
                     mbetween = self.find_moment(between)
-                    if between is not None and between != parent and mbetween > mchild:
+                    if between is not None and between != parent and mbetween > mchild and mbetween <= mparent:
                         fuse = False
                         break
             else:
                 for q in child.qubits:
                     between = self.previous_neighbor(q, mchild)
                     mbetween = self.find_moment(between)
-                    if between is not None and between != parent and mbetween < mchild:
+                    if between is not None and between != parent and mbetween < mchild and mbetween >= mparent:
                         fuse = False
                         break
 

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -90,65 +90,6 @@ class _Queue(list):
             self.moments[idx][q] = gate
             self.moment_index[q] = idx + 1
 
-    @staticmethod
-    def can_fuse(left, right, max_qubits):
-        """Check if two gates can be fused."""
-        if left is None or right is None:
-            return False
-        if left.marked or right.marked:
-            # gates are already fused
-            return False
-        if len(left.qubit_set | right.qubit_set) > max_qubits:
-            # combined qubits are more than ``max_qubits``
-            return False
-        return True
-
-    @staticmethod
-    def fuse(left, right):
-        left_gates = set(left.right_neighbors.values()) - {right}
-        right_gates = set(right.left_neighbors.values()) - {left}
-        if len(left_gates) > 0 and len(right_gates) > 0:
-            # abort if there are blocking gates between
-            return
-
-        # determine which gate will be the parent
-        qubits = left.qubit_set & right.qubit_set
-        if len(left_gates) > len(right_gates):
-            parent, child = left, right
-            between_gates = set(parent.right_neighbors.get(q) for q in qubits)
-            if between_gates == {child}:
-                child.marked = True
-                parent.append(child)
-                for q in qubits:
-                    neighbor = child.right_neighbors.get(q)
-                    if neighbor is not None:
-                        parent.right_neighbors[q] = neighbor
-                        neighbor.left_neighbors[q] = parent
-                    else:
-                        parent.right_neighbors.pop(q)
-        else:
-            parent, child = right, left
-            between_gates = set(parent.left_neighbors.get(q) for q in qubits)
-            if between_gates == {child}:
-                child.marked = True
-                parent.prepend(child)
-                for q in qubits:
-                    neighbor = child.left_neighbors.get(q)
-                    if neighbor is not None:
-                        parent.left_neighbors[q] = neighbor
-                        neighbor.right_neighbors[q] = parent
-
-        if child.marked:
-            for q in child.qubit_set - qubits:
-                neighbor = child.right_neighbors.get(q)
-                if neighbor is not None:
-                    parent.right_neighbors[q] = neighbor
-                    neighbor.left_neighbors[q] = parent
-                neighbor = child.left_neighbors.get(q)
-                if neighbor is not None:
-                    parent.left_neighbors[q] = neighbor
-                    neighbor.right_neighbors[q] = parent
-
 
 class AbstractCircuit(ABC):
     """Circuit object which holds a list of gates.

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1713,5 +1713,5 @@ class FusedGate(Gate):
     def _dagger(self):
         dagger = self.__class__(*self.init_args)
         for gate in self.gates[::-1]:
-            dagger.add(gate.dagger())
+            dagger.append(gate.dagger())
         return dagger

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1684,6 +1684,9 @@ class FusedGate(Gate):
     def from_gate(cls, gate):
         fgate = cls(*gate.qubits)
         fgate.append(gate)
+        if isinstance(gate, SpecialGate):
+            # special gates do not participate in fusion
+            fgate.marked = True
         return fgate
 
     def prepend(self, gate):

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1740,8 +1740,9 @@ class FusedGate(Gate):
             # not in the shared qubits
             return
 
-        # determine which gate will be the parent
         qubits = self.qubit_set & gate.qubit_set
+        # the gate with most neighbors different than the two gates to
+        # fuse will be the parent
         if len(left_gates) > len(right_gates):
             parent, child = self, gate
             between_gates = set(parent.right_neighbors.get(q) for q in qubits)
@@ -1768,6 +1769,7 @@ class FusedGate(Gate):
                         neighbor.right_neighbors[q] = parent
 
         if child.marked:
+            # update the neighbors graph
             for q in child.qubit_set - qubits:
                 neighbor = child.right_neighbors.get(q)
                 if neighbor is not None:

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1665,9 +1665,6 @@ class FusedGate(Gate):
 
     This gate is constructed automatically by :meth:`qibo.core.circuit.Circuit.fuse`
     and should not be used by user.
-    :class:`qibo.abstractions.gates.FusedGate` works with arbitrary number of
-    target qubits however the backend implementation
-    :class:`qibo.core.gates.FusedGate` assumes two target qubits.
     """
 
     def __init__(self, *q):

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1680,6 +1680,9 @@ class FusedGate(Gate):
         self.marked = False
         self.fused = False
 
+        self.left_neighbors = {}
+        self.right_neighbors = {}
+
     @classmethod
     def from_gate(cls, gate):
         fgate = cls(*gate.qubits)

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -1678,6 +1678,7 @@ class FusedGate(Gate):
         self.qubit_set = set(q)
         self.gates = []
         self.marked = False
+        self.fused = False
 
     @classmethod
     def from_gate(cls, gate):

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -111,8 +111,10 @@ class Circuit(circuit.AbstractCircuit):
         queue = _Queue(self.nqubits)
         queue.extend(gates.FusedGate.from_gate(gate) for gate in self.queue)
         
-        max_targets = max(len(gate.qubits) for gate in queue)
-        max_targets = max(max_qubits, max_targets)
+        #max_targets = max(len(gate.qubits) for gate in queue)
+        #max_targets = max(max_qubits, max_targets)
+
+        max_targets = max_qubits
 
         # FIXME: Handle special gates
         for gate in queue:

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -110,11 +110,6 @@ class Circuit(circuit.AbstractCircuit):
         #queue = self.fuse_neighbors()
         queue = _Queue(self.nqubits)
         queue.extend(gates.FusedGate.from_gate(gate) for gate in self.queue)
-        
-        #max_targets = max(len(gate.qubits) for gate in queue)
-        #max_targets = max(max_qubits, max_targets)
-
-        max_targets = max_qubits
 
         # FIXME: Handle special gates
         for gate in queue:
@@ -125,13 +120,13 @@ class Circuit(circuit.AbstractCircuit):
                     if not gate.marked:
                         neighbor = queue.next_neighbor(q, m)
                         if neighbor is not None and not neighbor.marked:
-                            queue.fuse(gate, neighbor, max_targets)
+                            queue.fuse(gate, neighbor, max_qubits)
 
                     # fuse nearest neighbors back in time
                     if not gate.marked:
                         neighbor = queue.previous_neighbor(q, m)
                         if neighbor is not None and not neighbor.marked:
-                            queue.fuse(gate, neighbor, max_targets)
+                            queue.fuse(gate, neighbor, max_qubits)
 
         # create a circuit and assign the new queue
         circuit = self._shallow_copy()

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -49,6 +49,9 @@ class Circuit(circuit.AbstractCircuit):
     def fuse(self, max_qubits=2):
         """Creates an equivalent circuit with the gates fused up to two-qubits.
 
+        Args:
+            max_qubits (int): Maximum number of qubits in the fused gates.
+
         Returns:
             A :class:`qibo.core.circuit.Circuit` object containing
             :class:`qibo.abstractions.gates.FusedGate` gates, each of which

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -47,7 +47,7 @@ class Circuit(circuit.AbstractCircuit):
             self.queue.append(gate.additional_unitary)
 
     def fuse(self, max_qubits=2):
-        """Creates an equivalent circuit with the gates fused up to two-qubits.
+        """Creates an equivalent circuit by fusing gates for increased simulation performance.
 
         Args:
             max_qubits (int): Maximum number of qubits in the fused gates.

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -77,16 +77,13 @@ class Circuit(circuit.AbstractCircuit):
             if not gate.marked:
                 for q in gate.qubits:
                     # fuse nearest neighbors forth in time
-                    if not gate.marked:
-                        neighbor = gate.right_neighbors.get(q)
-                        if neighbor is not None and not neighbor.marked:
-                            queue.fuse(gate, neighbor, max_qubits)
+                    neighbor = gate.right_neighbors.get(q)
+                    if queue.can_fuse(gate, neighbor, max_qubits):
+                        queue.fuse(gate, neighbor)
                     # fuse nearest neighbors back in time
-                    if not gate.marked:
-                        neighbor = gate.left_neighbors.get(q)
-                        if neighbor is not None and not neighbor.marked:
-                            queue.fuse(neighbor, gate, max_qubits)
-
+                    neighbor = gate.left_neighbors.get(q)
+                    if queue.can_fuse(gate, neighbor, max_qubits):
+                        queue.fuse(neighbor, gate)
         # create a circuit and assign the new queue
         circuit = self._shallow_copy()
         circuit.queue = queue.from_fused()

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -104,6 +104,10 @@ class Circuit(circuit.AbstractCircuit):
                     circuit.queue.append(gate.gates[0])
                 else:
                     circuit.queue.append(gate)
+            elif not gate.qubits:
+                # special gates are marked by default so we need
+                # to add them manually
+                circuit.queue.append(gate.gates[0])
         return circuit
 
     def _eager_execute(self, state):

--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -78,12 +78,12 @@ class Circuit(circuit.AbstractCircuit):
                 for q in gate.qubits:
                     # fuse nearest neighbors forth in time
                     neighbor = gate.right_neighbors.get(q)
-                    if queue.can_fuse(gate, neighbor, max_qubits):
-                        queue.fuse(gate, neighbor)
+                    if gate.can_fuse(neighbor, max_qubits):
+                        gate.fuse(neighbor)
                     # fuse nearest neighbors back in time
                     neighbor = gate.left_neighbors.get(q)
-                    if queue.can_fuse(gate, neighbor, max_qubits):
-                        queue.fuse(neighbor, gate)
+                    if gate.can_fuse(neighbor, max_qubits):
+                        neighbor.fuse(gate)
         # create a circuit and assign the new queue
         circuit = self._shallow_copy()
         circuit.queue = queue.from_fused()

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -1119,28 +1119,27 @@ class FusedGate(MatrixGate, abstract_gates.FusedGate):
         Note that this method assumes maximum two target qubits and should be
         updated if the fusion algorithm is extended to gates of higher rank.
         """
-        matrix = K.qnp.eye(2 ** len(self.target_qubits))
+        rank = len(self.target_qubits)
+        matrix = K.qnp.eye(2 ** rank)
         for gate in self.gates:
             # transfer gate matrix to numpy as it is more efficient for
             # small tensor calculations
             gmatrix = K.to_numpy(gate.matrix)
-            if len(gate.qubits) < len(self.target_qubits):
-                # fuse one-qubit gate (2x2 matrix) to a two-qubit ``FusedGate``
-                # Kronecker product with identity is needed to make the
-                # original matrix 4x4.
-                if gate.qubits[0] == self.target_qubits[0]:
-                    # gate target qubit is the first ```FusedGate`` target
-                    gmatrix = K.qnp.kron(gmatrix, K.qnp.eye(2))
-                else:
-                    # gate target qubit is the second ``FusedGate`` target
-                    gmatrix = K.qnp.kron(K.qnp.eye(2), gmatrix)
-            elif gate.qubits != self.target_qubits:
-                # fuse two-qubit gate (4x4 matrix) for which the target qubits
-                # are in opposite order compared to the ``FusedGate`` and
-                # the corresponding matrix has to be transposed before fusion
-                gmatrix = K.qnp.reshape(gmatrix, 4 * (2,))
-                gmatrix = K.qnp.transpose(gmatrix, [1, 0, 3, 2])
-                gmatrix = K.qnp.reshape(gmatrix, (4, 4))
+            # Kronecker product with identity is needed to make the
+            # original matrix have shape (2**rank x 2**rank)
+            eye = K.qnp.eye(2 ** (rank - len(gate.qubits)))
+            gmatrix = K.qnp.kron(gmatrix, eye)
+            # Transpose the new matrix indices so that it targets the
+            # target qubits of the original gate
+            original_shape = gmatrix.shape
+            gmatrix = K.qnp.reshape(gmatrix, 2 * rank * (2,))
+            qubits = list(gate.qubits)
+            indices = qubits + [q for q in self.target_qubits if q not in qubits]
+            indices = K.np.argsort(indices)
+            transpose_indices = list(indices)
+            transpose_indices.extend(indices + rank)
+            gmatrix = K.qnp.transpose(gmatrix, transpose_indices)
+            gmatrix = K.qnp.reshape(gmatrix, original_shape)
             # fuse the individual gate matrix to the total ``FusedGate`` matrix
             matrix = gmatrix @ matrix
         return K.cast(matrix)

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -1109,9 +1109,6 @@ class FusedGate(MatrixGate, abstract_gates.FusedGate):
     def __init__(self, *q):
         BackendGate.__init__(self)
         abstract_gates.FusedGate.__init__(self, *q)
-        if K.is_custom and len(self.target_qubits) > 2:
-            # Custom kernels currently support up to two target qubits
-            raise_error(NotImplementedError, "Fused gates can target up to two qubits.")
 
     def _construct_unitary(self):
         """Constructs a single unitary by multiplying the matrices of the gates that are fused.

--- a/src/qibo/tests/test_abstract_gates.py
+++ b/src/qibo/tests/test_abstract_gates.py
@@ -379,7 +379,10 @@ def test_special_gate():
 
 def test_fused_gate():
     gate = gates.FusedGate(0, 1)
-    gate.add(gates.H(0))
-    gate.add(gates.CNOT(0, 1))
-    with pytest.raises(ValueError):
-        gate.add(gates.CZ(1, 2))
+    gate.append(gates.H(0))
+    gate.append(gates.CNOT(0, 1))
+    assert len(gate.gates) == 2
+    gate.prepend(gates.TOFFOLI(0, 1, 2))
+    assert gate.qubits == (0, 1, 2)
+    assert len(gate.gates) == 3
+    assert isinstance(gate.gates[0], gates.TOFFOLI)

--- a/src/qibo/tests/test_core_fusion.py
+++ b/src/qibo/tests/test_core_fusion.py
@@ -29,9 +29,9 @@ def test_two_fusion_gate():
     c = c.fuse()
     assert len(c.queue) == 2
     fgate1, fgate2 = c.queue
-    assert fgate1.gates[0] == queue[0]
-    assert fgate1.gates[1] == queue[-1]
-    assert fgate2.gates == [queue[1], queue[2], queue[4], queue[3]]
+    assert fgate2.gates[0] == queue[0]
+    assert fgate2.gates[1] == queue[-1]
+    assert fgate1.gates == [queue[1], queue[2], queue[4], queue[3]]
 
 
 def test_fusedgate_matrix_calculation(backend):
@@ -81,7 +81,8 @@ def test_fuse_circuit_three_qubit_gate(backend, max_qubits):
 
 @pytest.mark.parametrize("nqubits", [4, 5, 10, 11])
 @pytest.mark.parametrize("nlayers", [1, 2])
-def test_variational_layer_fusion(backend, nqubits, nlayers):
+@pytest.mark.parametrize("max_qubits", [2, 3, 4])
+def test_variational_layer_fusion(backend, nqubits, nlayers, max_qubits):
     """Check fused variational layer execution."""
     theta = 2 * np.pi * np.random.random((2 * nlayers * nqubits,))
     theta_iter = iter(theta)
@@ -94,13 +95,13 @@ def test_variational_layer_fusion(backend, nqubits, nlayers):
         c.add((gates.CZ(i, i + 1) for i in range(1, nqubits - 1, 2)))
         c.add(gates.CZ(0, nqubits - 1))
 
-    fused_c = c.fuse()
+    fused_c = c.fuse(max_qubits=max_qubits)
     K.assert_allclose(fused_c(), c())
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 @pytest.mark.parametrize("ngates", [10, 20])
-@pytest.mark.parametrize("max_qubits", [2, 3])
+@pytest.mark.parametrize("max_qubits", [2, 3, 4])
 def test_random_circuit_fusion(backend, nqubits, ngates, max_qubits):
     """Check gate fusion in randomly generated circuits."""
     one_qubit_gates = [gates.RX, gates.RY, gates.RZ]

--- a/src/qibo/tests/test_core_fusion.py
+++ b/src/qibo/tests/test_core_fusion.py
@@ -63,7 +63,8 @@ def test_fuse_circuit_two_qubit_gates(backend):
     K.assert_allclose(fused_c(), c())
 
 
-def test_fuse_circuit_three_qubit_gate(backend):
+@pytest.mark.parametrize("max_qubits", [2, 3, 4])
+def test_fuse_circuit_three_qubit_gate(backend, max_qubits):
     """Check circuit fusion in circuit with three-qubit gate."""
     c = Circuit(4)
     c.add((gates.H(i) for i in range(4)))
@@ -74,7 +75,7 @@ def test_fuse_circuit_three_qubit_gate(backend):
     c.add((gates.H(i) for i in range(4)))
     c.add(gates.CNOT(0, 1))
     c.add(gates.CZ(2, 3))
-    fused_c = c.fuse()
+    fused_c = c.fuse(max_qubits=max_qubits)
     K.assert_allclose(fused_c(), c(), atol=1e-12)
 
 
@@ -99,7 +100,8 @@ def test_variational_layer_fusion(backend, nqubits, nlayers):
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 @pytest.mark.parametrize("ngates", [10, 20])
-def test_random_circuit_fusion(backend, nqubits, ngates):
+@pytest.mark.parametrize("max_qubits", [2, 3])
+def test_random_circuit_fusion(backend, nqubits, ngates, max_qubits):
     """Check gate fusion in randomly generated circuits."""
     one_qubit_gates = [gates.RX, gates.RY, gates.RZ]
     two_qubit_gates = [gates.CNOT, gates.CZ, gates.SWAP]
@@ -114,7 +116,7 @@ def test_random_circuit_fusion(backend, nqubits, ngates):
         while q0 == q1:
             q0, q1 = np.random.randint(0, nqubits, (2,))
         c.add(gate(q0, q1))
-    fused_c = c.fuse()
+    fused_c = c.fuse(max_qubits=max_qubits)
     K.assert_allclose(fused_c(), c(), atol=1e-7)
 
 

--- a/src/qibo/tests/test_core_fusion.py
+++ b/src/qibo/tests/test_core_fusion.py
@@ -76,7 +76,12 @@ def test_fuse_circuit_three_qubit_gate(backend, max_qubits):
     c.add(gates.CNOT(0, 1))
     c.add(gates.CZ(2, 3))
     fused_c = c.fuse(max_qubits=max_qubits)
-    K.assert_allclose(fused_c(), c(), atol=1e-12)
+    if K.name == "qibotf" and max_qubits > 2:
+        # qibotf does not support multi-qubit kernel
+        with pytest.raises(NotImplementedError):
+            _ = fused_c()
+    else:
+        K.assert_allclose(fused_c(), c(), atol=1e-12)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5, 10, 11])
@@ -96,7 +101,10 @@ def test_variational_layer_fusion(backend, nqubits, nlayers, max_qubits):
         c.add(gates.CZ(0, nqubits - 1))
 
     fused_c = c.fuse(max_qubits=max_qubits)
-    K.assert_allclose(fused_c(), c())
+    if K.name == "qibotf" and max_qubits > 2:
+        pytest.skip("qibotf does not support multi-qubit kernel")
+    else:
+        K.assert_allclose(fused_c(), c())
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
@@ -118,7 +126,10 @@ def test_random_circuit_fusion(backend, nqubits, ngates, max_qubits):
             q0, q1 = np.random.randint(0, nqubits, (2,))
         c.add(gate(q0, q1))
     fused_c = c.fuse(max_qubits=max_qubits)
-    K.assert_allclose(fused_c(), c(), atol=1e-7)
+    if K.name == "qibotf" and max_qubits > 2:
+        pytest.skip("qibotf does not support multi-qubit kernel")
+    else:
+        K.assert_allclose(fused_c(), c(), atol=1e-7)
 
 
 def test_controlled_by_gates_fusion(backend):

--- a/src/qibo/tests/test_core_fusion.py
+++ b/src/qibo/tests/test_core_fusion.py
@@ -114,8 +114,6 @@ def test_random_circuit_fusion(backend, nqubits, ngates):
         while q0 == q1:
             q0, q1 = np.random.randint(0, nqubits, (2,))
         c.add(gate(q0, q1))
-    
-    print(c.to_qasm())
     fused_c = c.fuse()
     K.assert_allclose(fused_c(), c(), atol=1e-7)
 
@@ -133,7 +131,6 @@ def test_controlled_by_gates_fusion(backend):
     K.assert_allclose(fused_c(), c())
 
 
-@pytest.mark.skip
 def test_callbacks_fusion(backend):
     """Check entropy calculation in fused circuit."""
     from qibo import callbacks

--- a/src/qibo/tests/test_core_gates.py
+++ b/src/qibo/tests/test_core_gates.py
@@ -612,6 +612,5 @@ def test_fused_gate_construct_unitary(backend, nqubits):
         gate.append(gates.TOFFOLI(0, 1, 2))
         toffoli = np.eye(8)
         toffoli[-2:, -2:] = np.array([[0, 1], [1, 0]])
-        print(toffoli)
         target_matrix = toffoli @ np.kron(target_matrix, np.eye(2))
     K.assert_allclose(gate.matrix, target_matrix)


### PR DESCRIPTION
Extends the `circuit.fuse()` to work with more than two qubits in the fused gates. The maximum number of qubits in a `FusedGate` is passed as argument in `circuit.fuse(max_qubits)`.

Here are some benchmarks comparing this with the two qubit fusion currently implemented in qibo:

<details>
<summary>variational - cupy</summary>

|   nqubits |   no fusion |  fusion master |  fusion (max_qubits=2) this branch |
|----------:|------------------------:|-------------------------------:|--------------------------------:|
|        20 |              0.00650024 |                     0.00381665 |                      0.00400567 |
|        21 |              0.013676   |                     0.00941253 |                      0.00939865 |
|        22 |              0.0244068  |                     0.0174996  |                      0.0174672  |
|        23 |              0.0470985  |                     0.0336952  |                      0.0337574  |
|        24 |              0.0919702  |                     0.0676015  |                      0.066224   |
|        25 |              0.183358   |                     0.132579   |                      0.132887   |
|        26 |              0.372621   |                     0.263389   |                      0.264354   |
|        27 |              0.751765   |                     0.53461    |                      0.53431    |
|        28 |              1.53455    |                     1.07948    |                      1.08052    |
|        29 |              3.0932     |                     2.1975     |                      2.17422    |
|        30 |              6.31183    |                     4.39072    |                      4.41419    |

</details>
<details>
<summary>supremacy - cupy</summary>

|   nqubits |   no fusion |  fusion master |  fusion (max_qubits=2) this branch |
|----------:|------------------------:|-------------------------------:|--------------------------------:|
|        20 |              0.00714312 |                     0.00362139 |                      0.00368185 |
|        21 |              0.0147595  |                     0.00922861 |                      0.00924082 |
|        22 |              0.0276767  |                     0.0176665  |                      0.017413   |
|        23 |              0.0532548  |                     0.0345442  |                      0.0344771  |
|        24 |              0.103385   |                     0.0685107  |                      0.0681491  |
|        25 |              0.208079   |                     0.13674    |                      0.136516   |
|        26 |              0.426755   |                     0.273745   |                      0.272982   |
|        27 |              0.855133   |                     0.550696   |                      0.550875   |
|        28 |              1.74063    |                     1.10813    |                      1.1088     |
|        29 |              3.55886    |                     2.25113    |                      2.24221    |
|        30 |              7.29316    |                     4.56042    |                      4.54837    |

</details>

<details>
<summary>variational - numba</summary>

|   nqubits |   no fusion |  fusion master |  fusion (max_qubits=2) this branch |
|----------:|------------------------:|-------------------------------:|--------------------------------:|
|        20 |              0.00717251 |                      0.0044237 |                      0.00438499 |
|        21 |              0.0145025  |                      0.0073688 |                      0.00857282 |
|        22 |              0.0245298  |                      0.014758  |                      0.0153122  |
|        23 |              0.0596275  |                      0.0320367 |                      0.0331313  |
|        24 |              0.192632   |                      0.0801779 |                      0.0694064  |
|        25 |              0.510924   |                      0.153383  |                      0.167004   |
|        26 |              1.08237    |                      0.357689  |                      0.351768   |
|        27 |              2.20973    |                      0.721261  |                      0.715018   |
|        28 |              4.70274    |                      1.47233   |                      1.53245    |
|        29 |              9.43148    |                      3.00157   |                      2.90914    |
|        30 |             19.8349     |                      6.3264    |                      6.12652    |

</details>
<details>
<summary>supremacy - numba</summary>

|   nqubits |   no fusion |  fusion master |  fusion (max_qubits=2) this branch |
|----------:|------------------------:|-------------------------------:|--------------------------------:|
|        20 |              0.00855581 |                     0.00485126 |                      0.00415087 |
|        21 |              0.0166401  |                     0.0092756  |                      0.00953794 |
|        22 |              0.0302078  |                     0.0158449  |                      0.0157746  |
|        23 |              0.0734877  |                     0.0407141  |                      0.0391196  |
|        24 |              0.232868   |                     0.0951609  |                      0.0730411  |
|        25 |              0.63422    |                     0.19142    |                      0.176894   |
|        26 |              1.37733    |                     0.374858   |                      0.37815    |
|        27 |              2.78392    |                     0.760626   |                      0.774159   |
|        28 |              5.74549    |                     1.6226     |                      1.60402    |
|        29 |             11.8313     |                     3.38964    |                      3.31643    |
|        30 |             24.7313     |                     6.58238    |                      6.7799     |

</details>


where we see that the two-qubit fusion performance remains the same as master. Here is a comparison to qiskit using max_qubits>=2:

<details>
<summary>supremacy - max_qubits = 2</summary>

|   nqubits |   qibo | qiskit |
|----------:|-----------------------------:|-------------------------------:|
|        20 |                   0.00424743 |                     0.00561269 |
|        21 |                   0.00906237 |                     0.00931303 |
|        22 |                   0.0149677  |                     0.0182811  |
|        23 |                   0.0361267  |                     0.0290986  |
|        24 |                   0.0923665  |                     0.0631892  |
|        25 |                   0.191264   |                     0.179972   |
|        26 |                   0.377141   |                     0.391424   |
|        27 |                   0.76376    |                     0.814479   |
|        28 |                   1.6189     |                     1.67025    |

</details>
<details>
<summary>supremacy - max_qubits = 3</summary>

|   nqubits |   qibo | qiskit |
|----------:|-----------------------------:|-------------------------------:|
|        20 |                   0.0038631  |                     0.00545168 |
|        21 |                   0.00901151 |                     0.0123674  |
|        22 |                   0.0169856  |                     0.0137096  |
|        23 |                   0.0338949  |                     0.0283528  |
|        24 |                   0.0888384  |                     0.046873   |
|        25 |                   0.176907   |                     0.136258   |
|        26 |                   0.375311   |                     0.224167   |
|        27 |                   0.769534   |                     0.450493   |
|        28 |                   1.62279    |                     0.945164   |

</details>
<details>
<summary>supremacy - max_qubits = 4</summary>

|   nqubits |   qibo | qiskit |
|----------:|-----------------------------:|-------------------------------:|
|        20 |                   0.00426801 |                     0.00549873 |
|        21 |                   0.00928775 |                     0.00831294 |
|        22 |                   0.0149652  |                     0.0233534  |
|        23 |                   0.0348389  |                     0.0303541  |
|        24 |                   0.078332   |                     0.0461663  |
|        25 |                   0.176815   |                     0.122285   |
|        26 |                   0.379753   |                     0.235653   |
|        27 |                   0.768286   |                     0.454412   |
|        28 |                   1.63447    |                     0.94747    |

</details>
<details>
<summary>supremacy - max_qubits = 5</summary>

|   nqubits |   qibo | qiskit |
|----------:|-----------------------------:|-------------------------------:|
|        20 |                   0.00449403 |                     0.012344   |
|        21 |                   0.00916354 |                     0.00820939 |
|        22 |                   0.0154273  |                     0.018616   |
|        23 |                   0.033929   |                     0.0309339  |
|        24 |                   0.0851702  |                     0.0657368  |
|        25 |                   0.186404   |                     0.116064   |
|        26 |                   0.373424   |                     0.232725   |
|        27 |                   0.754416   |                     0.44802    |
|        28 |                   1.61651    |                     0.954646   |

</details>

where we see that we do not get improvement when using max_qubits > 2, in contrast to other libraries (qiskit, qsim). This is more likely associated to qiboteam/qibojit#51 about multi-qubit custom operators. 

Regardless, I believe that this PR is useful to have since it doesn't affect any current feature (two-qubit fusion performance remains the same) and enables higher order fusion, even if it is not really optimized. If we improve the multi-qubit operators in qibojit, hopefully this will work better.