### PR TITLE
Expectation values from samples

### DIFF
--- a/src/qibo/hamiltonians/abstract.py
+++ b/src/qibo/hamiltonians/abstract.py
@@ -92,7 +92,7 @@ class AbstractHamiltonian:
             freq (collections.Counter): the keys are the observed values in binary form
             and the values the corresponding frequencies, that is the number
             of times each measured value/bitstring appears.
-            qubit_map (list): Mapping between frequencies and qubits. If None, [1,...,len(key)]
+            qubit_map (tuple): Mapping between frequencies and qubits. If None, [1,...,len(key)]
 
         Returns:
             Real number corresponding to the expectation value.

--- a/src/qibo/hamiltonians/abstract.py
+++ b/src/qibo/hamiltonians/abstract.py
@@ -83,6 +83,21 @@ class AbstractHamiltonian:
             Real number corresponding to the expectation value.
         """
         raise_error(NotImplementedError)
+        
+    @abstractmethod
+    def expectation_from_samples(self, freq, qubit_map=None):  # pragma: no cover
+        """Computes the real expectation value of a diagonal observable given the frequencies when measuring in the computational basis.
+
+        Args:
+            freq (collections.Counter): the keys are the observed values in binary form
+            and the values the corresponding frequencies, that is the number
+            of times each measured value/bitstring appears.
+            qubit_map (list): Mapping between frequencies and qubits. If None, [1,...,len(key)]
+
+        Returns:
+            Real number corresponding to the expectation value.
+        """
+        raise_error(NotImplementedError)
 
     @abstractmethod
     def __add__(self, o):  # pragma: no cover

--- a/src/qibo/hamiltonians/abstract.py
+++ b/src/qibo/hamiltonians/abstract.py
@@ -83,7 +83,7 @@ class AbstractHamiltonian:
             Real number corresponding to the expectation value.
         """
         raise_error(NotImplementedError)
