### PR TITLE
Measurement fixes and improvements

### DIFF
--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -436,18 +436,19 @@ any parametrized gate as follows:
     c = Circuit(2)
     c.add(gates.H(0))
     output = c.add(gates.M(0, collapse=True))
-    c.add(gates.RX(1, theta=np.pi * output / 4))
+    c.add(gates.RX(1, theta=np.pi * output.symbols[0] / 4))
     result = c()
 
 In this case the first qubit will be measured and if 1 is found a pi/4 X-rotation
 will be applied to the second qubit, otherwise no rotation. Qibo allows to
-use ``output`` as a parameter during circuit creation by representing it using
-a ``sympy.Symbol``. The symbol acquires a numerical value later during execution
-when the measurement is performed. As explained above, if a ``nshots > 1`` is
-given during circuit execution the execution is repeated using a loop.
+use ``output`` as a parameter during circuit creation through the use of
+``sympy.Symbol`` objects. These symbols can be accessed through the ``output.symbols``
+list and they acquire a numerical value during execution when the measurement
+is performed. As explained above, if ``nshots > 1`` is given during circuit
+execution the execution is repeated using a loop.
 
 If more than one qubits are used in a ``collapse=True`` measurement gate the
-``output`` can be indexed accordingly:
+``output.symbols`` list can be indexed accordingly:
 
 .. testcode::
 
@@ -458,8 +459,8 @@ If more than one qubits are used in a ``collapse=True`` measurement gate the
     c = Circuit(3)
     c.add(gates.H(0))
     output = c.add(gates.M(0, 1, collapse=True))
-    c.add(gates.RX(1, theta=np.pi * output[0] / 4))
-    c.add(gates.RY(2, theta=np.pi * (output[0] + output[1]) / 5))
+    c.add(gates.RX(1, theta=np.pi * output.symbols[0] / 4))
+    c.add(gates.RY(2, theta=np.pi * (output.symbols[0] + output.symbols[1]) / 5))
     result = c()
 
 

--- a/examples/shor/functions.py
+++ b/examples/shor/functions.py
@@ -385,19 +385,19 @@ def quantum_order_finding_semiclassical(N, a):
     # Using multiple measurements for the semiclassical QFT.
     for i in range(1, 2 * n):
         # reset measured qubit to |0>
-        circuit.add(gates.RX(q_reg, theta=np.pi * results[-1]))
+        circuit.add(gates.RX(q_reg, theta=np.pi * results[-1].symbols[0]))
         circuit.add(gates.H(q_reg))
         # a_i = (a**(2**(2*n - 1 - i)))
         circuit.add(c_U(q_reg, x, b, exponents[-1 - i], N, ancilla, n))
         angle = 0
         for k in range(2, i + 2):
-            angle += 2 * np.pi * results[i + 1 - k] / (2**k)
+            angle += 2 * np.pi * results[i + 1 - k].symbols[0] / (2**k)
         circuit.add(gates.U1(q_reg, -angle))
         circuit.add(gates.H(q_reg))
         results.append(circuit.add(gates.M(q_reg, collapse=True)))
 
     circuit()  # execute
-    s = sum(int(r.outcome()) * (2**i) for i, r in enumerate(results))
+    s = sum(int(r.symbols[0].outcome()) * (2**i) for i, r in enumerate(results))
     print(f"The quantum circuit measures s = {s}.\n")
     return s
 

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -411,13 +411,13 @@ class NumpyBackend(Backend):
                             gate.substitute_symbols()
                         state = gate.apply(self, state, nqubits)
 
-            if circuit.measurement_gate:
+            if circuit.measurements:
                 result = CircuitResult(self, circuit, state, 1)
-                results.append(result.samples(binary=False)[0])
+                results.append(result.samples()[0])
             else:
                 results.append(state)
 
-        if circuit.measurement_gate:
+        if circuit.measurements:
             final_result = CircuitResult(self, circuit, state, nshots)
             final_result._samples = self.aggregate_shots(results)
             circuit._final_state = final_result

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -87,7 +87,7 @@ class M(Gate):
         self.target_qubits = tuple(q)
         self.register_name = register_name
         self.collapse = collapse
-        self.result = None
+        self._result = None
 
         self.init_args = q
         self.init_kwargs = {
@@ -102,13 +102,19 @@ class M(Gate):
                     NotImplementedError,
                     "Bitflip measurement noise is not " "available when collapsing.",
                 )
-            self.result = MeasurementResult(self)
+            self._result = MeasurementResult(self)
 
         if p1 is None:
             p1 = p0
         if p0 is None:
             p0 = p1
         self.bitflip_map = (self._get_bitflip_map(p0), self._get_bitflip_map(p1))
+
+    @property
+    def result(self):
+        if self._result is None:
+            self._result = MeasurementResult(self)
+        return self._result
 
     @staticmethod
     def _get_bitflip_tuple(qubits: Tuple[int], probs: "ProbsType") -> Tuple[float]:

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -238,6 +238,9 @@ class M(Gate):
         )
 
     def apply(self, backend, state, nqubits):
+        if not self.collapse:
+            return state
+
         qubits = sorted(self.target_qubits)
         # measure and get result
         probs = backend.calculate_probabilities(state, qubits, nqubits)
@@ -250,6 +253,9 @@ class M(Gate):
         return backend.collapse_state(state, qubits, shot, nqubits)
 
     def apply_density_matrix(self, backend, state, nqubits):
