### PR TITLE
Depolarizing channel on gpu

### DIFF
--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -303,9 +303,9 @@ class DepolarizingChannel(Channel):
 
     def apply_density_matrix(self, backend, state, nqubits):
         lam = self.init_kwargs["lam"]
-        return (1 - lam) * backend.cast(state) + lam / 2**nqubits * I(
-            *range(nqubits)
-        ).asmatrix(backend)
+        return (1 - lam) * backend.cast(state) + lam / 2**nqubits * backend.cast(
+            I(*range(nqubits)).asmatrix(backend)
+        )
 
     def apply(self, backend, state, nqubits):
         num_qubits = len(self.target_qubits)


### PR DESCRIPTION
I updated CUDA and cupy on my machine and I realised that the depolarizing channel raises a `TypeError` when applying it to density matrix circuits and running them on gpu with `qibojit-cupy` using the latest version of `cupy` (`cupy-cuda12x`). This PR fixes it.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