-        
+
     @abstractmethod
     def expectation_from_samples(self, freq, qubit_map=None):  # pragma: no cover
         """Computes the real expectation value of a diagonal observable given the frequencies when measuring in the computational basis.

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -140,10 +140,10 @@ class Hamiltonian(AbstractHamiltonian):
             raise_error(NotImplementedError, "Observable is not diagonal.")
         keys=list(freq.keys())
         if qubit_map is None:
-            qubit_map=list(range(len(keys[0])))
+            qubit_map=list(range(int(np.log2(len(Obs)))))
         counts=np.array(list(freq.values()))/sum(freq.values())
         O=0
-        kl=len(keys[0])
+        kl=len(qubit_map)
         for j, k in enumerate(keys):
             index=0
             for i in qubit_map:
@@ -579,7 +579,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
                 if subk.count(1)%2==1:
                     o_k=-1
                 O_q+=o_k*counts[i]
-            O+=O_q*coeff[j]
+            O+=O_q*float(coeff[j])
         return O
         
     def __add__(self, o):

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -133,6 +133,23 @@ class Hamiltonian(AbstractHamiltonian):
                 "value for state of type {}."
                 "".format(type(state)),
             )
+            
+    def expectation_from_samples(self, freq, qubit_map=None):
+        Obs=self.matrix
+        if np.count_nonzero(Obs - np.diag(np.diagonal(Obs)))!=0:
+            raise_error(NotImplementedError, "Observable is not diagonal.")
+        keys=list(freq.keys())
+        if qubit_map is None:
+            qubit_map=list(range(len(keys[0])))
+        counts=np.array(list(freq.values()))/sum(freq.values())
+        O=0
+        kl=len(keys[0])
+        for j, k in enumerate(keys):
+            index=0
+            for i in qubit_map:
+                index+=int(k[qubit_map.index(i)])*2**(kl-1-i)
+            O+=Obs[index,index]*counts[j]
+        return O
 
     def eye(self, n=None):
         if n is None:

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import sympy
 
 from qibo.config import EINSUM_CHARS, log, raise_error
@@ -137,6 +136,7 @@ class Hamiltonian(AbstractHamiltonian):
             )
 
     def expectation_from_samples(self, freq, qubit_map=None):
+        import numpy as np
         obs = self.matrix
         if np.count_nonzero(obs - np.diag(np.diagonal(obs))) != 0:
             raise_error(NotImplementedError, "Observable is not diagonal.")
@@ -555,6 +555,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
         return Hamiltonian.expectation(self, state, normalize)
 
     def expectation_from_samples(self, freq, qubit_map=None):
+        import numpy as np
         terms = self.terms
         for term in terms:
             for factor in term.factors:

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -136,6 +136,7 @@ class Hamiltonian(AbstractHamiltonian):
 
     def expectation_from_samples(self, freq, qubit_map=None):
         import numpy as np
+
         obs = self.matrix
         if np.count_nonzero(obs - np.diag(np.diagonal(obs))) != 0:
             raise_error(NotImplementedError, "Observable is not diagonal.")
@@ -555,6 +556,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
     def expectation_from_samples(self, freq, qubit_map=None):
         import numpy as np
+
         terms = self.terms
         for term in terms:
             for factor in term.factors:

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -563,9 +563,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
                         NotImplementedError, "Observable is not a Z Pauli string."
                     )
             if len(term.factors) != len(set(term.factors)):
-                raise_error(
-                        NotImplementedError, "Z^k is not implemented since Z^2=I."
-                    )
+                raise_error(NotImplementedError, "Z^k is not implemented since Z^2=I.")
         keys = list(freq.keys())
         counts = np.array(list(freq.values())) / sum(freq.values())
         coeff = list(self.form.as_coefficients_dict().values())

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-import sympy
 import numpy as np
+import sympy
+
 from qibo.config import EINSUM_CHARS, log, raise_error
 from qibo.hamiltonians.abstract import AbstractHamiltonian
 from qibo.symbols import Z
+
 
 class Hamiltonian(AbstractHamiltonian):
     """Hamiltonian based on a dense or sparse matrix representation.
@@ -133,22 +135,22 @@ class Hamiltonian(AbstractHamiltonian):
                 "value for state of type {}."
                 "".format(type(state)),
             )
-            
+
     def expectation_from_samples(self, freq, qubit_map=None):
-        Obs=self.matrix
-        if np.count_nonzero(Obs - np.diag(np.diagonal(Obs)))!=0:
+        Obs = self.matrix
+        if np.count_nonzero(Obs - np.diag(np.diagonal(Obs))) != 0:
             raise_error(NotImplementedError, "Observable is not diagonal.")
-        keys=list(freq.keys())
+        keys = list(freq.keys())
         if qubit_map is None:
-            qubit_map=list(range(int(np.log2(len(Obs)))))
-        counts=np.array(list(freq.values()))/sum(freq.values())
-        O=0
-        kl=len(qubit_map)
+            qubit_map = list(range(int(np.log2(len(Obs)))))
+        counts = np.array(list(freq.values())) / sum(freq.values())
+        O = 0
+        kl = len(qubit_map)
         for j, k in enumerate(keys):
-            index=0
+            index = 0
             for i in qubit_map:
-                index+=int(k[qubit_map.index(i)])*2**(kl-1-i)
-            O+=Obs[index,index]*counts[j]
+                index += int(k[qubit_map.index(i)]) * 2 ** (kl - 1 - i)
+            O += Obs[index, index] * counts[j]
         return O
 
     def eye(self, n=None):
@@ -551,37 +553,39 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
     def expectation(self, state, normalize=False):
         return Hamiltonian.expectation(self, state, normalize)
-    
+
     def expectation_from_samples(self, freq, qubit_map=None):
-        obs=self.terms
+        obs = self.terms
         for term in obs:
             for factor in term.factors:
