### PR TITLE
circuit initialization

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -382,7 +382,6 @@ class NumpyBackend(Backend):
                       initial state for circuit with accelerators {circuit.density_matrix}.""",
                 )
             else:
-                tot = initial_state + circuit
                 return self.execute_circuit(initial_state + circuit, None, nshots)
 
         if circuit.repeated_execution:

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -382,6 +382,7 @@ class NumpyBackend(Backend):
                       initial state for circuit with accelerators {circuit.density_matrix}.""",
                 )
             else:
+                tot = initial_state + circuit
                 return self.execute_circuit(initial_state + circuit, None, nshots)
 
         if circuit.repeated_execution:

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -186,7 +186,7 @@ class Circuit:
     def _basis_initialization(self, basis: str, eigenstate: str):
         """This function appends some gates at the beginning of the
         circuit's queue in order to initialize all the qubits in a specific
-        basis eigenstate.
+        eigenstate of the operator defined in `basis`:
 
             - if eigenstate is  '+', no gate added
             - if eigenstate is '-', add an X gate

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -205,7 +205,7 @@ class Circuit:
             initial_queue.append(gates.H)
             initial_queue.append(gates.S)
         elif basis != "Z":
-            raise NotImplementedError(f"Invalid basis {basis}")
+            raise_error(NotImplementedError, f"Invalid basis {basis}")
         for gate in initial_queue:
             for qubit in range(self.nqubits):
                 self.queue.append(gate(qubit))

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -129,14 +129,7 @@ class Circuit:
         queues (DistributedQueues): Gate queues for each accelerator device. Defaults to `None`.
     """
 