+        if not self.collapse:
+            return state
+
         qubits = sorted(self.target_qubits)
         # measure and get result
         probs = backend.calculate_probabilities_density_matrix(state, qubits, nqubits)

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -87,7 +87,7 @@ class M(Gate):
         self.target_qubits = tuple(q)
         self.register_name = register_name
         self.collapse = collapse
-        self._result = None
+        self.result = MeasurementResult(self)
 
         self.init_args = q
         self.init_kwargs = {
@@ -102,19 +102,12 @@ class M(Gate):
                     NotImplementedError,
                     "Bitflip measurement noise is not " "available when collapsing.",
                 )
-            self._result = MeasurementResult(self)
 
         if p1 is None:
             p1 = p0
         if p0 is None:
             p0 = p1
         self.bitflip_map = (self._get_bitflip_map(p0), self._get_bitflip_map(p1))
-
-    @property
-    def result(self):
-        if self._result is None:
-            self._result = MeasurementResult(self)
-        return self._result
 
     @staticmethod
     def _get_bitflip_tuple(qubits: Tuple[int], probs: "ProbsType") -> Tuple[float]:

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -565,6 +565,11 @@ class Circuit:
                     return gate.result
                 else:
                     self.measurements.append(gate)
+            else:
+                for measurement in self.measurements:
+                    if set(measurement.qubits) & set(gate.qubits):
+                        measurement.collapse = True
+                        self.repeated_execution = True
 
             if isinstance(gate, gates.UnitaryChannel):
                 self.repeated_execution = not self.density_matrix

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -42,6 +42,7 @@ class _Queue(list):
         self.nqubits = nqubits
         self.moments = [nqubits * [None]]
         self.moment_index = nqubits * [0]
+        self.nmeasurements = 0
 
     def to_fused(self):
         """Transforms all gates in queue to :class:`qibo.gates.FusedGate`."""
@@ -81,6 +82,9 @@ class _Queue(list):
             qubits = gate.qubits
         else:  # special gate acting on all qubits
             qubits = tuple(range(self.nqubits))
+
+        if isinstance(gate, gates.M):
+            self.nmeasurements += 1
 
         # calculate moment index for this gate
         idx = max(self.moment_index[q] for q in qubits)
@@ -556,7 +560,8 @@ class Circuit:
             if isinstance(gate, gates.M):
                 if gate.register_name is None:
                     # add default register name
-                    gate.register_name = f"register{len(self.measurements)}"
+                    nreg = self.queue.nmeasurements - 1
+                    gate.register_name = f"register{nreg}"
                 else:
                     name = gate.register_name
                     for mgate in self.measurements:

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -562,7 +562,7 @@ class Circuit:
                         )
                 if gate.collapse:
                     self.repeated_execution = True
-                    return gate.get_symbols()
+                    return gate.result
                 else:
                     self.measurements.append(gate)
 

--- a/src/qibo/models/distcircuit.py
+++ b/src/qibo/models/distcircuit.py
@@ -118,6 +118,9 @@ class DistributedQueues:
         This method also creates the ``DistributedQubits`` object holding the
         global qubits list.
         """
+        queue = [
+            gate for gate in queue if not isinstance(gate, gates.M) or gate.collapse
+        ]
         counter = self.count(queue, self.nqubits)
         if self.qubits is None:
             self.qubits = DistributedQubits(

--- a/src/qibo/noise.py
+++ b/src/qibo/noise.py
@@ -106,6 +106,4 @@ class NoiseModel:
                     qubits = tuple(set(gate.qubits) & set(qubits))
                 for q in qubits:
                     noisy_circuit.add(error.channel(q, *error.options))
-        noisy_circuit.measurement_tuples = dict(circuit.measurement_tuples)
-        noisy_circuit.measurement_gate = circuit.measurement_gate
         return noisy_circuit

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import collections
 
+import numpy as np
+
 from qibo.config import raise_error
 
 
@@ -94,7 +96,7 @@ class MeasurementResult:
                 of shape `(nshots,)`.
         """
         if binary:
-            return self.backend.cast(self._samples, dtype="int32")
+            return np.array(self._samples, dtype="int32")
         else:
             qubits = self.measurement_gate.target_qubits
             return self.backend.samples_to_decimal(self._samples, len(qubits))
@@ -273,7 +275,7 @@ class CircuitResult:
         qubits = self.measurement_gate.target_qubits
         if self._samples is None:
             if self.measurements[0].result.has_samples():
-                self._samples = self.backend.np.concatenate(
+                self._samples = np.concatenate(
                     [gate.result.samples() for gate in self.measurements], axis=1
                 )
             else:
@@ -294,7 +296,7 @@ class CircuitResult:
                 qubit_map = {
                     q: i for i, q in enumerate(self.measurement_gate.target_qubits)
                 }
-                self._samples = self.backend.cast(samples, dtype="int64")
+                self._samples = np.array(samples, dtype="int32")
                 for gate in self.measurements:
                     rqubits = tuple(qubit_map.get(q) for q in gate.target_qubits)
                     gate.result.register_samples(

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -265,7 +265,8 @@ class CircuitResult:
     def has_samples(self):
         if self.measurements:
             return self.measurements[0].result.has_samples()
-        return False
+        else:  # pragma: no cover
+            return False
 
     @property
     def measurement_gate(self):
@@ -276,7 +277,7 @@ class CircuitResult:
         if self._measurement_gate is None:
             from qibo import gates
 
-            if not self.measurements:
+            if not self.measurements:  # pragma: no cover
                 raise_error(ValueError, "Circuit does not contain measurements.")
 
             for gate in self.measurements:
@@ -342,15 +343,10 @@ class CircuitResult:
                     )
 
         if registers:
-            nreg = 0
-            results = {}
-            for gate in self.measurements:
-                name = gate.register_name
-                if name is None:
-                    name = f"register{nreg}"
-                    nreg += 1
-                results[name] = gate.result.samples(binary)
-            return results
+            return {
+                gate.register_name: gate.result.samples(binary)
+                for gate in self.measurements
+            }
 
         if binary:
             return self._samples
@@ -411,15 +407,10 @@ class CircuitResult:
                 )
 
         if registers:
