### PR TITLE
Accepting circuits as initial states

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -335,8 +335,14 @@ class NumpyBackend(Backend):
             if not initial_state.density_matrix == circuit.density_matrix:
                 raise_error(
                     ValueError,
-                    f"""Cannot set circuit with density_matrix {initial_state.density_matrix} a
+                    f"""Cannot set circuit with density_matrix {initial_state.density_matrix} as
                       initial state for circuit with density_matrix {circuit.density_matrix}.""",
+                )
+            elif not initial_state.accelerators == circuit.accelerators:
+                raise_error(
+                    ValueError,
+                    f"""Cannot set circuit with accelerators {initial_state.density_matrix} as
+                      initial state for circuit with accelerators {circuit.density_matrix}.""",
                 )
             else:
                 return self.execute_circuit(initial_state + circuit, None, nshots)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -332,7 +332,14 @@ class NumpyBackend(Backend):
         self, circuit, initial_state=None, nshots=None, return_array=False
     ):
         if isinstance(initial_state, type(circuit)):
-            return self.execute_circuit(initial_state, None, nshots)
+            if not initial_state.density_matrix == circuit.density_matrix:
+                raise_error(
+                    ValueError,
+                    f"""Cannot set circuit with density_matrix {initial_state.density_matrix} a
+                      initial state for circuit with density_matrix {circuit.density_matrix}.""",
+                )
+            else:
+                return self.execute_circuit(initial_state + circuit, None, nshots)
 
         if circuit.repeated_execution:
             return self.execute_circuit_repeated(circuit, initial_state, nshots)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -338,7 +338,9 @@ class NumpyBackend(Backend):
                     f"""Cannot set circuit with density_matrix {initial_state.density_matrix} as
                       initial state for circuit with density_matrix {circuit.density_matrix}.""",
                 )
-            elif not initial_state.accelerators == circuit.accelerators:
+            elif (
+                not initial_state.accelerators == circuit.accelerators
+            ):  # pragma: no cover
                 raise_error(
                     ValueError,
                     f"""Cannot set circuit with accelerators {initial_state.density_matrix} as

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -331,6 +331,9 @@ class NumpyBackend(Backend):
     def execute_circuit(
         self, circuit, initial_state=None, nshots=None, return_array=False
     ):
+        if isinstance(initial_state, type(circuit)):
+            return self.execute_circuit(initial_state, None, nshots)
+
         if circuit.repeated_execution:
             return self.execute_circuit_repeated(circuit, initial_state, nshots)
 

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -967,8 +967,11 @@ class Circuit:
     def execute(self, initial_state=None, nshots=None):
         """Executes the circuit. Exact implementation depends on the backend.
 
-        See :meth:`qibo.core.circuit.Circuit.execute` for more
-        details.
+        Args:
+            initial_state (`np.ndarray` or :class:`qibo.models.circuit.Circuit`): Initial configuration.
+                Can be specified by the setting the state vector using an array or a circuit. If ``None``
+                the initial state is ``|000..00>``.
+            nshots (int): Number of shots.
         """
         if self.compiled:
             # pylint: disable=E1101

--- a/src/qibo/tests/test_models_circuit_execution.py
+++ b/src/qibo/tests/test_models_circuit_execution.py
@@ -106,3 +106,18 @@ def test_density_matrix_circuit(backend):
     target_rho = m2.dot(target_rho).dot(m2.T.conj())
     target_rho = m3.dot(target_rho).dot(m3.T.conj())
     backend.assert_allclose(final_rho, target_rho)
+
+
+def test_circuit_initial_state(backend):
+    c = Circuit(2)
+    c.add(gates.H(0))
+    c.add(gates.X(1))
+
+    c1 = Circuit(2)
+    c1.add(gates.H(0))
+    c1.add(gates.H(1))
+
+    c_final_state = backend.execute_circuit(c, c1)
+    c1_final_state = backend.execute_circuit(c1)
+
+    backend.assert_allclose(c_final_state, c1_final_state)


### PR DESCRIPTION
This PR implements the following point:
- [x] modify circuit execution to accept initial states of two types: arrays and circuits (to be able to execute on hardware).

from #720 and PR #799.
I will open a PR in qibolab to support this feature.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
