### PR TITLE
Depolarizing channel

### DIFF
--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -303,21 +303,16 @@ class DepolarizingChannel(Channel):
 
     def apply_density_matrix(self, backend, state, nqubits):
         lam = self.init_kwargs["lam"]
-        return (1 - lam) * backend.cast(
-            state
-        ) + lam * backend.apply_gate_density_matrix(
-            I(*self.target_qubits), state, nqubits
-        )
+        return (1 - lam) * backend.cast(state) + lam / 2**nqubits * I(
+            *range(nqubits)
+        ).asmatrix(backend)
 
     def apply(self, backend, state, nqubits):
-        from qibo.backends import NumpyBackend
-
         num_qubits = len(self.target_qubits)
         num_terms = 4**num_qubits
         prob_pauli = self.init_kwargs["lam"] / num_terms
         probs = (num_terms - 1) * [prob_pauli]
         gates = []
-        backend = NumpyBackend()
         for pauli_list in list(product([I, X, Y, Z], repeat=num_qubits))[1::]:
             fgate = FusedGate(*range(num_qubits))
             for j, pauli in enumerate(pauli_list):

--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -265,7 +265,7 @@ class PauliNoiseChannel(UnitaryChannel):
         self.init_kwargs = {"px": px, "py": py, "pz": pz}
 
 
-class DepolarizingChannel(UnitaryChannel):
+class DepolarizingChannel(Channel):
     """:math:`n`-qubit Depolarizing quantum error channel,
 
     .. math::
@@ -285,8 +285,7 @@ class DepolarizingChannel(UnitaryChannel):
     """
 
     def __init__(self, q, lam=0):
-        from qibo.backends import NumpyBackend
-
+        super().__init__()
         num_qubits = len(q)
         num_terms = 4**num_qubits
         max_param = num_terms / (num_terms - 1)
@@ -295,7 +294,27 @@ class DepolarizingChannel(UnitaryChannel):
                 ValueError,
                 "Depolarizing parameter must be in between 0 and {}.".format(max_param),
             )
-        prob_pauli = lam / num_terms
+
+        self.name = "DepolarizingChannel"
+        self.target_qubits = q
+
+        self.init_args = [q]
+        self.init_kwargs = {"lam": lam}
+
+    def apply_density_matrix(self, backend, state, nqubits):
+        lam = self.init_kwargs["lam"]
+        return (1 - lam) * backend.cast(
+            state
+        ) + lam * backend.apply_gate_density_matrix(
+            I(*self.target_qubits), state, nqubits
+        )
+
+    def apply(self, backend, state, nqubits):
+        from qibo.backends import NumpyBackend
+
+        num_qubits = len(self.target_qubits)
+        num_terms = 4**num_qubits
+        prob_pauli = self.init_kwargs["lam"] / num_terms
         probs = (num_terms - 1) * [prob_pauli]
         gates = []
         backend = NumpyBackend()
@@ -303,14 +322,10 @@ class DepolarizingChannel(UnitaryChannel):
             fgate = FusedGate(*range(num_qubits))
             for j, pauli in enumerate(pauli_list):
                 fgate.append(pauli(j))
-            gates.append(Unitary(backend.asmatrix_fused(fgate), *q))
-
-        super().__init__(probs, gates)
-        self.name = "DepolarizingChannel"
-        assert self.target_qubits == q
-
-        self.init_args = [q]
-        self.init_kwargs = {"lam": lam}
+            gates.append(Unitary(backend.asmatrix_fused(fgate), *self.target_qubits))
+        self.gates = tuple(gates)
+        self.coefficients = tuple(probs)
+        return backend.apply_channel(self, state, nqubits)
 
 
 class ResetChannel(Channel):

--- a/src/qibo/tests/test_gates_channels.py
+++ b/src/qibo/tests/test_gates_channels.py
@@ -155,7 +155,7 @@ def test_depolarizing_channel(backend):
     lam = 0.3
     initial_rho_r = np.einsum("ijik->jk", initial_rho.reshape([2, 4, 2, 4]))
     channel = gates.DepolarizingChannel((1, 2), lam)
-    final_rho = backend.apply_channel_density_matrix(channel, np.copy(initial_rho), 3)
+    final_rho = channel.apply_density_matrix(backend, np.copy(initial_rho), 3)
     final_rho_r = np.einsum("ijik->jk", final_rho.reshape([2, 4, 2, 4]))
     target_rho_r = (1 - lam) * initial_rho_r + lam * np.trace(
         initial_rho_r


### PR DESCRIPTION
This PR implements a fix for issue #718. Debugging the code, I found that the bottleneck was in
https://github.com/qiboteam/qibojit/blob/df5f2360bf89dace3bf6833cde7f0d68999da94f/src/qibojit/backends/cpu.py#L182
The depolarizing channel is given by 
$\mathcal{E}(\rho)=(1-\lambda)\rho+\frac{\lambda}{2^n}I=(1-\frac{(4^n-1)\lambda}{4^n})\rho+\frac{\lambda}{4^n}{\sum}_{j=2}^{4^n}P_j\rho P_j^t$
 where $P_j$ denotes all products of $n$ Pauli matrices and the identity $(P_1=I^{\otimes n})$.
The channel is currently implemented as a sum of Kraus operators which allows it to be used with state vectors and density matrices. However, when running density matrix circuits with qibojit this implementation turns out to be too slow.
So I have implemented the channel as $(1-\lambda)\rho+\frac{\lambda}{2^n}I$ when using density matrices and as a sum of kraus operators for state vectors. This allows the channel to be used in both cases while solving the performance issue with qibojit. This can be benchmarked with:

```py
import time
import qibo
from qibo import gates
from qibo.models import Circuit

nc = Circuit(3, density_matrix=True)
nc.add(gates.DepolarizingChannel((0,1,), 0.1))

qibo.set_backend("numpy")
start_time = time.time()
result = nc()
print(time.time() - start_time)

qibo.set_backend("qibojit", platform="numba")
start_time = time.time()
result = nc()
print(time.time() - start_time)

qibo.set_backend("qibojit", platform="numba")
qibo.set_threads(1)
start_time = time.time()
result = nc()
print(time.time() - start_time)
```
In my computer numpy takes 0.0002 sec, qibojit (multi-threading) 0.001 sec, qibojit (single-thread) 0.0001 sec.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
