### PR TITLE
Fix pickle for the backend object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     ],
     extras_require={
         "docs": ["sphinx", "sphinx_rtd_theme", "recommonmark", "sphinxcontrib-bibtex", "sphinx_markdown_tables", "nbsphinx", "IPython"],
-        "tests": ["pytest", "cirq", "ply", "sklearn"],
+        "tests": ["pytest", "cirq", "ply", "sklearn", "dill"],
     },
     python_requires=">=3.7.0",
     long_description=long_description,

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -136,6 +136,26 @@ class Backend:
 
         return self.constructed_backends.get(name)
 
+    def __getstate__(self):
+        return {
+            "profile": self.profile,
+            "_availability": self._availability,
+            "qnp": self.qnp,
+            "_backends_min_version": self._backends_min_version,
+            "constructed_backends": self.constructed_backends,
+            "hardware_backends": self.hardware_backends,
+            "active_backend": self.active_backend
+        }
+
+    def __setstate__(self, data):
+        self.profile = data.get("profile")
+        self._availability = data.get("_availability")
+        self.qnp = data.get("qnp")
+        self._backends_min_version = data.get("_backends_min_version")
+        self.constructed_backends = data.get("constructed_backends")
+        self.hardware_backends = data.get("hardware_backends")
+        self.active_backend = data.get("active_backend")
+
     def __getattr__(self, x):
         return getattr(self.active_backend, x)
 

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -137,24 +137,10 @@ class Backend:
         return self.constructed_backends.get(name)
 
     def __getstate__(self):
-        return {
-            "profile": self.profile,
-            "_availability": self._availability,
-            "qnp": self.qnp,
-            "_backends_min_version": self._backends_min_version,
-            "constructed_backends": self.constructed_backends,
-            "hardware_backends": self.hardware_backends,
-            "active_backend": self.active_backend
-        }
+        return self.active_backend
 
-    def __setstate__(self, data):
-        self.profile = data.get("profile")
-        self._availability = data.get("_availability")
-        self.qnp = data.get("qnp")
-        self._backends_min_version = data.get("_backends_min_version")
-        self.constructed_backends = data.get("constructed_backends")
-        self.hardware_backends = data.get("hardware_backends")
-        self.active_backend = data.get("active_backend")
+    def __setstate__(self, backend):
+        self.active_backend = backend
 
     def __getattr__(self, x):
         return getattr(self.active_backend, x)

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -9,6 +9,19 @@ def test_construct_backend(backend_name):
         bk = K.construct_backend("nonexistent")
 
 
+def test_pickle(backend_name):
+    """Check ``K.__setstate__`` and ``K.__getstate__`` methods."""
+    import dill
+    from qibo.backends import Backend
+    backend = Backend()
+    backend.active_backend = backend.construct_backend(backend_name)
+    if backend_name in ("tensorflow", "qibotf"):
+        pytest.skip("Tensorflow backend cannot be pickled.")
+    serial = dill.dumps(backend)
+    new_backend = dill.loads(serial)
+    assert new_backend.name == backend.name
+
+
 def test_set_backend(backend_name):
     """Check ``set_backend`` for switching gate backends."""
     original_backend = backends.get_backend()


### PR DESCRIPTION
Attempting to dump the backend object `K` with `dill` leads to a maximum recursion error which is associated with the `__getattr__` method that we use for implementing the backend methods. Btw, method seems a bit unstable in general, it could be useful to consider alternatives.

This PR implements a workaround for dill by defining custom `__setstate__` and `__getstate__` methods for the backend.