### PR TITLE
Add version attribute in backends

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -19,6 +19,7 @@ class NumpyBackend(Backend):
         self.name = "numpy"
         self.matrices = Matrices(self.dtype)
         self.tensor_types = np.ndarray
+        self.version = np.__version__
         self.numeric_types = (
             int,
             float,

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -169,6 +169,8 @@ class TensorflowBackend(NumpyBackend):
         import tensorflow as tf
         import tensorflow.experimental.numpy as tnp  # pylint: disable=E0401
 
+        self.version = tf.__version__
+
         tnp.experimental_enable_numpy_behavior()
         self.tf = tf
         self.np = tnp


### PR DESCRIPTION
As suggested by @stavros11 in qiboteam/qcvv#66, I am adding an attribute containing the backend version
Given that the qibo version is already stored in the report, I choose to save directly the version of the library used by the backend. 