### PR TITLE
Fix trainability after `circuit.invert()`

### DIFF
--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -372,6 +372,8 @@ class Circuit:
         Returns:
             The circuit inverse.
         """
+        from qibo.gates import ParametrizedGate
+
         skip_measurements = True
         measurements = []
         new_circuit = self.__class__(**self.init_kwargs)
@@ -379,7 +381,10 @@ class Circuit:
             if isinstance(gate, gates.M) and skip_measurements:
                 measurements.append(gate)
             else:
-                new_circuit.add(gate.dagger())
+                new_gate = gate.dagger()
+                if isinstance(gate, ParametrizedGate):
+                    new_gate.trainable = gate.trainable
+                new_circuit.add(new_gate)
                 skip_measurements = False
         new_circuit.add(measurements[::-1])
         return new_circuit


### PR DESCRIPTION
As mentioned in #812, I think it is useful to preserve the trainability of the gates if you reverse the circuit. In this PR I have modified the `invert` method so that the new gate, if parametric, inherits the trainability value from that of the original circuit.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
