### PR TITLE
rm qibo logo from conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -102,6 +102,4 @@ def setup(app):
     app.add_css_file("css/style.css")
 
 
-html_logo = "logo.png"
-
 html_show_sourcelink = False

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.9"
+__version__ = "0.2.0.dev0"
 from qibo import callbacks, gates, hamiltonians, models, optimizers, parallel, solvers
 from qibo.backends import (
     get_backend,


### PR DESCRIPTION
As discussed in #691, here we remove the `qibo` logo from the `conf.py` file which is used while compiling the documentation. 