-                if isinstance(factor,Z)==False:
-                    raise_error(NotImplementedError, "Observable is not a Z Pauli string.")
-        keys=list(freq.keys())
-        counts=np.array(list(freq.values()))/sum(freq.values())
-        coeff=list(self.form.as_coefficients_dict().values())
-        qubits=[]
+                if isinstance(factor, Z) == False:
+                    raise_error(
+                        NotImplementedError, "Observable is not a Z Pauli string."
+                    )
+        keys = list(freq.keys())
+        counts = np.array(list(freq.values())) / sum(freq.values())
+        coeff = list(self.form.as_coefficients_dict().values())
+        qubits = []
         for o in obs:
-            Qubits=[]
+            Qubits = []
             for k in o.target_qubits:
                 Qubits.append(k)
-            qubits.append(Qubits) 
+            qubits.append(Qubits)
         if qubit_map is None:
-            qubit_map=list(range(len(keys[0])))
-        O=0
+            qubit_map = list(range(len(keys[0])))
+        O = 0
         for j, q in enumerate(qubits):
-            subk=[]
-            O_q=0
+            subk = []
+            O_q = 0
             for i, k in enumerate(keys):
-                subk=[int(k[qubit_map.index(s)]) for s in q]
-                o_k=1
-                if subk.count(1)%2==1:
-                    o_k=-1
-                O_q+=o_k*counts[i]
-            O+=O_q*float(coeff[j])
+                subk = [int(k[qubit_map.index(s)]) for s in q]
+                o_k = 1
+                if subk.count(1) % 2 == 1:
+                    o_k = -1
+                O_q += o_k * counts[i]
+            O += O_q * float(coeff[j])
         return O
-        
+
     def __add__(self, o):
         if isinstance(o, self.__class__):
             if self.nqubits != o.nqubits:

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -231,7 +231,7 @@ class CircuitResult:
             )
         noiseless_samples = self.samples()
         return self.backend.apply_bitflips(noiseless_samples, probs)
-    
+
     def expectation_from_samples(self, observable):
         """Computes the real expectation value of a diagonal observable from frequencies.
 
@@ -241,6 +241,6 @@ class CircuitResult:
         Returns:
             Real number corresponding to the expectation value.
         """
-        freq=self.frequencies(binary=True)
-        qubit_map=self.circuit.measurement_gate.qubits
-        return observable.expectation_from_samples(freq,qubit_map)
+        freq = self.frequencies(binary=True)
+        qubit_map = self.circuit.measurement_gate.qubits
+        return observable.expectation_from_samples(freq, qubit_map)

--- a/src/qibo/states.py
+++ b/src/qibo/states.py
@@ -232,3 +232,16 @@ class CircuitResult:
             )
         noiseless_samples = self.samples()
         return self.backend.apply_bitflips(noiseless_samples, probs)
+    
+    def expectation_from_samples(self, observable):
+        """Computes the real expectation value of a diagonal observable from frequencies.
+
+        Args:
+            observable (Hamiltonian/SymbolicHamiltonian): diagonal observable in the computational basis.
+
+        Returns:
+            Real number corresponding to the expectation value.
+        """
+        freq=self.frequencies(binary=True)
+        qubit_map=self.circuit.measurement_gate.qubits
+        return observable.expectation_from_samples(freq,qubit_map)

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -3,9 +3,10 @@
 import numpy as np
 import pytest
 
-from qibo import hamiltonians
+from qibo import hamiltonians, gates
 from qibo.tests.utils import random_complex, random_sparse_matrix
-
+from qibo.models import Circuit
+from qibo.symbols import Z, I
 
 def test_hamiltonian_init(backend):
     with pytest.raises(TypeError):
@@ -244,6 +245,36 @@ def test_hamiltonian_expectation_errors(backend):
         h.expectation(state)
     with pytest.raises(TypeError):
         h.expectation("test")
