### PR TITLE
Delegate `CircuitResult.probabilities()` to the backend

### DIFF
--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -204,6 +204,17 @@ class Backend(abc.ABC):
         raise_error(NotImplementedError)
 
     @abc.abstractmethod
+    def circuit_result_probabilities(self, result, qubits=None):  # pragma: no cover
+        """Calculates measurement probabilities by tracing out qubits.
+
+        Args:
+            result (:class:`qibo.states.CircuitResult`): Result object that contains
+                the data required to represent the state.
+            qubits (list, set): Set of qubits that are measured.
+        """
+        raise_error(NotImplementedError)
+
+    @abc.abstractmethod
     def calculate_symbolic(self, state, nqubits, decimals=5, cutoff=1e-10, max_terms=20): # pragma: no cover
         """Dirac representation of a state vector."""
         raise_error(NotImplementedError)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -395,6 +395,16 @@ class NumpyBackend(Backend):
     def circuit_result_tensor(self, result):
         return result.execution_result
 
+    def circuit_result_probabilities(self, result, qubits=None):
+        if qubits is None:  # pragma: no cover
+            qubits = result.circuit.measurement_gate.qubits
+
+        state = self.circuit_result_tensor(result)
+        if result.density_matrix:
+            return self.calculate_probabilities_density_matrix(state, qubits, result.nqubits)
+        else:
+            return self.calculate_probabilities(state, qubits, result.nqubits)
+
     def calculate_symbolic(self, state, nqubits, decimals=5, cutoff=1e-10, max_terms=20):
         state = self.to_numpy(state)
         terms = []

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -80,19 +80,10 @@ class CircuitResult:
     def probabilities(self, qubits=None):
         """Calculates measurement probabilities by tracing out qubits.
 
-        Exactly one of the following arguments should be given.
-
         Args:
             qubits (list, set): Set of qubits that are measured.
         """
-        if qubits is None:  # pragma: no cover
-            qubits = self.circuit.measurement_gate.qubits
-
-        state = self.backend.circuit_result_tensor(self)
-        if self.density_matrix:
-            return self.backend.calculate_probabilities_density_matrix(state, qubits, self.nqubits)
-        else:
-            return self.backend.calculate_probabilities(state, qubits, self.nqubits)
+        return self.backend.circuit_result_probabilities(self, qubits)
 
     def samples(self, binary=True, registers=False):
         """Returns raw measurement samples.


### PR DESCRIPTION
Moves the implementation of `CircuitResult.probabilities()` to the backend, to allow having alternative implementations of the probability calculation on hardware backends. Unlike simulation, hardware backends do not rely on the state vector tensor to calculate measurement probabilities.

Similar refactoring may be required for `CircuitResult.samples()` and `CircuitResult.frequencies()` depending on hardware needs.