-            nreg = 0
-            results = {}
-            for gate in self.measurements:
-                name = gate.register_name
-                if name is None:
-                    name = f"register{nreg}"
-                    nreg += 1
-                results[name] = gate.result.frequencies(binary)
-            return results
+            return {
+                gate.register_name: gate.result.frequencies(binary)
+                for gate in self.measurements
+            }
 
         if binary:
             return frequencies_to_binary(self._frequencies, len(qubits))

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -4,19 +4,207 @@ import collections
 from qibo.config import raise_error
 
 
-class CircuitResult:
-    def __init__(self, backend, circuit, execution_result, nshots=None):
+class MeasurementResult:
+    def __init__(
+        self, measurement_gate, measurement_tuples=None, nshots=None, backend=None
+    ):
+        self.measurement_gate = measurement_gate
+        self.measurement_tuples = measurement_tuples
         self.backend = backend
-        self.circuit = circuit
-        self.nqubits = circuit.nqubits
-        self.density_matrix = circuit.density_matrix
-        self.execution_result = execution_result
-        self.nshots = nshots
+        if nshots is None:
+            self.nshots = 0
+        else:
+            self.nshots = nshots
 
         self._samples = None
         self._frequencies = None
         self._bitflip_p0 = None
         self._bitflip_p1 = None