+        
+
+def test_hamiltonian_expectation_from_samples(backend):
+    """Test Hamiltonian expectation value calculation."""
+    obs0 = Z(0) * Z(1)+Z(0) * Z(2)
+    obs1= Z(0) * Z(1)+Z(0) * Z(2)*I(3)
+    h0 = hamiltonians.SymbolicHamiltonian(obs0,backend=backend)
+    h1 = hamiltonians.SymbolicHamiltonian(obs1,backend=backend)
+    matrix = backend.to_numpy(h0.matrix)
+    c = Circuit(4)
+    c.add(gates.RX(0,np.random.rand()))
+    c.add(gates.RX(1,np.random.rand()))
+    c.add(gates.RX(2,np.random.rand()))
+    c.add(gates.RX(3,np.random.rand()))
+    c.add(gates.M(0, 1, 2, 3))
+    nshots=10**5
+    result = c(nshots=nshots)
+    state = c()
+    freq=result.frequencies(binary=True)
+    Obs0=hamiltonians.Hamiltonian(3,matrix).expectation_from_samples(freq,qubit_map=None)
+    Obs1=h1.expectation(c().state())
+
+    backend.assert_allclose(Obs0, Obs1, atol=10/np.sqrt(nshots))
+    
+
+def test_hamiltonian_expectation_from_samples_errors(backend):
+    obs=random_complex((4, 4))
+    h=hamiltonians.Hamiltonian(2,obs,backend=backend)
+    with pytest.raises(ValueError):
+        h.expectation_from_samples(None,qubit_map=None)
 
 
 @pytest.mark.parametrize("dtype", [np.complex128, np.complex64])

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -273,7 +273,7 @@ def test_hamiltonian_expectation_from_samples(backend):
 def test_hamiltonian_expectation_from_samples_errors(backend):
     obs=random_complex((4, 4))
     h=hamiltonians.Hamiltonian(2,obs,backend=backend)
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         h.expectation_from_samples(None,qubit_map=None)
 
 

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -250,8 +250,8 @@ def test_hamiltonian_expectation_errors(backend):
 
 def test_hamiltonian_expectation_from_samples(backend):
     """Test Hamiltonian expectation value calculation."""
-    obs0 = 2*Z(0) * Z(1) + Z(0) * Z(2)
-    obs1 = 2*Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    obs0 = 2 * Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = 2 * Z(0) * Z(1) + Z(0) * Z(2) * I(3)
     h0 = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
     h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     matrix = backend.to_numpy(h0.matrix)

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -3,10 +3,11 @@
 import numpy as np
 import pytest
 
-from qibo import hamiltonians, gates
-from qibo.tests.utils import random_complex, random_sparse_matrix
+from qibo import gates, hamiltonians
 from qibo.models import Circuit
-from qibo.symbols import Z, I
+from qibo.symbols import I, Z
+from qibo.tests.utils import random_complex, random_sparse_matrix
+
 
 def test_hamiltonian_init(backend):
     with pytest.raises(TypeError):
@@ -245,36 +246,38 @@ def test_hamiltonian_expectation_errors(backend):
         h.expectation(state)
     with pytest.raises(TypeError):
         h.expectation("test")
-        
+
 
 def test_hamiltonian_expectation_from_samples(backend):
     """Test Hamiltonian expectation value calculation."""
-    obs0 = Z(0) * Z(1)+Z(0) * Z(2)
-    obs1= Z(0) * Z(1)+Z(0) * Z(2)*I(3)
-    h0 = hamiltonians.SymbolicHamiltonian(obs0,backend=backend)
-    h1 = hamiltonians.SymbolicHamiltonian(obs1,backend=backend)
+    obs0 = Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    h0 = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
+    h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     matrix = backend.to_numpy(h0.matrix)
     c = Circuit(4)
-    c.add(gates.RX(0,np.random.rand()))
-    c.add(gates.RX(1,np.random.rand()))
-    c.add(gates.RX(2,np.random.rand()))
-    c.add(gates.RX(3,np.random.rand()))
+    c.add(gates.RX(0, np.random.rand()))
+    c.add(gates.RX(1, np.random.rand()))
+    c.add(gates.RX(2, np.random.rand()))
+    c.add(gates.RX(3, np.random.rand()))
     c.add(gates.M(0, 1, 2, 3))
