### PR TITLE
Rename matrices to qmatrices

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, 'run-workflow') || github.event_name == 'push'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, '3.10']

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,17 +1,9 @@
 # -*- coding: utf-8 -*-
 __version__ = "0.1.9.dev0"
 from qibo import callbacks, gates, hamiltonians, models, optimizers, parallel, solvers
-from qibo.backends import (
-    get_backend,
-    get_device,
-    get_precision,
-    get_threads,
-    matrices,
-    set_backend,
-    set_device,
-    set_precision,
-    set_threads,
-)
+from qibo.backends import get_backend, get_device, get_precision, get_threads
+from qibo.backends import qmatrices as matrices
+from qibo.backends import set_backend, set_device, set_precision, set_threads
 from qibo.config import (
     get_batch_size,
     get_metropolis_threshold,

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -98,7 +98,7 @@ class QiboMatrices:
         self.Z = self.matrices.Z
 
 
-matrices = QiboMatrices()
+qmatrices = QiboMatrices()
 
 
 def get_backend():
@@ -115,7 +115,7 @@ def get_precision():
 
 def set_precision(precision):
     GlobalBackend().set_precision(precision)
-    matrices.create(GlobalBackend().dtype)
+    qmatrices.create(GlobalBackend().dtype)
 
 
 def get_device():

--- a/src/qibo/hamiltonians/models.py
+++ b/src/qibo/hamiltonians/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from qibo.backends import matrices
+from qibo.backends import qmatrices as matrices
 from qibo.config import raise_error
 from qibo.hamiltonians.hamiltonians import Hamiltonian, SymbolicHamiltonian
 from qibo.hamiltonians.terms import HamiltonianTerm

--- a/src/qibo/models/hep.py
+++ b/src/qibo/models/hep.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from qibo import gates
-from qibo.backends import matrices
+from qibo.backends import qmatrices as matrices
 from qibo.config import raise_error
 from qibo.hamiltonians import Hamiltonian
 from qibo.models.circuit import Circuit

--- a/src/qibo/models/qgan.py
+++ b/src/qibo/models/qgan.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.random import randn
 
 from qibo import gates, hamiltonians, models
-from qibo.backends import matrices
+from qibo.backends import qmatrices as matrices
 from qibo.config import raise_error
 
 

--- a/src/qibo/symbols.py
+++ b/src/qibo/symbols.py
@@ -3,7 +3,7 @@ import numpy as np
 import sympy
 
 from qibo import gates
-from qibo.backends import matrices
+from qibo.backends import qmatrices as matrices
 from qibo.config import raise_error
 
 


### PR DESCRIPTION
The latest version of `dill` released yesterday causes some of our [tests to fail](https://github.com/qiboteam/qibo/actions/runs/3318916439/jobs/5483421300). While debugging this issue, I realized that there is a variable name collision in our code: in backends/__init__.py we define a `matrices` variable, while there is also a matrices.py under backends. Therefore I am not sure what happens when one imports qibo.backends.matrices.

Here I renamed the `matrices` variable to `qmatrices`. Maybe it would be cleaner to rename matrices.py, however this is also used in qibojit so we would need to update it and create a version incompatibility. @scarrazza let me know what you think.

Another solution to fix the CI is to pin dill's version to the previous one, but the problem with the variable names may appear again in the future.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
