### PR TITLE
Fix to adiabatic example

### DIFF
--- a/examples/adiabatic/linear.py
+++ b/examples/adiabatic/linear.py
@@ -46,7 +46,7 @@ def main(nqubits, hfield, T, dt, solver, save):
     target_energy = bac.to_numpy(h1.eigenvalues()[0]).real
 
     # Check ground state
-    state_energy = bac.to_numpy(callbacks.Energy(h1).apply(bac, target_state)).real
+    state_energy = bac.to_numpy(h1.expectation(target_state)).real
     np.testing.assert_allclose(state_energy.real, target_energy)
 
     energy = callbacks.Energy(h1)

--- a/examples/adiabatic/linear.py
+++ b/examples/adiabatic/linear.py
@@ -1,5 +1,6 @@
 """Adiabatic evolution for the Ising Hamiltonian using linear scaling."""
 import argparse
+from pathlib import Path
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -38,13 +39,14 @@ def main(nqubits, hfield, T, dt, solver, save):
     """
     h0 = hamiltonians.X(nqubits)
     h1 = hamiltonians.TFIM(nqubits, h=hfield)
+    bac = h1.backend
 
     # Calculate target values (H1 ground state)
     target_state = h1.ground_state()
-    target_energy = h1.eigenvalues()[0].numpy().real
+    target_energy = bac.to_numpy(h1.eigenvalues()[0]).real
 
     # Check ground state
-    state_energy = callbacks.Energy(h1)(target_state).numpy()
+    state_energy = bac.to_numpy(callbacks.Energy(h1).apply(bac, target_state)).real
     np.testing.assert_allclose(state_energy.real, target_energy)
 
     energy = callbacks.Energy(h1)
@@ -70,7 +72,9 @@ def main(nqubits, hfield, T, dt, solver, save):
     plt.ylabel("Overlap")
 
     if save:
-        plt.savefig(f"images/dynamics_n{nqubits}T{T}.png", bbox_inches="tight")
+        out_fol = Path("images")
+        out_fol.mkdir(exist_ok=True)
+        plt.savefig(out_fol / f"dynamics_n{nqubits}T{T}.png", bbox_inches="tight")
     else:
         plt.show()
 

--- a/examples/adiabatic/optimize.py
+++ b/examples/adiabatic/optimize.py
@@ -50,7 +50,7 @@ def main(nqubits, hfield, params, dt, solver, method, maxiter, save):
     target_energy = bac.to_numpy(h1.eigenvalues()[0]).real
 
     # Check ground state
-    state_energy = bac.to_numpy(callbacks.Energy(h1).apply(bac, target_state)).real
+    state_energy = bac.to_numpy(h1.expectation(target_state)).real
     np.testing.assert_allclose(state_energy.real, target_energy)
 
     evolution = models.AdiabaticEvolution(h0, h1, spolynomial, dt=dt, solver=solver)

--- a/examples/adiabatic/optimize.py
+++ b/examples/adiabatic/optimize.py
@@ -72,7 +72,8 @@ def main(nqubits, hfield, params, dt, solver, method, maxiter, save):
         out_fol.mkdir(exist_ok=True)
         evolution.opt_history["loss"].append(target_energy)
         np.save(out_fol / f"{save}_n{nqubits}_loss.npy", evolution.opt_history["loss"])
-        np.save(out_fol / f"{save}_n{nqubits}_params.npy", evolution.opt_history["params"]
+        np.save(
+            out_fol / f"{save}_n{nqubits}_params.npy", evolution.opt_history["params"]
         )
 
 

--- a/examples/adiabatic/optimize.py
+++ b/examples/adiabatic/optimize.py
@@ -1,5 +1,6 @@
 """Adiabatic evolution scheduling optimization for the Ising Hamiltonian."""
 import argparse
+from pathlib import Path
 
 import numpy as np
 
@@ -42,13 +43,14 @@ def main(nqubits, hfield, params, dt, solver, method, maxiter, save):
     """
     h0 = hamiltonians.X(nqubits)
     h1 = hamiltonians.TFIM(nqubits, h=hfield)
+    bac = h1.backend
 
     # Calculate target values (H1 ground state)
     target_state = h1.ground_state()
-    target_energy = h1.eigenvalues()[0].numpy().real
+    target_energy = bac.to_numpy(h1.eigenvalues()[0]).real
 
     # Check ground state
-    state_energy = callbacks.Energy(h1)(target_state).numpy()
+    state_energy = bac.to_numpy(callbacks.Energy(h1).apply(bac, target_state)).real
     np.testing.assert_allclose(state_energy.real, target_energy)
 
     evolution = models.AdiabaticEvolution(h0, h1, spolynomial, dt=dt, solver=solver)