-    def __init__(
-        self,
-        nqubits,
-        accelerators=None,
-        density_matrix=False,
-        basis="Z",
-        eigenstate="+",
-    ):
+    def __init__(self, nqubits, accelerators=None, density_matrix=False):
         if not isinstance(nqubits, int):
             raise_error(
                 TypeError,

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -128,7 +128,7 @@ class Circuit:
         nlocal (int): Total number of available qubits in each device. Defaults to `None`.
         queues (DistributedQueues): Gate queues for each accelerator device. Defaults to `None`.
         initialize (str): Basis to define the circuit inizial state.
-        eigenstate (str): Eigenstates that will belong to the basis. 
+        eigenstate (str): Eigenstates that will belong to the basis.
     """
 
     def __init__(

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -185,12 +185,15 @@ class Circuit:
 
         if eigenstate == "-":
             initial_queue.append(gates.X)
+        elif eigenstate != "+":
+            raise NotImplementedError("Invalid eigenstate")
         if initialize == "X":
             initial_queue.append(gates.H)
         elif initialize == "Y":
             initial_queue.append(gates.H)
             initial_queue.append(gates.S)
-
+        elif initialize != "Z":
+            raise NotImplementedError("Invalid initialize")
         for gate in initial_queue:
             for qubit in range(nqubits):
                 self.queue.append(gate(qubit))

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -186,7 +186,7 @@ class Circuit:
         if eigenstate == "-":
             initial_queue.append(gates.X)
         elif eigenstate != "+":
-            raise NotImplementedError("Invalid eigenstate")
+            raise NotImplementedError(f"Invalid eigenstate {eigenstate}")
         if initialize == "X":
             initial_queue.append(gates.H)
         elif initialize == "Y":

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -127,6 +127,8 @@ class Circuit:
         nglobal (int): Base two logarithm of the number of devices. Defaults to `None`.
         nlocal (int): Total number of available qubits in each device. Defaults to `None`.
         queues (DistributedQueues): Gate queues for each accelerator device. Defaults to `None`.
+        initialize (str): Basis to define the circuit inizial state.
+        eigenstate (str): Eigenstates that will belong to the basis. 
     """
 
     def __init__(

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -248,15 +248,13 @@ class Circuit:
         # Add gates from `self` to `newcircuit` (including measurements)
         for gate in self.queue:
             if isinstance(gate, gates.M):
-                newcircuit.add(gates.M(*list(gate._target_qubits)))
-            else:
-                newcircuit.add(gate)
+                gate.basis = []
+            newcircuit.add(gate)
         # Add gates from `circuit` to `newcircuit` (including measurements)
         for gate in circuit.queue:
             if isinstance(gate, gates.M):
-                newcircuit.add(gates.M(*list(gate._target_qubits)))
-            else:
-                newcircuit.add(gate)
+                gate.basis = []
+            newcircuit.add(gate)
         # Re-execute full circuit when sampling if one of the circuit has repeated_execution ``True``
         newcircuit.repeated_execution = (
             self.repeated_execution or circuit.repeated_execution

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -245,28 +245,18 @@ class Circuit:
                 )
 
         newcircuit = self.__class__(**self.init_kwargs)
-        Circuit._fill_new_circuit(self, newcircuit)
-        Circuit._fill_new_circuit(circuit, newcircuit)
+        # Add gates from `self` to `newcircuit` (including measurements)
+        for gate in self.queue:
+            newcircuit.add(gate)
+        # Add gates from `circuit` to `newcircuit` (including measurements)
+        for gate in circuit.queue:
+            newcircuit.add(gate)
         # Re-execute full circuit when sampling if one of the circuit has
         # repeated_execution ``True``
         newcircuit.repeated_execution = (
             self.repeated_execution or circuit.repeated_execution
         )
         return newcircuit
-
-    @staticmethod
-    def _fill_new_circuit(circuit, newcircuit):
-        # this method appends all the `circuit`'s gate in new_circuit
-        excluded_gates = []
-        # all the gates in the basis of the measure gates should not
-        # be added to the new circuit, otherwise once the measure gate is added in the circuit
-        # there will be two of the same.
-        for gate in circuit.queue:
-            if isinstance(gate, gates.M):
-                excluded_gates.extend(gate.basis)
-        for gate in circuit.queue:
-            if gate not in excluded_gates:
-                newcircuit.add(gate)
 
     def on_qubits(self, *qubits):
         """Generator of gates contained in the circuit acting on specified qubits.
@@ -592,7 +582,15 @@ class Circuit:
                     )
 
             if isinstance(gate, gates.M):
-                self.add(gate.basis)
+                # The following loop is useful when two circuits are added together:
+                # all the gates in the basis of the measure gates should not
+                # be added to the new circuit, otherwise once the measure gate is added in the circuit
+                # there will be two of the same.
+
+                for base in gate.basis:
+                    if base not in self.queue:
+                        self.add(base)
+
                 self.queue.append(gate)
                 if gate.register_name is None:
                     # add default register name

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -136,7 +136,7 @@ class Circuit:
         nqubits,
         accelerators=None,
         density_matrix=False,
-        initialize="Z",
+        basis="Z",
         eigenstate="+",
     ):
         if not isinstance(nqubits, int):
@@ -181,21 +181,33 @@ class Circuit:
                 )
             self._distributed_init(nqubits, accelerators)
 
-        initial_queue = []
+        self._basis_initialization(basis, eigenstate)
 
+    def _basis_initialization(self, basis: str, eigenstate: str):
+        """This function appends some gates at the beginning of the
+        circuit's queue in order to initialize all the qubits in a specific
+        basis eigenstate.
+
+            - if eigenstate is  '+', no gate added
+            - if eigenstate is '-', add an X gate
+            - if basis is 'Z', no gate added
+            - if basis is 'X', add a Hadamard gate
+            - if basis is 'Y', add a Hadamard and an S gate
+        """
+        initial_queue = []
         if eigenstate == "-":
             initial_queue.append(gates.X)
         elif eigenstate != "+":
             raise NotImplementedError(f"Invalid eigenstate {eigenstate}")
-        if initialize == "X":
+        if basis == "X":
             initial_queue.append(gates.H)
-        elif initialize == "Y":
+        elif basis == "Y":
             initial_queue.append(gates.H)
             initial_queue.append(gates.S)
-        elif initialize != "Z":
-            raise NotImplementedError(f"Invalid initialize {initialize}")
+        elif basis != "Z":
+            raise NotImplementedError(f"Invalid basis {basis}")
         for gate in initial_queue:
-            for qubit in range(nqubits):
+            for qubit in range(self.nqubits):
                 self.queue.append(gate(qubit))
 
     def _distributed_init(self, nqubits, accelerators):  # pragma: no cover

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -198,7 +198,7 @@ class Circuit:
         if eigenstate == "-":
             initial_queue.append(gates.X)
         elif eigenstate != "+":
-            raise NotImplementedError(f"Invalid eigenstate {eigenstate}")
+            raise_error(NotImplementedError, f"Invalid eigenstate {eigenstate}")
         if basis == "X":
             initial_queue.append(gates.H)
         elif basis == "Y":

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -193,7 +193,7 @@ class Circuit:
             initial_queue.append(gates.H)
             initial_queue.append(gates.S)
         elif initialize != "Z":
-            raise NotImplementedError("Invalid initialize")
+            raise NotImplementedError(f"Invalid initialize {initialize}")
         for gate in initial_queue:
             for qubit in range(nqubits):
                 self.queue.append(gate(qubit))

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -129,7 +129,14 @@ class Circuit:
         queues (DistributedQueues): Gate queues for each accelerator device. Defaults to `None`.
     """
 
-    def __init__(self, nqubits, accelerators=None, density_matrix=False, initialize = "Z", eigenstate = "+"):
+    def __init__(
+        self,
+        nqubits,
+        accelerators=None,
+        density_matrix=False,
+        initialize="Z",
+        eigenstate="+",
+    ):
         if not isinstance(nqubits, int):
             raise_error(
                 TypeError,
@@ -171,22 +178,20 @@ class Circuit:
                     "Distributed circuit is not implemented " "for density matrices.",
                 )
             self._distributed_init(nqubits, accelerators)
-        
+
         initial_queue = []
-        
-        if eigenstate =="-":
+
+        if eigenstate == "-":
             initial_queue.append(gates.X)
         if initialize == "X":
             initial_queue.append(gates.H)
         elif initialize == "Y":
             initial_queue.append(gates.H)
             initial_queue.append(gates.S)
-        
+
         for gate in initial_queue:
             for qubit in range(nqubits):
                 self.queue.append(gate(qubit))
-
-            
 
     def _distributed_init(self, nqubits, accelerators):  # pragma: no cover
         """Distributed implementation of :class:`qibo.models.circuit.Circuit`.

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -129,7 +129,7 @@ class Circuit:
         queues (DistributedQueues): Gate queues for each accelerator device. Defaults to `None`.
     """
 
-    def __init__(self, nqubits, accelerators=None, density_matrix=False):
+    def __init__(self, nqubits, accelerators=None, density_matrix=False, initialize = "Z", eigenstate = "+"):
         if not isinstance(nqubits, int):
             raise_error(
                 TypeError,
@@ -171,6 +171,22 @@ class Circuit:
                     "Distributed circuit is not implemented " "for density matrices.",
                 )
             self._distributed_init(nqubits, accelerators)
+        
+        initial_queue = []
+        
+        if eigenstate =="-":
+            initial_queue.append(gates.X)
+        if initialize == "X":
+            initial_queue.append(gates.H)
+        elif initialize == "Y":
+            initial_queue.append(gates.H)
+            initial_queue.append(gates.S)
+        
+        for gate in initial_queue:
+            for qubit in range(nqubits):
+                self.queue.append(gate(qubit))
+
+            
 
     def _distributed_init(self, nqubits, accelerators):  # pragma: no cover
         """Distributed implementation of :class:`qibo.models.circuit.Circuit`.

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -247,7 +247,10 @@ class Circuit:
         newcircuit = self.__class__(**self.init_kwargs)
         # Add gates from `self` to `newcircuit` (including measurements)
         for gate in self.queue:
-            newcircuit.add(gate)
+            if isinstance(gate, gates.M):
+                newcircuit.add(gates.M(*list(gate._target_qubits)))
+            else:
+                newcircuit.add(gate)
         # Add gates from `circuit` to `newcircuit` (including measurements)
         for gate in circuit.queue:
             if isinstance(gate, gates.M):
@@ -258,7 +261,6 @@ class Circuit:
         newcircuit.repeated_execution = (
             self.repeated_execution or circuit.repeated_execution
         )
-
         return newcircuit
 
     def on_qubits(self, *qubits):

--- a/src/qibo/models/utils.py
+++ b/src/qibo/models/utils.py
@@ -95,7 +95,7 @@ def initialize(nqubits: int, basis=gates.Z, eigenstate="+"):
         - baisis (gates): Can be a qibo gate or a callable that accepts a qubit,
         the default value is `gates.Z`.
         - eigenstate (str): Specify which eigenstate of the operator defined in
-        `basis` will be the qubits' state. The dafault value is "+".
+        `basis` will be the qubits' state. The default value is "+".
     """
     circuit_basis = Circuit(nqubits)
     circuit_eigenstate = Circuit(nqubits)

--- a/src/qibo/models/utils.py
+++ b/src/qibo/models/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from qibo import gates
+from qibo.config import raise_error
 from qibo.models.circuit import Circuit
 
 
@@ -83,3 +84,33 @@ def gibbs(hamiltonian, state, eta=0.1):
         avg += np.exp(-eta * obj)
         sum_count += count
     return -np.log(avg / sum_count)
+
+
+def initialize(nqubits: int, basis="Z", eigenstate="+"):
+    """This function appends some gates at the beginning of the
+    circuit's queue in order to initialize all the qubits in a specific
+    eigenstate of the operator defined in `basis`:
+
+        - if eigenstate is  '+', no gate added
+        - if eigenstate is '-', add an X gate
+        - if basis is 'Z', no gate added
+        - if basis is 'X', add a Hadamard gate
+        - if basis is 'Y', add a Hadamard and an S gate
+    """
+    circuit = Circuit(nqubits)
+    gates_list = []
+    if eigenstate == "-":
+        gates_list.append(gates.X)
+    elif eigenstate != "+":
+        raise_error(NotImplementedError, f"Invalid eigenstate {eigenstate}")
+    if basis == "X":
+        gates_list.append(gates.H)
+    elif basis == "Y":
+        gates_list.append(gates.H)
+        gates_list.append(gates.S)
+    elif basis != "Z":
+        raise_error(NotImplementedError, f"Invalid basis {basis}")
+    for gate in gates_list:
+        for i in range(nqubits):
+            circuit.add(gate(i))
+    return circuit

--- a/src/qibo/models/utils.py
+++ b/src/qibo/models/utils.py
@@ -86,7 +86,7 @@ def gibbs(hamiltonian, state, eta=0.1):
     return -np.log(avg / sum_count)
 
 
-def initialize(nqubits: int, basis="Z", eigenstate="+"):
+def initialize(nqubits: int, basis: gates, eigenstate="+"):
     """This function appends some gates at the beginning of the
     circuit's queue in order to initialize all the qubits in a specific
     eigenstate of the operator defined in `basis`:
@@ -97,20 +97,17 @@ def initialize(nqubits: int, basis="Z", eigenstate="+"):
         - if basis is 'X', add a Hadamard gate
         - if basis is 'Y', add a Hadamard and an S gate
     """
-    circuit = Circuit(nqubits)
-    gates_list = []
+    circuit_basis = Circuit(nqubits)
+    circuit_eigenstate = Circuit(nqubits)
     if eigenstate == "-":
-        gates_list.append(gates.X)
+        for i in range(nqubits):
+            circuit_eigenstate.add(gates.X(i))
     elif eigenstate != "+":
         raise_error(NotImplementedError, f"Invalid eigenstate {eigenstate}")
-    if basis == "X":
-        gates_list.append(gates.H)
-    elif basis == "Y":
-        gates_list.append(gates.H)
-        gates_list.append(gates.S)
-    elif basis != "Z":
-        raise_error(NotImplementedError, f"Invalid basis {basis}")
-    for gate in gates_list:
-        for i in range(nqubits):
-            circuit.add(gate(i))
-    return circuit
+
+    for i in range(nqubits):
+        value = basis(i).basis_rotation()
+        if value is not None:
+            circuit_basis.add(value)
+    circuit_basis = circuit_basis.invert()
+    return circuit_eigenstate + circuit_basis

--- a/src/qibo/models/utils.py
+++ b/src/qibo/models/utils.py
@@ -86,16 +86,16 @@ def gibbs(hamiltonian, state, eta=0.1):
     return -np.log(avg / sum_count)
 
 
-def initialize(nqubits: int, basis: gates, eigenstate="+"):
-    """This function appends some gates at the beginning of the
-    circuit's queue in order to initialize all the qubits in a specific
-    eigenstate of the operator defined in `basis`:
+def initialize(nqubits: int, basis=gates.Z, eigenstate="+"):
+    """This function returns a circuit that prepeares all the
+    qubits in a specific state.
 
-        - if eigenstate is  '+', no gate added
-        - if eigenstate is '-', add an X gate
-        - if basis is 'Z', no gate added
-        - if basis is 'X', add a Hadamard gate
-        - if basis is 'Y', add a Hadamard and an S gate
+    Args:
+        - nqubits (int): Number of qubit in the circuit.
+        - baisis (gates): Can be a qibo gate or a callable that accepts a qubit,
+        the default value is `gates.Z`.
+        - eigenstate (str): Specify which eigenstate of the operator defined in
+        `basis` will be the qubits' state. The dafault value is "+".
     """
     circuit_basis = Circuit(nqubits)
     circuit_eigenstate = Circuit(nqubits)

--- a/src/qibo/models/utils.py
+++ b/src/qibo/models/utils.py
@@ -95,7 +95,8 @@ def initialize(nqubits: int, basis=gates.Z, eigenstate="+"):
         - baisis (gates): Can be a qibo gate or a callable that accepts a qubit,
         the default value is `gates.Z`.
         - eigenstate (str): Specify which eigenstate of the operator defined in
-        `basis` will be the qubits' state. The default value is "+".
+        `basis` will be the qubits' state. The default value is "+". Regarding the eigenstates
+        of `gates.Z`, the `+` eigenstate is mapped in the zero state and the `-` eigenstate in the one state.
     """
     circuit_basis = Circuit(nqubits)
     circuit_eigenstate = Circuit(nqubits)

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -53,17 +53,17 @@ def test_eigenstate(nqubits):
 
 @pytest.mark.parametrize("nqubits", [1, 5])
 def test_initialize(nqubits):
-    c = Circuit(nqubits, initialize="X")
+    c = Circuit(nqubits, basis="X")
     for gate in c.queue:
         assert type(gate) == gates.H
-    c = Circuit(nqubits, initialize="Y")
+    c = Circuit(nqubits, basis="Y")
     check_gates = [gates.H] * nqubits + [gates.S] * nqubits
     for i, gate in enumerate(c.queue):
         assert type(gate) == check_gates[i]
-    c = Circuit(nqubits, initialize="Z")
+    c = Circuit(nqubits, basis="Z")
     assert not c.queue  # empty list
     with pytest.raises(NotImplementedError):
-        c = Circuit(nqubits, initialize="W")
+        c = Circuit(nqubits, basis="W")
 
 
 @pytest.mark.parametrize("nqubits", [0, -10, 2.5])

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -63,7 +63,7 @@ def test_initialize(nqubits):
     c = Circuit(nqubits, initialize="Z")
     assert not c.queue  # empty list
     with pytest.raises(NotImplementedError):
-        c = Circuit(nqubits, eigenstate="W")
+        c = Circuit(nqubits, initialize="W")
 
 
 @pytest.mark.parametrize("nqubits", [0, -10, 2.5])

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -40,6 +40,32 @@ def test_circuit_init():
     assert c.nqubits == 2
 
 
+@pytest.mark.parametrize("nqubits", [1, 5])
+def test_eigenstate(nqubits):
+    c = Circuit(nqubits, eigenstate="-")
+    for gate in c.queue:
+        assert type(gate) == gates.X
+    c = Circuit(nqubits, eigenstate="+")
+    assert not c.queue  # empty list
+    with pytest.raises(NotImplementedError):
+        c = Circuit(nqubits, eigenstate="x")
+
+
+@pytest.mark.parametrize("nqubits", [1, 5])
+def test_initialize(nqubits):
+    c = Circuit(nqubits, initialize="X")
+    for gate in c.queue:
+        assert type(gate) == gates.H
+    c = Circuit(nqubits, initialize="Y")
+    check_gates = [gates.H] * nqubits + [gates.S] * nqubits
+    for i, gate in enumerate(c.queue):
+        assert type(gate) == check_gates[i]
+    c = Circuit(nqubits, initialize="Z")
+    assert not c.queue  # empty list
+    with pytest.raises(NotImplementedError):
+        c = Circuit(nqubits, eigenstate="W")
+
+
 @pytest.mark.parametrize("nqubits", [0, -10, 2.5])
 def test_circuit_init_errors(nqubits):
     with pytest.raises((ValueError, TypeError)):


### PR DESCRIPTION
This PR fixes the circuit initialization requested in #720, with the deployment of the `initialize` and `eigenstate` inputs, that will add the gates to perform the basis changing of the initial state.
It follows a little example,
```python
circuit = Circuit(5, initialize="X", eigenstate="-")
print(circuit.draw())
# Output:
# q0: ─X─H─
# q1: ─X─H─
# q2: ─X─H─
# q3: ─X─H─
# q4: ─X─H─
```
@scarrazza what do you think about it ? 
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
