### PR TITLE
Fix backend pickle

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -137,10 +137,24 @@ class Backend:
         return self.constructed_backends.get(name)
 
     def __getstate__(self):
-        return self.active_backend
+        return {
+            "profile": self.profile,
+            "_availability": self._availability,
+            "qnp": self.qnp,
+            "_backends_min_version": self._backends_min_version,
+            "constructed_backends": self.constructed_backends,
+            "hardware_backends": self.hardware_backends,
+            "active_backend": self.active_backend
+        }
 
-    def __setstate__(self, backend):
-        self.active_backend = backend
+    def __setstate__(self, data):
+        self.profile = data.get("profile")
+        self._availability = data.get("_availability")
+        self.qnp = data.get("qnp")
+        self._backends_min_version = data.get("_backends_min_version")
+        self.constructed_backends = data.get("constructed_backends")
+        self.hardware_backends = data.get("hardware_backends")
+        self.active_backend = data.get("active_backend")
 
     def __getattr__(self, x):
         return getattr(self.active_backend, x)

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -18,10 +18,8 @@ def test_pickle(backend_name):
     if backend_name in ("tensorflow", "qibotf"):
         pytest.skip("Tensorflow backend cannot be pickled.")
     serial = dill.dumps(backend)
-    print(type(backend))
     new_backend = dill.loads(serial)
     assert new_backend.name == backend.name
-    print(type(new_backend))
     original_backend = new_backend.active_backend.name
     new_backend.active_backend = new_backend.construct_backend("numpy")
 

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -18,8 +18,12 @@ def test_pickle(backend_name):
     if backend_name in ("tensorflow", "qibotf"):
         pytest.skip("Tensorflow backend cannot be pickled.")
     serial = dill.dumps(backend)
+    print(type(backend))
     new_backend = dill.loads(serial)
     assert new_backend.name == backend.name
+    print(type(new_backend))
+    original_backend = new_backend.active_backend.name
+    new_backend.active_backend = new_backend.construct_backend("numpy")
 
 
 def test_set_backend(backend_name):


### PR DESCRIPTION
The following:
```py
import qibo
import dill

qibo.set_backend("qibolab")
dill.dump_session("session.pkl")
dill.load_session("session.pkl")
qibo.set_backend("numpy")
```
namely changing the backend after loading a session from pickle fails with `AttributeError`. Here the `__getitem__` and `__setitem__` methods are update to pickle and load all the attributes of the `Backend` object to fix this issue.