-    nshots=10**5
+    nshots = 10**5
     result = c(nshots=nshots)
     state = c()
-    freq=result.frequencies(binary=True)
-    Obs0=hamiltonians.Hamiltonian(3,matrix).expectation_from_samples(freq,qubit_map=None)
-    Obs1=h1.expectation(c().state())
+    freq = result.frequencies(binary=True)
+    Obs0 = hamiltonians.Hamiltonian(3, matrix).expectation_from_samples(
+        freq, qubit_map=None
+    )
+    Obs1 = h1.expectation(c().state())
 
-    backend.assert_allclose(Obs0, Obs1, atol=10/np.sqrt(nshots))
-    
+    backend.assert_allclose(Obs0, Obs1, atol=10 / np.sqrt(nshots))
+
 
 def test_hamiltonian_expectation_from_samples_errors(backend):
-    obs=random_complex((4, 4))
-    h=hamiltonians.Hamiltonian(2,obs,backend=backend)
+    obs = random_complex((4, 4))
+    h = hamiltonians.Hamiltonian(2, obs, backend=backend)
     with pytest.raises(NotImplementedError):
-        h.expectation_from_samples(None,qubit_map=None)
+        h.expectation_from_samples(None, qubit_map=None)
 
 
 @pytest.mark.parametrize("dtype", [np.complex128, np.complex64])

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -250,8 +250,8 @@ def test_hamiltonian_expectation_errors(backend):
 
 def test_hamiltonian_expectation_from_samples(backend):
     """Test Hamiltonian expectation value calculation."""
-    obs0 = Z(0) * Z(1) + Z(0) * Z(2)
-    obs1 = Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    obs0 = 2*Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = 2*Z(0) * Z(1) + Z(0) * Z(2) * I(3)
     h0 = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
     h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     matrix = backend.to_numpy(h0.matrix)

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -263,12 +263,11 @@ def test_hamiltonian_expectation_from_samples(backend):
     c.add(gates.M(0, 1, 2, 3))
     nshots = 10**5
     result = c(nshots=nshots)
-    state = c()
     freq = result.frequencies(binary=True)
     Obs0 = hamiltonians.Hamiltonian(3, matrix).expectation_from_samples(
         freq, qubit_map=None
     )
-    Obs1 = h1.expectation(c().state())
+    Obs1 = h1.expectation(result.state())
 
     backend.assert_allclose(Obs0, Obs1, atol=10 / np.sqrt(nshots))
 

--- a/src/qibo/tests/test_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_hamiltonians_symbolic.py
@@ -286,10 +286,9 @@ def test_hamiltonian_expectation_from_samples(backend):
     c.add(gates.M(0, 1, 2, 3))
     nshots = 10**5
     result = c(nshots=nshots)
-    state = c()
     freq = result.frequencies(binary=True)
     Obs0 = h0.expectation_from_samples(freq, qubit_map=None)
-    Obs1 = h1.expectation(c().state())
+    Obs1 = h1.expectation(result.state())
     backend.assert_allclose(Obs0, Obs1, atol=10 / np.sqrt(nshots))
 
 

--- a/src/qibo/tests/test_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_hamiltonians_symbolic.py
@@ -7,7 +7,7 @@ import sympy
 from qibo import hamiltonians, gates
 from qibo.tests.utils import random_complex
 from qibo.models import Circuit
-from qibo.symbols import Z, I
+from qibo.symbols import Z, Y, I
 
 
 def symbolic_tfim(nqubits, h=1.0):
@@ -296,7 +296,7 @@ def test_hamiltonian_expectation_from_samples(backend):
 def test_hamiltonian_expectation_from_samples_errors(backend):
     obs = Z(0) * Y(1)
     h = hamiltonians.SymbolicHamiltonian(obs,backend=backend)
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         h.expectation_from_samples(None,qubit_map=None)
 
 

