### PR TITLE
Added furo as extras_require in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     extras_require={
         "docs": [
             "sphinx",
-            "sphinx_rtd_theme",
+            "furo",
             "recommonmark",
             "sphinxcontrib-bibtex",
             "sphinx_markdown_tables",


### PR DESCRIPTION
In order to compile `sphinx` with the new theme, `furo` must be installed. I modified the `setup.py` file by adding it in the `extras_require` where we currently have `sphinx_rtd_theme`. 
