### PR TITLE
Fix `tf.math.mod` on GPU

### DIFF
--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -241,7 +241,8 @@ class TensorflowBackend(NumpyBackend):
 
     def samples_to_binary(self, samples, nqubits):
         # redefining this because ``tnp.right_shift`` is not available
-        qrange = self.np.arange(nqubits - 1, -1, -1, dtype="int64")
+        qrange = self.np.arange(nqubits - 1, -1, -1, dtype="int32")
+        samples = self.tf.cast(samples, dtype="int32")
         samples = self.tf.bitwise.right_shift(samples[:, self.np.newaxis], qrange)
         return self.tf.math.mod(samples, 2)
 
@@ -305,9 +306,15 @@ class TensorflowBackend(NumpyBackend):
                 [4, 0, 0, 0, 0, 0, 0, 4, 4, 0]
             ]
         elif name == "test_probabilistic_measurement":
-            return {0: 271, 1: 239, 2: 242, 3: 248}
+            if "GPU" in self.device:  # pragma: no cover
+                return {0: 273, 1: 233, 2: 242, 3: 252}
+            else:
+                return {0: 271, 1: 239, 2: 242, 3: 248}
         elif name == "test_unbalanced_probabilistic_measurement":
-            return {0: 168, 1: 188, 2: 154, 3: 490}
+            if "GPU" in self.device:  # pragma: no cover
+                return {0: 196, 1: 153, 2: 156, 3: 495}
+            else:
+                return {0: 168, 1: 188, 2: 154, 3: 490}
         elif name == "test_post_measurement_bitflips_on_circuit":
             return [
                 {5: 30}, {5: 16, 7: 10, 6: 2, 3: 1, 4: 1},


### PR DESCRIPTION
The latest tensorflow appears to have an issue on GPU. The following script:
```py
import numpy as np
import tensorflow as tf

x = tf.cast(np.random.randint(10, size=(10,)), dtype="int64")
y = tf.math.mod(x, 2)
```
fails with
```
tensorflow.python.framework.errors_impl.UnknownError: JIT compilation failed. [Op:FloorMod]
```
It works if I change the precision to int32. On CPU it works with both precisions.

This causes some tests in #584 to fail on tensorflow GPU. Here I change the precisions in the related methods to int32, to avoid these issues.