### PR TITLE
Ubuntu font in the documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,6 +78,8 @@ html_theme_options = {
         "color-brand-primary": "#6400FF",
         "color-brand-secondary": "#6400FF",
         "color-brand-content": "#6400FF",
+        "font-stack": "Ubuntu",
+        "font-stack--monospace": "Courier, monospace",
     }
 }
 


### PR DESCRIPTION
With this PR the documentation's font is changed into "Ubuntu", which is the one used in the webpage.
