### PR TITLE
Update `gate.init_kwargs` when setting new parameters

### DIFF
--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -316,6 +316,7 @@ class ParametrizedGate(Gate):
         """Updates the values of gate's parameters."""
         if isinstance(self.parameter_names, str):
             nparams = 1
+            names = [self.parameter_names]
             if not isinstance(x, collections.abc.Iterable):
                 x = [x]
             else:
@@ -330,6 +331,7 @@ class ParametrizedGate(Gate):
                         x = [x]
         else:
             nparams = len(self.parameter_names)
+            names = self.parameter_names
 
         if not self._parameters:
             params = nparams * [None]
@@ -347,6 +349,7 @@ class ParametrizedGate(Gate):
                 self.symbolic_parameters[i] = v
             params[i] = v
         self._parameters = tuple(params)
+        self.init_kwargs.update({n: v for n, v in zip(names, self._parameters)})
 
         # set parameters in device gates
         for gate in self.device_gates:  # pragma: no cover

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -349,7 +349,9 @@ class ParametrizedGate(Gate):
                 self.symbolic_parameters[i] = v
             params[i] = v
         self._parameters = tuple(params)
-        self.init_kwargs.update({n: v for n, v in zip(names, self._parameters)})
+        self.init_kwargs.update(
+            {n: v for n, v in zip(names, self._parameters) if n in self.init_kwargs}
+        )
 
         # set parameters in device gates
         for gate in self.device_gates:  # pragma: no cover

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -1109,7 +1109,7 @@ class GeneralizedfSim(ParametrizedGate):
         self.name = "generalizedfsim"
         self.target_qubits = (q0, q1)
 
-        self.parameter_names = ["u", "phi"]
+        self.parameter_names = ["unitary", "phi"]
         self.parameters = unitary, phi
         self.nparams = 5
 

--- a/src/qibo/tests/test_gates_abstract.py
+++ b/src/qibo/tests/test_gates_abstract.py
@@ -329,7 +329,31 @@ def test_fused_gate():
 
 
 def test_generator_eigenvalue():
-
     gate = gates.H(0)
     with pytest.raises(NotImplementedError):
         gate.generator_eigenvalue()
+
+
+def test_gate_set_parameters():
+    gate = gates.RX(0, theta=0)
+    assert gate.parameters == (0,)
+    gate.parameters = 0.5
+    gate2 = gate.__class__(*gate.init_args, **gate.init_kwargs)
+    assert gate.parameters == (0.5,)
+    assert gate2.parameters == (0.5,)
+
+
+def test_generalizedfsim_set_parameters():
+    import numpy as np
+
+    gate = gates.GeneralizedfSim(0, 1, unitary=np.eye(2), phi=0)
+    np.testing.assert_allclose(gate.parameters[0], np.eye(2))
+    assert gate.parameters[1] == 0
+
+    new_unitary = np.random.random((2, 2))
+    gate.parameters = (new_unitary, 0.5)
+    gate2 = gate.__class__(*gate.init_args, **gate.init_kwargs)
+    np.testing.assert_allclose(gate.parameters[0], new_unitary)
+    np.testing.assert_allclose(gate2.parameters[0], new_unitary)
+    assert gate.parameters[1] == 0.5
+    assert gate2.parameters[1] == 0.5


### PR DESCRIPTION
When changing the parameters of a parametrized gate the `gate.init_kwargs` dictionary is not updated. Therefore if a new gate is created after it will have the old parameter values. For example
```py
gate = gates.RX(0, theta=0)
gate.parameters = 0.5
gate2 = gates.__class__(*gate.init_args, **gate.init_kwargs)
# gate2.parameters is still 0
```
This is relevant among other things for the [transpiler](https://github.com/qiboteam/qibolab/blob/d64cc98afbdc23adc1e472d70d8c1827d5f8da96/src/qibolab/transpilers/connectivity.py#L100), which is using this when creating new gates that respect hardware connectivity.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