+        self._symbols = None
+
+    def __repr__(self):
+        qubits = self.measurement_gate.qubits
+        nshots = self.nshots
+        return f"MeasurementResult(qubits={qubits}, nshots={nshots})"
+
+    def probabilities(self, qubits=None):  # pragma: no cover
+        """Calculates measurement probabilities by tracing out qubits.
+
+        Args:
+            qubits (list, set): Set of qubits that are measured.
+        """
+        raise_error(NotImplementedError)
+
+    def add_shot(self, probs):
+        qubits = sorted(self.measurement_gate.target_qubits)
+        shot = self.backend.sample_shots(probs, 1)
+        if self._samples:
+            self._samples.append(shot[0])
+        else:
+            self._samples = [shot[0]]
+        self.nshots += 1
+        return shot
+
+    @property
+    def symbols(self):
+        if self._symbols is None:
+            from qibo.gates.measurements import MeasurementSymbol
+
+            qubits = self.measurement_gate.target_qubits
+            self._symbols = [MeasurementSymbol(i, self) for i in range(len(qubits))]
+
+        return self._symbols
+
+    def samples(self, binary=True, registers=False):
+        """Returns raw measurement samples.
+
+        Args:
+            binary (bool): Return samples in binary or decimal form.
+            registers (bool): Group samples according to registers.
+
+        Returns:
+            If `binary` is `True`
+                samples are returned in binary form as a tensor
+                of shape `(nshots, n_measured_qubits)`.
+            If `binary` is `False`
+                samples are returned in decimal form as a tensor
+                of shape `(nshots,)`.
+            If `registers` is `True`
+                samples are returned in a `dict` where the keys are the register
+                names and the values are the samples tensors for each register.
+            If `registers` is `False`
+                a single tensor is returned which contains samples from all the
+                measured qubits, independently of their registers.
+        """
+        qubits = self.measurement_gate.qubits
+        if self._samples is None:
+            probs = self.probabilities(qubits)  # pylint: disable=E1111
+            self._samples = self.backend.sample_shots(probs, self.nshots)
+            if self.measurement_gate.has_bitflip_noise():
+                p0, p1 = self.measurement_gate.bitflip_map
+                bitflip_probabilities = [
+                    [p0.get(q) for q in qubits],
+                    [p1.get(q) for q in qubits],
+                ]
+                noiseless_samples = self.backend.samples_to_binary(
+                    self._samples, len(qubits)
+                )
+                noisy_samples = self.backend.apply_bitflips(
+                    noiseless_samples, bitflip_probabilities
+                )
+                self._samples = self.backend.samples_to_decimal(
+                    noisy_samples, len(qubits)
+                )
+
+        _samples = self.backend.cast(self._samples, dtype="int64")
+        if registers:
+            qubit_map = {q: i for i, q in enumerate(qubits)}
+            reg_samples = {}
+            samples = self.backend.samples_to_binary(_samples, len(qubits))
+            for name, rqubits in self.measurement_tuples.items():
+                rqubits = tuple(qubit_map.get(q) for q in rqubits)
+                rsamples = samples[:, rqubits]
+                if binary:
+                    reg_samples[name] = rsamples
+                else:
+                    reg_samples[name] = self.backend.samples_to_decimal(
+                        rsamples, len(rqubits)
+                    )
+            return reg_samples
+
+        if binary:
+            return self.backend.samples_to_binary(_samples, len(qubits))
+        else:
+            return _samples
+
+    def frequencies(self, binary=True, registers=False):
+        """Returns the frequencies of measured samples.
+
+        Args:
+            binary (bool): Return frequency keys in binary or decimal form.
+            registers (bool): Group frequencies according to registers.
+
+        Returns:
+            A `collections.Counter` where the keys are the observed values
+            and the values the corresponding frequencies, that is the number
+            of times each measured value/bitstring appears.
+
+            If `binary` is `True`
+                the keys of the `Counter` are in binary form, as strings of
+                0s and 1s.
+            If `binary` is `False`
+                the keys of the `Counter` are integers.
+            If `registers` is `True`
+                a `dict` of `Counter` s is returned where keys are the name of
+                each register.
+            If `registers` is `False`
+                a single `Counter` is returned which contains samples from all
+                the measured qubits, independently of their registers.
+        """
+        qubits = self.measurement_gate.qubits
+        if self._frequencies is None:
+            if self.measurement_gate.has_bitflip_noise() and self._samples is None:
+                self._samples = self.samples(binary=False)
+            if self._samples is None:
+                probs = self.probabilities(qubits)  # pylint: disable=E1111
+                self._frequencies = self.backend.sample_frequencies(probs, self.nshots)
+            else:
+                self._frequencies = self.backend.calculate_frequencies(self._samples)
+
+        if registers:
+            qubit_map = {q: i for i, q in enumerate(qubits)}
+            reg_frequencies = {}
+            binary_frequencies = self._frequencies_to_binary(
+                self._frequencies, len(qubits)
+            )
+            for name, rqubits in self.measurement_tuples.items():
+                rfreqs = collections.Counter()
+                for bitstring, freq in binary_frequencies.items():
+                    idx = 0
+                    for i, q in enumerate(rqubits):
+                        if int(bitstring[qubit_map.get(q)]):
+                            idx += 2 ** (len(rqubits) - i - 1)
+                    rfreqs[idx] += freq
+                if binary:
+                    reg_frequencies[name] = self._frequencies_to_binary(
+                        rfreqs, len(rqubits)
+                    )
+                else:
+                    reg_frequencies[name] = rfreqs
+            return reg_frequencies
+
+        if binary:
+            return self._frequencies_to_binary(self._frequencies, len(qubits))
+        else:
+            return self._frequencies
+
+    @staticmethod
+    def _frequencies_to_binary(frequencies, nqubits):
+        return collections.Counter(
+            {"{:b}".format(k).zfill(nqubits): v for k, v in frequencies.items()}
+        )
+
+    def apply_bitflips(self, p0, p1=None):
+        mgate = self.measurement_gate
+        if p1 is None:
+            probs = 2 * (mgate._get_bitflip_tuple(mgate.qubits, p0),)
+        else:
+            probs = (
+                mgate._get_bitflip_tuple(mgate.qubits, p0),
+                mgate._get_bitflip_tuple(mgate.qubits, p1),
+            )
+        noiseless_samples = self.samples()
+        return self.backend.apply_bitflips(noiseless_samples, probs)
+
+
+class CircuitResult(MeasurementResult):
+    def __init__(self, backend, circuit, execution_result, nshots=None):
+        mgate = circuit.measurement_gate
+        mtuples = circuit.measurement_tuples
+        super().__init__(mgate, mtuples, nshots, backend)
+        self.nqubits = circuit.nqubits
+        self.density_matrix = circuit.density_matrix
+        self.execution_result = execution_result
 
     def state(self, numpy=False, decimals=-1, cutoff=1e-10, max_terms=20):
         """State's tensor representation as an backend tensor.
@@ -89,146 +277,3 @@ class CircuitResult:
             qubits (list, set): Set of qubits that are measured.
         """
         return self.backend.circuit_result_probabilities(self, qubits)
