### PR TITLE
rm Ubuntu font from furo configuration

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -81,8 +81,6 @@ html_theme_options = {
         "color-brand-primary": "#6400FF",
         "color-brand-secondary": "#6400FF",
         "color-brand-content": "#6400FF",
-        "font-stack": "Ubuntu",
-        "font-stack--monospace": "Courier, monospace",
     }
 }
 


### PR DESCRIPTION
After a discussion I had with the @qiboteam/coredevs, I propose to return to the original Furo font for the time being. 
Right now it is important to have a stable and presentable version of the documentation by the release (in a few days). We propose to address the restoration of the style in more detail at a later date.

If you agree with this, I propagate this choice in `qibolab` and `qibocal` too.
