### PR TITLE
First small fix to math rendering in quantum_info

### DIFF
--- a/src/qibo/quantum_info/basis.py
+++ b/src/qibo/quantum_info/basis.py
@@ -128,7 +128,7 @@ def comp_basis_to_pauli(nqubits: int, normalize: bool = False):
 
     The unitary :math:`U` is given by
 
-    ..math::
+    .. math::
         U = \\sum_{k = 0}^{d^{2} - 1} \\, {|k)}{(P_{k}|} \\,\\, ,
 
     where :math:`{|A)}` is the system-vectorization of :math:`A`,
@@ -159,7 +159,7 @@ def pauli_to_comp_basis(nqubits: int, normalize: bool = False):
 
     The unitary :math:`U` is given by
 
-    ..math::
+    .. math::
         U = \\sum_{k = 0}^{d^{2} - 1} \\, {|P_{k})}{(b_{k}|} \\, .
 
     Args:


### PR DESCRIPTION
While reading the new documentation (I was having a look at the gradients' section), I noticed that the rendering of docstrings (especially regarding formulas and bra/ket notation) is not shown correctly in the quantum information paragraph. An example [here](https://qibo.readthedocs.io/en/stable/api-reference/qibo.html#computational-basis-to-pauli-basis).

I open this PR for fixing this. 
I did a little small fix, but since the work is not mine, to avoid making mistakes, it's best for you @renatomello to take a look at it. I apologize if what I say is obvious, but perhaps using `|state \rangle` ( $|state\rangle$ ) can help solve part of the problem.

Thanks for the work and sorry for the intrusion.