-
-    def samples(self, binary=True, registers=False):
-        """Returns raw measurement samples.
-
-        Args:
-            binary (bool): Return samples in binary or decimal form.
-            registers (bool): Group samples according to registers.
-
-        Returns:
-            If `binary` is `True`
-                samples are returned in binary form as a tensor
-                of shape `(nshots, n_measured_qubits)`.
-            If `binary` is `False`
-                samples are returned in decimal form as a tensor
-                of shape `(nshots,)`.
-            If `registers` is `True`
-                samples are returned in a `dict` where the keys are the register
-                names and the values are the samples tensors for each register.
-            If `registers` is `False`
-                a single tensor is returned which contains samples from all the
-                measured qubits, independently of their registers.
-        """
-        qubits = self.circuit.measurement_gate.qubits
-        if self._samples is None:
-            probs = self.probabilities(qubits)
-            self._samples = self.backend.sample_shots(probs, self.nshots)
-            if self.circuit.measurement_gate.has_bitflip_noise():
-                p0, p1 = self.circuit.measurement_gate.bitflip_map
-                bitflip_probabilities = [
-                    [p0.get(q) for q in qubits],
-                    [p1.get(q) for q in qubits],
-                ]
-                noiseless_samples = self.backend.samples_to_binary(
-                    self._samples, len(qubits)
-                )
-                noisy_samples = self.backend.apply_bitflips(
-                    noiseless_samples, bitflip_probabilities
-                )
-                self._samples = self.backend.samples_to_decimal(
-                    noisy_samples, len(qubits)
-                )
-
-        if registers:
-            qubit_map = {q: i for i, q in enumerate(qubits)}
-            reg_samples = {}
-            samples = self.backend.samples_to_binary(self._samples, len(qubits))
-            for name, rqubits in self.circuit.measurement_tuples.items():
-                rqubits = tuple(qubit_map.get(q) for q in rqubits)
-                rsamples = samples[:, rqubits]
-                if binary:
-                    reg_samples[name] = rsamples
-                else:
-                    reg_samples[name] = self.backend.samples_to_decimal(
-                        rsamples, len(rqubits)
-                    )
-            return reg_samples
-
-        if binary:
-            return self.backend.samples_to_binary(self._samples, len(qubits))
-        else:
-            return self._samples
-
-    @staticmethod
-    def _frequencies_to_binary(frequencies, nqubits):
-        return collections.Counter(
-            {"{:b}".format(k).zfill(nqubits): v for k, v in frequencies.items()}
-        )
-
-    def frequencies(self, binary=True, registers=False):
-        """Returns the frequencies of measured samples.
-
-        Args:
-            binary (bool): Return frequency keys in binary or decimal form.
-            registers (bool): Group frequencies according to registers.
-
-        Returns:
-            A `collections.Counter` where the keys are the observed values
-            and the values the corresponding frequencies, that is the number
-            of times each measured value/bitstring appears.
-
-            If `binary` is `True`
-                the keys of the `Counter` are in binary form, as strings of
-                0s and 1s.
-            If `binary` is `False`
-                the keys of the `Counter` are integers.
-            If `registers` is `True`
-                a `dict` of `Counter` s is returned where keys are the name of
-                each register.
-            If `registers` is `False`
-                a single `Counter` is returned which contains samples from all
-                the measured qubits, independently of their registers.
-        """
-        qubits = self.circuit.measurement_gate.qubits
-        if self._frequencies is None:
-            if (
-                self.circuit.measurement_gate.has_bitflip_noise()
-                and self._samples is None
-            ):
-                self._samples = self.samples(binary=False)
-            if self._samples is None:
-                probs = self.probabilities(qubits)
-                self._frequencies = self.backend.sample_frequencies(probs, self.nshots)
-            else:
-                self._frequencies = self.backend.calculate_frequencies(self._samples)
-
-        if registers:
-            qubit_map = {q: i for i, q in enumerate(qubits)}
-            reg_frequencies = {}
-            binary_frequencies = self._frequencies_to_binary(
-                self._frequencies, len(qubits)
-            )
-            for name, rqubits in self.circuit.measurement_tuples.items():
-                rfreqs = collections.Counter()
-                for bitstring, freq in binary_frequencies.items():
-                    idx = 0
-                    for i, q in enumerate(rqubits):
-                        if int(bitstring[qubit_map.get(q)]):
-                            idx += 2 ** (len(rqubits) - i - 1)
-                    rfreqs[idx] += freq
-                if binary:
-                    reg_frequencies[name] = self._frequencies_to_binary(
-                        rfreqs, len(rqubits)
-                    )
-                else:
-                    reg_frequencies[name] = rfreqs
-            return reg_frequencies
-
-        if binary:
-            return self._frequencies_to_binary(self._frequencies, len(qubits))
-        else:
-            return self._frequencies
-
-    def apply_bitflips(self, p0, p1=None):
-        mgate = self.circuit.measurement_gate
-        if p1 is None:
-            probs = 2 * (mgate._get_bitflip_tuple(mgate.qubits, p0),)
-        else:
-            probs = (
-                mgate._get_bitflip_tuple(mgate.qubits, p0),
-                mgate._get_bitflip_tuple(mgate.qubits, p1),
-            )
-        noiseless_samples = self.samples()
-        return self.backend.apply_bitflips(noiseless_samples, probs)

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -26,6 +26,19 @@ def apply_bitflips(result, p0, p1=None):
 
 
 class MeasurementResult:
+    """Data structure for holding measurement outcomes.
+
+    :class:`qibo.states.MeasurementResult` objects can be obtained
+    when adding measurement gates to a circuit.
+
+    Args:
+        gate (:class:`qibo.gates.M`): Measurement gate associated with
+            this result object.
+        nshots (int): Number of measurement shots.
+        backend (:class:`qibo.backends.abstract.AbstractBackend`): Backend
+            to use for calculations.
+    """
+
     def __init__(self, gate, nshots=0, backend=None):
         self.measurement_gate = gate
         self.backend = backend
@@ -57,21 +70,28 @@ class MeasurementResult:
         return self._samples is not None
 
     def register_samples(self, samples, backend=None):
+        """Register samples array to the ``MeasurementResult`` object."""
         self._samples = samples
         if self.backend is None:
             self.backend = backend
 
     def register_frequencies(self, frequencies, backend=None):
+        """Register frequencies to the ``MeasurementResult`` object."""
         self._frequencies = frequencies
         if self.backend is None:
             self.backend = backend
 
     def reset(self):
+        """Remove all registered samples and frequencies."""
         self._samples = None
         self._frequencies = None
 
     @property
     def symbols(self):
+        """List of ``sympy.Symbols`` associated with the results of the measurement.
+
+        These symbols are useful for conditioning parametrized gates on measurement outcomes.
+        """
         if self._symbols is None:
             from qibo.gates.measurements import MeasurementSymbol
 
@@ -134,6 +154,24 @@ class MeasurementResult:
 
 
 class CircuitResult:
