### PR TITLE
Rename matrices.py to npmatrices.py

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest-cov
         pip install .[tests,docs]
-        pip install git+https://github.com/qiboteam/qibojit
+        pip install git+https://github.com/qiboteam/qibojit/npmatrices
         pip install tensorflow
     - name: Test with pylint
       run: |

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -11,7 +11,6 @@ jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, 'run-workflow') || github.event_name == 'push'
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, '3.10']
@@ -37,8 +36,6 @@ jobs:
     - name: Test with pytest core
       run: |
         pytest src/qibo/tests/ --cov=qibo --cov-report=xml --pyargs qibo --durations=60
-      env:
-        OMP_NUM_THREADS: 1
     - name: Test documentation examples
       if: startsWith(matrix.os, 'ubuntu')
       run: |
@@ -47,9 +44,7 @@ jobs:
     - name: Test examples
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'
       run: |
-        pytest examples/
-      env:
-        OMP_NUM_THREAD: 1
+        OMP_NUM_THREADS=1 pytest examples/
     - name: Upload coverage to Codecov
       if: startsWith(matrix.os, 'ubuntu')
       uses: codecov/codecov-action@v2

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest-cov
         pip install .[tests,docs]
-        pip install git+https://github.com/qiboteam/qibojit/npmatrices
+        pip install git+https://github.com/qiboteam/qibojit@npmatrices
         pip install tensorflow
     - name: Test with pylint
       run: |

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, 'run-workflow') || github.event_name == 'push'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, '3.10']
@@ -36,6 +37,8 @@ jobs:
     - name: Test with pytest core
       run: |
         pytest src/qibo/tests/ --cov=qibo --cov-report=xml --pyargs qibo --durations=60
+      env:
+        OMP_NUM_THREADS: 1
     - name: Test documentation examples
       if: startsWith(matrix.os, 'ubuntu')
       run: |
@@ -44,7 +47,9 @@ jobs:
     - name: Test examples
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'
       run: |
-        OMP_NUM_THREADS=1 pytest examples/
+        pytest examples/
+      env:
+        OMP_NUM_THREAD: 1
     - name: Upload coverage to Codecov
       if: startsWith(matrix.os, 'ubuntu')
       uses: codecov/codecov-action@v2

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest-cov
         pip install .[tests,docs]
-        pip install git+https://github.com/qiboteam/qibojit@npmatrices
+        pip install git+https://github.com/qiboteam/qibojit
         pip install tensorflow
     - name: Test with pylint
       run: |

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -2,7 +2,7 @@
 import os
 
 from qibo.backends.abstract import Backend
-from qibo.backends.matrices import Matrices
+from qibo.backends.npmatrices import NumpyMatrices
 from qibo.backends.numpy import NumpyBackend
 from qibo.backends.tensorflow import TensorflowBackend
 from qibo.config import log, raise_error
@@ -91,7 +91,7 @@ class QiboMatrices:
         self.create(dtype)
 
     def create(self, dtype):
-        self.matrices = Matrices(dtype)
+        self.matrices = NumpyMatrices(dtype)
         self.I = self.matrices.I(2)
         self.X = self.matrices.X
         self.Y = self.matrices.Y

--- a/src/qibo/backends/npmatrices.py
+++ b/src/qibo/backends/npmatrices.py
@@ -17,7 +17,7 @@ else:  # pragma: no cover
         return wrapper
 
 
-class Matrices:
+class NumpyMatrices:
     """Matrix representation of every gate as a numpy array."""
 
     def __init__(self, dtype):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -6,7 +6,7 @@ import numpy as np
 from qibo import __version__
 from qibo.backends import einsum_utils
 from qibo.backends.abstract import Backend
-from qibo.backends.matrices import Matrices
+from qibo.backends.npmatrices import NumpyMatrices
 from qibo.config import log, raise_error
 from qibo.gates import FusedGate
 from qibo.gates.abstract import ParametrizedGate, SpecialGate
@@ -18,7 +18,7 @@ class NumpyBackend(Backend):
         super().__init__()
         self.np = np
         self.name = "numpy"
-        self.matrices = Matrices(self.dtype)
+        self.matrices = NumpyMatrices(self.dtype)
         self.tensor_types = np.ndarray
         self.versions = {"qibo": __version__, "numpy": self.np.__version__}
         self.numeric_types = (

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -5,12 +5,12 @@ import os
 import numpy as np
 
 from qibo import __version__
-from qibo.backends.matrices import Matrices
+from qibo.backends.npmatrices import NumpyMatrices
 from qibo.backends.numpy import NumpyBackend
 from qibo.config import TF_LOG_LEVEL, log, raise_error
 
 
-class TensorflowMatrices(Matrices):
+class TensorflowMatrices(NumpyMatrices):
     # Redefine parametrized gate matrices for backpropagation to work
 
     def __init__(self, dtype):

--- a/src/qibo/tests/test_parallel.py
+++ b/src/qibo/tests/test_parallel.py
@@ -13,7 +13,6 @@ from qibo.models import QFT, Circuit
 from qibo.parallel import parallel_execution, parallel_parametrized_execution
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="Mac tests")
 def test_parallel_circuit_evaluation(backend):
     """Evaluate circuit for multiple input states."""
     nqubits = 10
@@ -32,7 +31,6 @@ def test_parallel_circuit_evaluation(backend):
     backend.assert_allclose(r1, r2)
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="Mac tests")
 def test_parallel_parametrized_circuit(backend):
     """Evaluate circuit for multiple parameters."""
     nqubits = 5

--- a/src/qibo/tests/test_parallel.py
+++ b/src/qibo/tests/test_parallel.py
@@ -13,6 +13,7 @@ from qibo.models import QFT, Circuit
 from qibo.parallel import parallel_execution, parallel_parametrized_execution
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Mac tests")
 def test_parallel_circuit_evaluation(backend):
     """Evaluate circuit for multiple input states."""
     nqubits = 10
@@ -31,6 +32,7 @@ def test_parallel_circuit_evaluation(backend):
     backend.assert_allclose(r1, r2)
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Mac tests")
 def test_parallel_parametrized_circuit(backend):
     """Evaluate circuit for multiple parameters."""
     nqubits = 5


### PR DESCRIPTION
Fixes #673. There is a name collision because `matrices` is the name of a module under backends but also defined in the `__init__.py` (see #674 for details). Here I rename matrices.py to npmatrices.py to fix this.

Qibojit only works using qiboteam/qibojit#92.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