--- a/src/qibo/tests/test_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_hamiltonians_symbolic.py
@@ -274,8 +274,8 @@ def test_symbolic_hamiltonian_state_ev(
 
 def test_hamiltonian_expectation_from_samples(backend):
     """Test Hamiltonian expectation value calculation."""
-    obs0 = 2*Z(0) * Z(1) + Z(0) * Z(2)
-    obs1 = 2*Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    obs0 = 2 * Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = 2 * Z(0) * Z(1) + Z(0) * Z(2) * I(3)
     h0 = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
     h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     c = Circuit(4)
@@ -294,7 +294,7 @@ def test_hamiltonian_expectation_from_samples(backend):
 
 
 def test_hamiltonian_expectation_from_samples_errors(backend):
-    obs = [Z(0) * Y(1), Z(0)*Z(1)**3]
+    obs = [Z(0) * Y(1), Z(0) * Z(1) ** 3]
     h1 = hamiltonians.SymbolicHamiltonian(obs[0], backend=backend)
     h2 = hamiltonians.SymbolicHamiltonian(obs[1], backend=backend)
     with pytest.raises(NotImplementedError):

--- a/src/qibo/tests/test_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_hamiltonians_symbolic.py
@@ -4,10 +4,10 @@ import numpy as np
 import pytest
 import sympy
 
-from qibo import hamiltonians, gates
-from qibo.tests.utils import random_complex
+from qibo import gates, hamiltonians
 from qibo.models import Circuit
-from qibo.symbols import Z, Y, I
+from qibo.symbols import I, Y, Z
+from qibo.tests.utils import random_complex
 
 
 def symbolic_tfim(nqubits, h=1.0):
@@ -270,34 +270,34 @@ def test_symbolic_hamiltonian_state_ev(
     local_ev = local_ham.expectation(state, normalize)
     target_ev = dense_ham.expectation(state, normalize)
     backend.assert_allclose(local_ev, target_ev)
-    
-    
+
+
 def test_hamiltonian_expectation_from_samples(backend):
     """Test Hamiltonian expectation value calculation."""
-    obs0 = Z(0) * Z(1)+Z(0) * Z(2)
-    obs1= Z(0) * Z(1)+Z(0) * Z(2)*I(3)
-    h0 = hamiltonians.SymbolicHamiltonian(obs0,backend=backend)
-    h1 = hamiltonians.SymbolicHamiltonian(obs1,backend=backend)
+    obs0 = Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    h0 = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
+    h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     c = Circuit(4)
-    c.add(gates.RX(0,np.random.rand()))
-    c.add(gates.RX(1,np.random.rand()))
-    c.add(gates.RX(2,np.random.rand()))
-    c.add(gates.RX(3,np.random.rand()))
+    c.add(gates.RX(0, np.random.rand()))
+    c.add(gates.RX(1, np.random.rand()))
+    c.add(gates.RX(2, np.random.rand()))
+    c.add(gates.RX(3, np.random.rand()))
     c.add(gates.M(0, 1, 2, 3))
-    nshots=10**5
+    nshots = 10**5
     result = c(nshots=nshots)
     state = c()
-    freq=result.frequencies(binary=True)
-    Obs0=h0.expectation_from_samples(freq,qubit_map=None)
-    Obs1=h1.expectation(c().state())
-    backend.assert_allclose(Obs0, Obs1, atol=10/np.sqrt(nshots))
-    
+    freq = result.frequencies(binary=True)
+    Obs0 = h0.expectation_from_samples(freq, qubit_map=None)
+    Obs1 = h1.expectation(c().state())
+    backend.assert_allclose(Obs0, Obs1, atol=10 / np.sqrt(nshots))
+
 
 def test_hamiltonian_expectation_from_samples_errors(backend):
     obs = Z(0) * Y(1)
-    h = hamiltonians.SymbolicHamiltonian(obs,backend=backend)
+    h = hamiltonians.SymbolicHamiltonian(obs, backend=backend)
     with pytest.raises(NotImplementedError):
-        h.expectation_from_samples(None,qubit_map=None)
+        h.expectation_from_samples(None, qubit_map=None)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])