@@ -61,15 +63,16 @@ def main(nqubits, hfield, params, dt, solver, method, maxiter, save):
     print("Final parameters:", parameters)
 
     final_state = evolution(parameters[-1])
-    overlap = callbacks.Overlap(target_state)(final_state).numpy()
+    overlap = bac.to_numpy(callbacks.Overlap(target_state).apply(bac, final_state)).real
     print("Target energy:", target_energy)
     print("Overlap:", overlap)
 
     if save:
+        out_fol = Path("optparams")
+        out_fol.mkdir(exist_ok=True)
         evolution.opt_history["loss"].append(target_energy)
-        np.save(f"optparams/{save}_n{nqubits}_loss.npy", evolution.opt_history["loss"])
-        np.save(
-            f"optparams/{save}_n{nqubits}_params.npy", evolution.opt_history["params"]
+        np.save(out_fol / f"{save}_n{nqubits}_loss.npy", evolution.opt_history["loss"])
+        np.save(out_fol / f"{save}_n{nqubits}_params.npy", evolution.opt_history["params"]
         )
 
 

--- a/examples/adiabatic/trotter_error.py
+++ b/examples/adiabatic/trotter_error.py
@@ -46,7 +46,8 @@ def main(nqubits, hfield, T, save):
         trotter_ev = models.StateEvolution(trotter_h, dt=T / nsteps)
         exact_state = exact_ev(final_time=T, initial_state=np.copy(initial_state))
         trotter_state = trotter_ev(final_time=T, initial_state=np.copy(initial_state))
-        overlaps.append(callbacks.Overlap(exact_state)(trotter_state).numpy())
+        ovlp = callbacks.Overlap(exact_state).apply(dense_h.backend, trotter_state)
+        overlaps.append(dense_h.backend.to_numpy(ovlp))
 
     dt_list = T / nsteps_list
     overlaps = 1 - np.array(overlaps)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -235,6 +235,44 @@ def test_grover3sat(nqubits, instance):
     run_script(args)
 
 
+@pytest.mark.parametrize("nqubits,hfield,T,dt", [(4, 1, 10, 1e-1)])
+@pytest.mark.parametrize("solver", ["exp", "rk4"])
+def test_adiabatic_linear(nqubits, hfield, T, dt, solver, save=False):
+    if "functions" in sys.modules:
+        del sys.modules["functions"]
+    args = locals()
+    path = os.path.join(base_dir, "adiabatic")
+    sys.path[-1] = path
+    os.chdir(path)
+    run_script(args, script_name="linear.py")
+
+
+@pytest.mark.parametrize("nqubits,hfield,dt, params", [(4, 1, 1e-2, [1.0])])
+@pytest.mark.parametrize("solver", ["exp"])
+@pytest.mark.parametrize("method", [("Powell")])
+def test_adiabatic_optimize(
+    nqubits, hfield, params, dt, solver, method, maxiter=None, save=False
+):
+    if "functions" in sys.modules:
+        del sys.modules["functions"]
+    args = locals()
+    path = os.path.join(base_dir, "adiabatic")
+    sys.path[-1] = path
+    os.chdir(path)
+    run_script(args, script_name="optimize.py")
+
+
+@pytest.mark.parametrize("nqubits,hfield,T", [(4, 1, 1)])
+def test_adiabatic_trotter(nqubits, hfield, T, save=False):
+    if "functions" in sys.modules:
+        del sys.modules["functions"]
+    args = locals()
+    path = os.path.join(base_dir, "adiabatic")
+    sys.path[-1] = path
+    os.chdir(path)
+    run_script(args, script_name="trotter_error.py")
+
+
 @pytest.mark.parametrize("nqubits,instance,T,dt", [(4, 1, 10, 1e-1)])
 @pytest.mark.parametrize("solver", ["exp", "rk4"])
 @pytest.mark.parametrize("dense", [True, False])


### PR DESCRIPTION
I was trying to use the code in https://github.com/qiboteam/qibo/tree/master/examples/adiabatic and wasn't working due to the usage of `.numpy()` and how the callbacks were being called. I guess this went unnoticed because it is missing from the [examples](https://github.com/qiboteam/qibo/blob/master/examples/test_examples.py)

I made some minimal changes so that it works for me but let me know if I'm using the correct functions/options (for instance, the `callback.apply` looks a bit cumbersome to me, but reading the code seemed like the right one for the use case).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [ ] Documentation is updated.
