### PR TITLE
Fix hamiltonian models neighbour and noise model tests/lint

### DIFF
--- a/src/qibo/hamiltonians/models.py
+++ b/src/qibo/hamiltonians/models.py
@@ -50,6 +50,8 @@ def XXZ(nqubits, delta=0.5, dense=True, backend=None):
             from qibo.hamiltonians import XXZ
             h = XXZ(3) # initialized XXZ model with 3 qubits
     """
+    if nqubits < 2:
+        raise_error(ValueError, "Number of qubits must be larger than one.")
     if dense:
         condition = lambda i, j: i in {j % nqubits, (j + 1) % nqubits}
         hx = _build_spin_model(nqubits, matrices.X, condition)
@@ -141,6 +143,8 @@ def TFIM(nqubits, h=0.0, dense=True, backend=None):
             :class:`qibo.core.hamiltonians.Hamiltonian`, otherwise it creates
             a :class:`qibo.core.hamiltonians.SymbolicHamiltonian`.
     """
+    if nqubits < 2:
+        raise_error(ValueError, "Number of qubits must be larger than one.")
     if dense:
         condition = lambda i, j: i in {j % nqubits, (j + 1) % nqubits}
         ham = -_build_spin_model(nqubits, matrices.Z, condition)

--- a/src/qibo/tests/test_hamiltonians_models.py
+++ b/src/qibo/tests/test_hamiltonians_models.py
@@ -52,3 +52,9 @@ def test_maxcut(backend, nqubits, dense, calcterms):
     if (not dense) and calcterms:
         _ = final_ham.terms
     backend.assert_allclose(final_ham.matrix, target_ham)
+
+
+@pytest.mark.parametrize("model", ["XXZ", "TFIM"])
+def test_missing_neighbour_qubit(backend, model):
+    with pytest.raises(ValueError):
+        H = getattr(hamiltonians, model)(nqubits=1, backend=backend)

--- a/src/qibo/tests/test_noise.py
+++ b/src/qibo/tests/test_noise.py
@@ -504,9 +504,9 @@ def test_noisy_circuit(backend, nshots, idle_qubits):
                 [500e-6] * 6 + [300e-9] * 2 + [0.2] * 2 + [0.3] * 6,
             ],
         ]
-        for bounds in bounds:
+        for bound in bounds:
             noise_model = CompositeNoiseModel(params)
-            noise_model.fit(result, bounds=bounds, backend=backend)
+            noise_model.fit(result, bounds=bound, backend=backend)
             backend.assert_allclose(
                 noise_model.hellinger, 1, rtol=noise_model.hellinger0["shot_error"]
             )


### PR DESCRIPTION
Closes #774 and fixes pylint and failing tests for noise model (after #672 merge).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