--- a/src/qibo/tests/test_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_hamiltonians_symbolic.py
@@ -274,8 +274,8 @@ def test_symbolic_hamiltonian_state_ev(
 
 def test_hamiltonian_expectation_from_samples(backend):
     """Test Hamiltonian expectation value calculation."""
-    obs0 = Z(0) * Z(1) + Z(0) * Z(2)
-    obs1 = Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    obs0 = 2*Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = 2*Z(0) * Z(1) + Z(0) * Z(2) * I(3)
     h0 = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
     h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     c = Circuit(4)
@@ -294,10 +294,13 @@ def test_hamiltonian_expectation_from_samples(backend):
 
 
 def test_hamiltonian_expectation_from_samples_errors(backend):
-    obs = Z(0) * Y(1)
-    h = hamiltonians.SymbolicHamiltonian(obs, backend=backend)
+    obs = [Z(0) * Y(1), Z(0)*Z(1)**3]
+    h1 = hamiltonians.SymbolicHamiltonian(obs[0], backend=backend)
+    h2 = hamiltonians.SymbolicHamiltonian(obs[1], backend=backend)
     with pytest.raises(NotImplementedError):
-        h.expectation_from_samples(None, qubit_map=None)
+        h1.expectation_from_samples(None, qubit_map=None)
+    with pytest.raises(NotImplementedError):
+        h2.expectation_from_samples(None, qubit_map=None)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])

--- a/src/qibo/tests/test_hamiltonians_symbolic.py
+++ b/src/qibo/tests/test_hamiltonians_symbolic.py
@@ -4,8 +4,10 @@ import numpy as np
 import pytest
 import sympy
 
-from qibo import hamiltonians
+from qibo import hamiltonians, gates
 from qibo.tests.utils import random_complex
+from qibo.models import Circuit
+from qibo.symbols import Z, I
 
 
 def symbolic_tfim(nqubits, h=1.0):
@@ -268,6 +270,34 @@ def test_symbolic_hamiltonian_state_ev(
     local_ev = local_ham.expectation(state, normalize)
     target_ev = dense_ham.expectation(state, normalize)
     backend.assert_allclose(local_ev, target_ev)
+    
+    
+def test_hamiltonian_expectation_from_samples(backend):
+    """Test Hamiltonian expectation value calculation."""
+    obs0 = Z(0) * Z(1)+Z(0) * Z(2)
+    obs1= Z(0) * Z(1)+Z(0) * Z(2)*I(3)
+    h0 = hamiltonians.SymbolicHamiltonian(obs0,backend=backend)
+    h1 = hamiltonians.SymbolicHamiltonian(obs1,backend=backend)
+    c = Circuit(4)
+    c.add(gates.RX(0,np.random.rand()))
+    c.add(gates.RX(1,np.random.rand()))
+    c.add(gates.RX(2,np.random.rand()))
+    c.add(gates.RX(3,np.random.rand()))
+    c.add(gates.M(0, 1, 2, 3))
+    nshots=10**5
+    result = c(nshots=nshots)
+    state = c()
+    freq=result.frequencies(binary=True)
+    Obs0=h0.expectation_from_samples(freq,qubit_map=None)
+    Obs1=h1.expectation(c().state())
+    backend.assert_allclose(Obs0, Obs1, atol=10/np.sqrt(nshots))
+    
+
+def test_hamiltonian_expectation_from_samples_errors(backend):
+    obs = Z(0) * Y(1)
+    h = hamiltonians.SymbolicHamiltonian(obs,backend=backend)
+    with pytest.raises(ValueError):
+        h.expectation_from_samples(None,qubit_map=None)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])