+    """Data structure returned by circuit execution.
+
+    Contains all the results produced by the circuit execution, such as
+    the state vector or density matrix, measurement samples and frequencies.
+
+    Args:
+        backend (:class:`qibo.backends.abstract.AbstractBackend`): Backend
+            to use for calculations.
+        circuit (:class:`qibo.models.Circuit`): Circuit object that is producing
+            this result.
+        execution_result: Abstract raw data created by the circuit execution.
+            The format of these data depends on the backend and they are processed
+            by the backend. For simulation backends ``execution_result`` is a tensor
+            holding the state vector or density matrix representation in the
+            computational basis.
+        nshots (int): Number of measurement shots, if measurements are performed.
+    """
+
     def __init__(self, backend, circuit, execution_result, nshots=None):
         self.nqubits = circuit.nqubits
         self.measurements = circuit.measurements

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -199,8 +199,12 @@ class MeasurementResult:
 
 class CircuitResult(MeasurementResult):
     def __init__(self, backend, circuit, execution_result, nshots=None):
-        mgate = circuit.measurement_gate
-        mtuples = circuit.measurement_tuples
+        if hasattr(circuit, "measurement_gate"):
+            mgate = circuit.measurement_gate
+            mtuples = circuit.measurement_tuples
+        else:
+            mgate, mtuples = None, None
+
         super().__init__(mgate, mtuples, nshots, backend)
         self.nqubits = circuit.nqubits
         self.density_matrix = circuit.density_matrix

--- a/src/qibo/tests/test_dill.py
+++ b/src/qibo/tests/test_dill.py
@@ -68,8 +68,9 @@ def test_dill_measurement_symbol(backend):
 
     circuit = Circuit(1)
     circuit.add(gates.H(0))
-    symbol = circuit.add(gates.M(0, collapse=True))
+    cresult = circuit.add(gates.M(0, collapse=True))
     result = backend.execute_circuit(circuit, nshots=1)
+    symbol = cresult.symbols[0]
     nsymbol = dill.loads(dill.dumps(symbol))
     assert type(nsymbol) == type(symbol)
     backend.assert_allclose(nsymbol.outcome(), symbol.outcome())

--- a/src/qibo/tests/test_measurements.py
+++ b/src/qibo/tests/test_measurements.py
@@ -110,17 +110,6 @@ def test_measurement_circuit(backend, accelerators):
     )
 
 
-@pytest.mark.skip
-def test_gate_after_measurement_error(backend, accelerators):
-    c = models.Circuit(4, accelerators)
-    c.add(gates.X(0))
-    c.add(gates.M(0))
-    c.add(gates.X(1))
-    # TODO: Change this to NotImplementedError
-    with pytest.raises(ValueError):
-        c.add(gates.H(0))
-
-
 @pytest.mark.parametrize("registers", [False, True])
 def test_measurement_qubit_order_simple(backend, registers):
     c = models.Circuit(2)
