### PR TITLE
Thermal relaxation channel

### DIFF
--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -435,10 +435,10 @@ class ThermalRelaxationChannel(Channel):
 
             preset0, preset1, exp_t2 = self.coefficients
             matrix = [
-                [1 - preset1, 0, 0, preset1],
+                [1 - preset1, 0, 0, preset0],
                 [0, exp_t2, 0, 0],
                 [0, 0, exp_t2, 0],
-                [preset0, 0, 0, 1 - preset0],
+                [preset1, 0, 0, 1 - preset0],
             ]
 
             qubits = (q, q + nqubits)

--- a/src/qibo/tests/test_gates_channels.py
+++ b/src/qibo/tests/test_gates_channels.py
@@ -191,7 +191,7 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
 
     if t2 > t1:
         p0, p1, exp = gate.coefficients
-        matrix = np.diag([1 - p1, p0, p1, 1 - p0])
+        matrix = np.diag([1 - p1, p1, p0, 1 - p0])
         matrix[0, -1], matrix[-1, 0] = exp, exp
         matrix = matrix.reshape(4 * (2,))
         # Apply matrix using Eq. (3.28) from arXiv:1111.6950


### PR DESCRIPTION
This PR fixes a bug in the thermal relaxation channel when $T_2>T_1$. In this case, the implementation of the channel uses a Choi-matrix representation.  There is a small error in the definition of this matrix. This implies that applying the channel on a density matrix gives a final state $\rho_f$ with $\operatorname{tr}(\rho_f)\neq1$.

```python
import numpy as np
from qibo import gates
from qibo.backends import construct_backend
from qibo.tests.utils import random_density_matrix

backend=construct_backend("numpy")

t1 = 0.5
t2 = 0.7
time = 0.4
excpop = 0
initial_rho = random_density_matrix(3)
gate = gates.ThermalRelaxationChannel(
    0, t1, t2, time=time, excited_population=excpop
)
final_rho = gate.apply_density_matrix(backend, np.copy(initial_rho), 3)
print(final_rho.trace())
# 1.4111552960641927+0j
```
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
