### PR TITLE
fix pylint errors

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -396,9 +396,10 @@ class NumpyBackend(Backend):
 
             else:
                 if circuit.accelerators:  # pragma: no cover
+                    # pylint: disable=E1111
                     state = self.execute_distributed_circuit(
                         circuit, initial_state, return_array=True
-                    )  # pylint: disable=E1111
+                    )  
                 else:
                     if initial_state is None:
                         state = self.zero_state(nqubits)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -399,7 +399,7 @@ class NumpyBackend(Backend):
                     # pylint: disable=E1111
                     state = self.execute_distributed_circuit(
                         circuit, initial_state, return_array=True
-                    )  
+                    )
                 else:
                     if initial_state is None:
                         state = self.zero_state(nqubits)

--- a/src/qibo/hamiltonians/adiabatic.py
+++ b/src/qibo/hamiltonians/adiabatic.py
@@ -158,11 +158,9 @@ class SymbolicAdiabaticHamiltonian(BaseAdiabaticHamiltonian):
             self.trotter_circuit = TrotterCircuit(
                 self.groups, dt, self.nqubits, accelerators
             )
-        # pylint: disable=E1102    
-        st = (
-            self.schedule(t / self.total_time) if t != 0 else 0
-        )  
-        # pylint: enable=E1102 
+        # pylint: disable=E1102
+        st = self.schedule(t / self.total_time) if t != 0 else 0
+        # pylint: enable=E1102
         coefficients = {self.h0: 1 - st, self.h1: st}
         self.trotter_circuit.set(dt, coefficients)
         return self.trotter_circuit.circuit

--- a/src/qibo/hamiltonians/adiabatic.py
+++ b/src/qibo/hamiltonians/adiabatic.py
@@ -158,9 +158,11 @@ class SymbolicAdiabaticHamiltonian(BaseAdiabaticHamiltonian):
             self.trotter_circuit = TrotterCircuit(
                 self.groups, dt, self.nqubits, accelerators
             )
+        # pylint: disable=E1102    
         st = (
             self.schedule(t / self.total_time) if t != 0 else 0
-        )  # pylint: disable=E1102
+        )  
+        # pylint: enable=E1102 
         coefficients = {self.h0: 1 - st, self.h1: st}
         self.trotter_circuit.set(dt, coefficients)
         return self.trotter_circuit.circuit

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -559,6 +559,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
         terms = self.terms
         for term in terms:
+            # pylint: disable=E1101
             for factor in term.factors:
                 if isinstance(factor, Z) == False:
                     raise_error(

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -971,12 +971,8 @@ class Circuit:
         """
         if self.compiled:
             # pylint: disable=E1101
-            state = self.compiled.executor(   
-                initial_state, nshots 
-            )  
-            self._final_state = self.compiled.result(
-                state, nshots
-            )  
+            state = self.compiled.executor(initial_state, nshots)
+            self._final_state = self.compiled.result(state, nshots)
             return self._final_state
         else:
             from qibo.backends import GlobalBackend

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -970,12 +970,13 @@ class Circuit:
         details.
         """
         if self.compiled:
-            state = self.compiled.executor(
-                initial_state, nshots
-            )  # pylint: disable=E1101
+            # pylint: disable=E1101
+            state = self.compiled.executor(   
+                initial_state, nshots 
+            )  
             self._final_state = self.compiled.result(
                 state, nshots
-            )  # pylint: disable=E1101
+            )  
             return self._final_state
         else:
             from qibo.backends import GlobalBackend

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -315,9 +315,7 @@ def vnCDR(
     noisy_array = np.array(train_val["noisy"]).reshape(-1, len(noise_levels))
     # Fit the model
     params = np.random.rand(len(noise_levels))
-    optimal_params = curve_fit(
-        model, noisy_array.T, train_val["noise-free"], p0=params 
-    )
+    optimal_params = curve_fit(model, noisy_array.T, train_val["noise-free"], p0=params)
     # Run the input circuit
     val = []
     for level in noise_levels:

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -312,11 +312,11 @@ def vnCDR(
             val = circuit_result.expectation_from_samples(observable)
             train_val["noisy"].append(val)
     # Repeat noise-free values for each noise level
-    train_val["noisy"] = np.array(train_val["noisy"]).reshape(-1, len(noise_levels))
+    noisy_array = np.array(train_val["noisy"]).reshape(-1, len(noise_levels))
     # Fit the model
     params = np.random.rand(len(noise_levels))
     optimal_params = curve_fit(
-        model, train_val["noisy"].T, train_val["noise-free"], p0=params
+        model, noisy_array.T, train_val["noise-free"], p0=params 
     )
     # Run the input circuit
     val = []


### PR DESCRIPTION
This PR solves #776. 
To solve the following error, I have disabled the `pylint` error locally, because the code looks good to me.
@AlejandroSopena confirms that the code works as expexted.
```
************* Module qibo.hamiltonians.hamiltonians
src/qibo/hamiltonians/hamiltonians.py:566:26: E1101: Instance of 'HamiltonianTerm' has no 'factors' member (no-member)
src/qibo/hamiltonians/hamiltonians.py:571:19: E1101: Instance of 'HamiltonianTerm' has no 'factors' member (no-member)
src/qibo/hamiltonians/hamiltonians.py:571:44: E1101: Instance of 'HamiltonianTerm' has no 'factors' member (no-member)
```
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
