### PR TITLE
Fix missing sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
             "nbsphinx",
             "IPython",
         ],
-        "tests": ["pytest", "cirq", "ply", "sklearn", "dill", "pre-commit"],
+        "tests": ["pytest", "cirq", "ply", "scikit-learn", "dill", "pre-commit"],
     },
     python_requires=">=3.7.0",
     long_description=long_description,


### PR DESCRIPTION
Rename `sklearn` to `scikit-learn` in the test requirements to fix failing example tests (see [here](https://github.com/qiboteam/qibo/actions/runs/3426811984/jobs/5709051189)).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
