### PR TITLE
Moved "qibo release" to the doc's side-bar

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,12 +20,12 @@ import qibo
 
 # -- Project information -----------------------------------------------------
 
-project = "qibo"
+project = "Release"
 copyright = "2020-2022 by the Qibo team"
 author = "The Qibo team"
 
 # The full version, including alpha/beta/rc tags
-# release = qibo.__version__
+release = qibo.__version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,7 +20,7 @@ import qibo
 
 # -- Project information -----------------------------------------------------
 
-project = "Release"
+project = "qibo"
 copyright = "2020-2022 by the Qibo team"
 author = "The Qibo team"
 
@@ -70,8 +70,11 @@ exclude_patterns = []
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
+
 html_theme = "furo"
+
+# custom title
+html_title = "Software version " + release
 
 html_theme_options = {
     "light_css_variables": {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,7 +74,7 @@ exclude_patterns = []
 html_theme = "furo"
 
 # custom title
-html_title = "Software version " + release
+html_title = "Version " + release
 
 html_theme_options = {
     "light_css_variables": {

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,8 +25,6 @@ Qibo key features:
 * Efficient simulation backends with GPU, multi-GPU and CPU with multi-threading support.
 * Simple mechanism for the implementation of new simulation and hardware backend drivers.
 
-This documentation refers to Qibo |release|.
-
 Contents
 ========
 


### PR DESCRIPTION
In this PR the software's release is added to the doc's side-bar (in the front-page) and removed from the introductory text. 

In order to show e.g.: `Release 0.1.10dev0`, I set "Release" where the package name should be placed. I know it is conceptually wrong, but it seemed the best solution to avoid repetition (Qibo is already mentioned in the navbar) and to clarify that the string `0.1.10dev0` refers to the release.

If there is a more elegant way, it is certainly preferable.