--- a/src/qibo/tests/test_states.py
+++ b/src/qibo/tests/test_states.py
@@ -1,9 +1,10 @@
+import numpy as np
 import pytest
 
 from qibo import gates, hamiltonians
 from qibo.models import Circuit
 from qibo.symbols import I, Z
-import numpy as np
+
 
 @pytest.mark.parametrize("target", range(5))
 @pytest.mark.parametrize("density_matrix", [False, True])
@@ -54,14 +55,14 @@ def test_state_representation_max_terms(backend, density_matrix):
             == "(0.17678+0j)|00000> + (0.17678+0j)|00001> + (0.17678+0j)|00010> + (0.17678+0j)|00011> + (0.17678+0j)|00100> + ..."
         )
 
-        
+
 @pytest.mark.parametrize("density_matrix", [False, True])
 def test_expectation_from_samples(backend, density_matrix):
 
     obs0 = 2 * Z(0) * Z(1) + Z(0) * Z(2)
     obs1 = 2 * Z(0) * Z(1) + Z(0) * Z(2) * I(3)
     h_sym = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
-    h_dense =  hamiltonians.Hamiltonian(3, h_sym.matrix, backend=backend)
+    h_dense = hamiltonians.Hamiltonian(3, h_sym.matrix, backend=backend)
     h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
     c = Circuit(4)
     c.add(gates.RX(0, np.random.rand()))

--- a/src/qibo/tests/test_states.py
+++ b/src/qibo/tests/test_states.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from qibo import gates
+from qibo import gates, hamiltonians
 from qibo.models import Circuit
-
+from qibo.symbols import I, Z
+import numpy as np
 
 @pytest.mark.parametrize("target", range(5))
 @pytest.mark.parametrize("density_matrix", [False, True])
@@ -53,3 +54,26 @@ def test_state_representation_max_terms(backend, density_matrix):
             result.symbolic(max_terms=5)
             == "(0.17678+0j)|00000> + (0.17678+0j)|00001> + (0.17678+0j)|00010> + (0.17678+0j)|00011> + (0.17678+0j)|00100> + ..."
         )
+
+        
+@pytest.mark.parametrize("density_matrix", [False, True])
+def test_expectation_from_samples(backend, density_matrix):
+
+    obs0 = 2 * Z(0) * Z(1) + Z(0) * Z(2)
+    obs1 = 2 * Z(0) * Z(1) + Z(0) * Z(2) * I(3)
+    h_sym = hamiltonians.SymbolicHamiltonian(obs0, backend=backend)
+    h_dense =  hamiltonians.Hamiltonian(3, h_sym.matrix, backend=backend)
+    h1 = hamiltonians.SymbolicHamiltonian(obs1, backend=backend)
+    c = Circuit(4)
+    c.add(gates.RX(0, np.random.rand()))
+    c.add(gates.RX(1, np.random.rand()))
+    c.add(gates.RX(2, np.random.rand()))
+    c.add(gates.RX(3, np.random.rand()))
+    c.add(gates.M(0, 1, 2))
+    nshots = 10**5
+    result = c(nshots=nshots)
+    expval_sym = result.expectation_from_samples(h_sym)
+    expval_dense = result.expectation_from_samples(h_dense)
+    expval = h1.expectation(result.state())
+    backend.assert_allclose(expval_sym, expval_dense)
+    backend.assert_allclose(expval_sym, expval, atol=10 / np.sqrt(nshots))


### PR DESCRIPTION
In this PR I implemented the computation of expectation values of `Zs` operators from counts. The input is the frequencies `result.frequencies(binary=True)` and a mapping for the qubits indices. For example, suppose we have a 10 qubit circuit but we are measuring 5 of them `[1,3,5,7,9]` and we want to compute an observable that acts on those or less qubits `Z(5)*Z(3)*Z(9)`. Then, `qubit_map=[1,3,5,7,9]`.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