@@ -224,24 +213,6 @@ def test_circuit_addition_with_measurements_in_both_circuits(backend, accelerato
     c = c1 + c2
     assert len(c.measurement_gate.target_qubits) == 2
     assert c.measurement_tuples == {"a": (1,), "b": (0,)}
-
-
-@pytest.mark.skip
-def test_gate_after_measurement_with_addition_error(backend, accelerators):
-    c = models.Circuit(4, accelerators)
-    c.add(gates.H(0))
-    c.add(gates.M(1))
-
-    # Try to add gate to qubit that is already measured
-    c2 = models.Circuit(4, accelerators)
-    c2.add(gates.H(1))
-    with pytest.raises(ValueError):
-        c += c2
-    # Try to add measurement to qubit that is already measured
-    c2 = models.Circuit(4, accelerators)
-    c2.add(gates.M(1, register_name="a"))
-    with pytest.raises(ValueError):
-        c += c2
 
 
 def test_circuit_copy_with_measurements(backend, accelerators):

--- a/src/qibo/tests/test_measurements.py
+++ b/src/qibo/tests/test_measurements.py
@@ -189,21 +189,29 @@ def test_circuit_with_unmeasured_qubits(backend, accelerators):
 
 def test_circuit_addition_with_measurements(backend):
     c = models.Circuit(2)
-    c.add(gates.H(0))
-    c.add(gates.H(1))
+    c.add(gates.X(0))
+    c.add(gates.X(1))
 
     meas_c = models.Circuit(2)
     c.add(gates.M(0, 1))
 
     c += meas_c
-    assert len(c.measurement_gate.target_qubits) == 2
-    assert c.measurement_tuples == {"register0": (0, 1)}
+    result = backend.execute_circuit(c, nshots=100)
+
+    assert_result(
+        backend,
+        result,
+        3 * np.ones(100),
+        np.ones((100, 2)),
+        {3: 100},
+        {"11": 100},
+    )
 
 
 def test_circuit_addition_with_measurements_in_both_circuits(backend, accelerators):
     c1 = models.Circuit(4, accelerators)
-    c1.add(gates.H(0))
-    c1.add(gates.H(1))
+    c1.add(gates.X(0))
+    c1.add(gates.X(1))
     c1.add(gates.M(1, register_name="a"))
 
     c2 = models.Circuit(4, accelerators)
@@ -211,8 +219,12 @@ def test_circuit_addition_with_measurements_in_both_circuits(backend, accelerato
     c2.add(gates.M(0, register_name="b"))
 
     c = c1 + c2
-    assert len(c.measurement_gate.target_qubits) == 2
-    assert c.measurement_tuples == {"a": (1,), "b": (0,)}
+    result = backend.execute_circuit(c, nshots=100)
+    assert_result(
+        backend,
+        result,
+        binary_frequencies={"10": 100},
+    )
 
 
 def test_circuit_copy_with_measurements(backend, accelerators):

--- a/src/qibo/tests/test_measurements.py
+++ b/src/qibo/tests/test_measurements.py
@@ -110,6 +110,7 @@ def test_measurement_circuit(backend, accelerators):
     )
 
 
+@pytest.mark.skip
 def test_gate_after_measurement_error(backend, accelerators):
     c = models.Circuit(4, accelerators)
     c.add(gates.X(0))
@@ -225,6 +226,7 @@ def test_circuit_addition_with_measurements_in_both_circuits(backend, accelerato
     assert c.measurement_tuples == {"a": (1,), "b": (0,)}
 
 
+@pytest.mark.skip
 def test_gate_after_measurement_with_addition_error(backend, accelerators):
     c = models.Circuit(4, accelerators)
     c.add(gates.H(0))
@@ -345,11 +347,11 @@ def test_registers_with_same_name_error(backend):
     """Check that circuits that contain registers with the same name cannot be added."""
     c1 = models.Circuit(2)
     c1.add(gates.H(0))
-    c1.add(gates.M(0))
+    c1.add(gates.M(0, register_name="a"))
 
     c2 = models.Circuit(2)
     c2.add(gates.H(1))
-    c2.add(gates.M(1))
+    c2.add(gates.M(1, register_name="a"))
 
     with pytest.raises(KeyError):
         c = c1 + c2

--- a/src/qibo/tests/test_measurements_probabilistic.py
+++ b/src/qibo/tests/test_measurements_probabilistic.py
@@ -127,7 +127,7 @@ def test_measurementresult_apply_bitflips(backend, i, p0, p1):
     c = models.Circuit(3)
     c.add(gates.M(*range(3)))
     result = CircuitResult(backend, c, None)
-    result._samples = np.zeros(10, dtype="int64")
+    result._samples = np.zeros((10, 3), dtype="int32")
     backend.set_seed(123)
     noisy_samples = result.apply_bitflips(p0, p1)
     targets = backend.test_regressions("test_measurementresult_apply_bitflips")

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -133,10 +133,12 @@ def test_add_measurement():
     g1 = gates.M(0, 2, register_name="a")
     g2 = gates.M(3, register_name="b")
     c.add([g1, g2])
-    assert c.measurement_gate is g1
+    mgate = c.measurement_gate
+    assert len(c.queue) == 2
     assert c.measurement_tuples == {"a": (0, 2), "b": (3,)}
-    assert g1.target_qubits == (0, 2, 3)
+    assert g1.target_qubits == (0, 2)
     assert g2.target_qubits == (3,)
+    assert mgate.target_qubits == (0, 2, 3)
     with pytest.raises(KeyError):
         c.add(gates.M(4, register_name="b"))
 
@@ -214,8 +216,7 @@ def test_circuit_addition(measurements):
         c2.add(gates.M(1, register_name="b"))
 
     c3 = c1 + c2
-    assert c3.depth == 3
-    assert list(c3.queue) == [g1, g2, g3]
+    assert c3.depth == 3 + int(measurements)
     if measurements:
         assert c3.measurement_tuples == {"a": (0,), "b": (1,)}
         assert c3.measurement_gate.target_qubits == (0, 1)
@@ -337,7 +338,6 @@ def test_circuit_copy_with_measurements():
     c1.add(gates.M(0, 1, register_name="a"))
     c1.add(gates.M(3, register_name="b"))
     c2 = c1.copy()
-    assert c2.measurement_gate is c1.measurement_gate
     assert c2.measurement_tuples == {"a": (0, 1), "b": (3,)}
 
 

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -141,6 +141,20 @@ def test_add_measurement():
         c.add(gates.M(4, register_name="b"))
 
 
+def test_add_measurement_collapse():
+    c = Circuit(3)
+    c.add(gates.X(0))
+    c.add(gates.M(0, 1))
+    c.add(gates.X(1))
+    c.add(gates.M(1))
+    c.add(gates.X(2))
+    c.add(gates.M(2))
+    assert len(c.queue) == 6
+    # assert that the first measurement was switched to collapse automatically
+    assert c.queue[1].collapse
+    assert len(c.measurements) == 2
+
+
 # :meth:`qibo.core.circuit.Circuit.fuse` is tested in `test_core_fusion.py`
 
 

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -133,12 +133,10 @@ def test_add_measurement():
     g1 = gates.M(0, 2, register_name="a")
     g2 = gates.M(3, register_name="b")
     c.add([g1, g2])
-    mgate = c.measurement_gate
     assert len(c.queue) == 2
     assert c.measurement_tuples == {"a": (0, 2), "b": (3,)}
     assert g1.target_qubits == (0, 2)
     assert g2.target_qubits == (3,)
-    assert mgate.target_qubits == (0, 2, 3)
     with pytest.raises(KeyError):
         c.add(gates.M(4, register_name="b"))
 
@@ -219,7 +217,6 @@ def test_circuit_addition(measurements):
     assert c3.depth == 3 + int(measurements)
     if measurements:
         assert c3.measurement_tuples == {"a": (0,), "b": (1,)}
-        assert c3.measurement_gate.target_qubits == (0, 1)
 
 
 def test_circuit_addition_errors():
@@ -355,7 +352,6 @@ def test_circuit_invert(measurements):
         assert g1.target_qubits == g2.target_qubits
         assert g1.control_qubits == g2.control_qubits
     if measurements:
-        assert invc.measurement_gate.target_qubits == (0, 2)
         assert invc.measurement_tuples == {"register0": (0, 2)}
 
 
@@ -376,7 +372,6 @@ def test_circuit_decompose(measurements):
         assert g1.target_qubits == g2.target_qubits
         assert g1.control_qubits == g2.control_qubits
     if measurements:
-        assert decompc.measurement_gate.target_qubits == (0, 2)
         assert decompc.measurement_tuples == {"register0": (0, 2)}
 
 
@@ -406,7 +401,6 @@ def test_circuit_with_noise(measurements, noise_map):
         assert g1.target_qubits == g2.target_qubits
         assert g1.control_qubits == g2.control_qubits
     if measurements:
-        assert noisyc.measurement_gate.target_qubits == (0, 1)
         assert noisyc.measurement_tuples == {"register0": (0, 1)}
 
 

--- a/src/qibo/tests/test_models_circuit_qasm.py
+++ b/src/qibo/tests/test_models_circuit_qasm.py
@@ -201,7 +201,6 @@ x q[0];
 y q[1];
 measure q[0] -> register0[0];
 measure q[1] -> register0[1];"""
-    print(c.to_qasm())
     assert_strings_equal(c.to_qasm(), target)
 
 

--- a/src/qibo/tests/test_models_circuit_qasm.py
+++ b/src/qibo/tests/test_models_circuit_qasm.py
@@ -201,6 +201,7 @@ x q[0];
 y q[1];
 measure q[0] -> register0[0];
 measure q[1] -> register0[1];"""
+    print(c.to_qasm())
     assert_strings_equal(c.to_qasm(), target)
 
 
@@ -418,9 +419,8 @@ measure q[2] -> a[1];
 measure q[4] -> a[2];
 measure q[3] -> b[1];"""
     c = Circuit.from_qasm(target)
-    assert c.depth == 1
-    assert isinstance(c.queue[0], gates.X)
-    assert isinstance(c.measurement_gate, gates.M)
+    assert c.depth == 2
+    assert isinstance(c.queue[1], gates.X)
     assert c.measurement_tuples == {"a": (0, 2, 4), "b": (1, 3)}
 
 
@@ -462,18 +462,6 @@ measure q[0] -> b[0];"""
 qreg q[2];
 creg a[2];
 measure q[0] -> a[2];"""
-    with pytest.raises(ValueError):
-        c = Circuit.from_qasm(target)
-
-    # Reuse measured qubit
-    target = """OPENQASM 2.0;
-qreg q[2];
-creg a[2];
-measure q[0] -> a[0];
-x q[1];
-measure q[1] -> a[1];"""
-    # Note that in this example the full register measurement is added during
-    # the first `measurement` call
     with pytest.raises(ValueError):
         c = Circuit.from_qasm(target)
 
@@ -535,7 +523,7 @@ creg a[2]; h q[0];x q[1]; cx q[0], q[1];
 measure q[0] -> a[0];measure q[1]->a[1]"""
     c = Circuit.from_qasm(target)
     assert c.nqubits == 2
-    assert c.depth == 2
+    assert c.depth == 3
     assert isinstance(c.queue[0], gates.H)
     assert isinstance(c.queue[1], gates.X)
     assert isinstance(c.queue[2], gates.CNOT)

--- a/src/qibo/tests/test_states.py
+++ b/src/qibo/tests/test_states.py
@@ -3,6 +3,12 @@ import pytest
 
 from qibo import gates
 from qibo.models import Circuit
+from qibo.states import MeasurementResult
+
+
+def test_measurement_result_repr():
+    result = MeasurementResult(gates.M(0), nshots=10)
+    assert str(result) == "MeasurementResult(qubits=(0,), nshots=10)"
 
 
 @pytest.mark.parametrize("target", range(5))


### PR DESCRIPTION
This PR implements various improvements in measurements, particularly:

* Eliminates the `circuit.measurement_gate` and adds all measurements (with and without collapse) in the gate queue.
* Makes possible to reuse (add more gates to) qubits that are measured. If the `collapse=True` option was not used when measuring a qubit that is reused then it is enabled automatically, as I am not aware of any other physical way that a qubit can be reused without collapsing it.
* Fixes an issue with `result = c.add(gates.M(0, 1, collapse=True))` which was out of sync with previous versions and the docs (thanks @igres26).
Now the `result` is a `MeasurementResult` object which has `result.samples()`, `result.frequencies()` and also `result.symbols` which is a list of `sympy.Symbols` that can be used to condition later gates on the measurement outcomes.
* The `result` object returned by `c.add` is now available for non-collapse measurements too.
For example
```py
from qibo import gates
from qibo.models import Circuit

c = Circuit(2)
c.add(gates.H(0))
c.add(gates.H(1))
m0 = c.add(gates.M(0))
m1 = c.add(gates.M(1))
r = c()
```
then
* `r` is a `CircuitResult` object that contains the final state vector and all measurements.
* `m0` is a `MeasurementResult` object that contains the measurements of qubit 0.
* `m1` is a `MeasurementResult` object that contains the measurements of qubit 1.

This is complete in terms of developments but I am labeling it as "do not merge" as I would like to make sure it plays well with qibolab before merging.