### PR TITLE
Fix docs compilation

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install package
       run: |
         python -m pip install --upgrade pip
+        pip install markdown==3.3.7 # docs fail with >=3.4
         pip install pytest-cov
         pip install .[tests,docs]
         pip install git+https://github.com/qiboteam/qibojit


### PR DESCRIPTION
I pinned the version of markdown to 3.3.7 to fix the issue with the compilation of documentation. @scarrazza, I am not sure if that's the best solution but it works for now.