### PR TITLE
Fix expectation value of symbolic Hamiltonian

### DIFF
--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -349,13 +349,15 @@ class Backend(abc.ABC):
         raise_error(NotImplementedError)
 
     @abc.abstractmethod
-    def calculate_expectation_state(self, matrix, state, normalize):  # pragma: no cover
+    def calculate_expectation_state(
+        self, hamiltonian, state, normalize
+    ):  # pragma: no cover
         """Calculate expectation value of a state vector given the observable matrix."""
         raise_error(NotImplementedError)
 
     @abc.abstractmethod
     def calculate_expectation_density_matrix(
-        self, matrix, state, normalize
+        self, hamiltonian, state, normalize
     ):  # pragma: no cover
         """Calculate expectation value of a density matrix given the observable matrix."""
         raise_error(NotImplementedError)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -643,17 +643,17 @@ class NumpyBackend(Backend):
             ud = self.np.transpose(self.np.conj(eigenvectors))
             return self.np.matmul(eigenvectors, self.np.matmul(expd, ud))
 
-    def calculate_expectation_state(self, matrix, state, normalize):
+    def calculate_expectation_state(self, hamiltonian, state, normalize):
         statec = self.np.conj(state)
-        hstate = matrix @ state
+        hstate = hamiltonian @ state
         ev = self.np.real(self.np.sum(statec * hstate))
         if normalize:
             norm = self.np.sum(self.np.square(self.np.abs(state)))
             ev = ev / norm
         return ev
 
-    def calculate_expectation_density_matrix(self, matrix, state, normalize):
-        ev = self.np.real(self.np.trace(matrix @ state))
+    def calculate_expectation_density_matrix(self, hamiltonian, state, normalize):
+        ev = self.np.real(self.np.trace(hamiltonian @ state))
         if normalize:
             norm = self.np.real(self.np.trace(state))
             ev = ev / norm

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -114,12 +114,10 @@ class Hamiltonian(AbstractHamiltonian):
         if isinstance(state, self.backend.tensor_types):
             shape = tuple(state.shape)
             if len(shape) == 1:  # state vector
-                return self.backend.calculate_expectation_state(
-                    self.matrix, state, normalize
-                )
+                return self.backend.calculate_expectation_state(self, state, normalize)
             elif len(shape) == 2:  # density matrix
                 return self.backend.calculate_expectation_density_matrix(
-                    self.matrix, state, normalize
+                    self, state, normalize
                 )
             else:
                 raise_error(
@@ -664,7 +662,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
                 self.backend,
                 self.backend.cast(state, copy=True),
                 self.nqubits,
-                density_matrix,
+                density_matrix=density_matrix,
             )
         if self.constant:  # pragma: no cover
             total += self.constant * state


### PR DESCRIPTION
Fix #639.

@chmwzc if you have time please give a try if this solves your issue.

The following script can be used to compare with master
```py
import numpy as np
from qibo.hamiltonians import XXZ

nqubits = 20
state = np.random.random(2 ** nqubits) + 1j * np.random.random(2 ** nqubits)
state = state / np.sqrt(np.sum(np.abs(state) ** 2))

ham = XXZ(nqubits, dense=False)

expectation = np.real(np.dot(np.conj(state), ham @ state))
print(expectation)
print(ham.expectation(state))
```