### PR TITLE
Add gate labels

### DIFF
--- a/doc/source/code-examples/examples.rst
+++ b/doc/source/code-examples/examples.rst
@@ -104,9 +104,9 @@ For example
     ccx: 1
 
 
-The circuit property ``circuit.gate_types`` will also return a ``collections.Counter``
-that contains the gate types and the corresponding numbers of appearance. The
-method ``circuit.gates_of_type()`` can be used to access gate objects of specific type.
+The circuit property ``circuit.gate_types`` (or ``circuit.gate_names``) will return a ``collections.Counter``
+that contains the gate types (or names) and the corresponding numbers of appearance. The
+method ``circuit.gates_of_type()`` can be used to access gate objects of specific type or name.
 For example for the circuit of the previous example:
 
 .. testsetup::
@@ -124,13 +124,13 @@ For example for the circuit of the previous example:
 
 .. testcode::
 
-    common_gates = c.gate_types.most_common()
+    common_gates = c.gate_names.most_common()
     # returns the list [("h", 3), ("cx", 2), ("ccx", 1)]
 
     most_common_gate = common_gates[0][0]
     # returns "h"
 
-    all_h_gates = c.gates_of_type("h")
+    all_h_gates = c.gates_of_type(gates.H)
     # returns the list [(0, ref to H(0)), (1, ref to H(1)), (4, ref to H(2))]
 
 A circuit may contain multi-controlled or other gates that are not supported by

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -18,6 +18,7 @@ class Gate:
         """
         Attributes:
             name (str): Name of the gate.
+            label (str): Optional label of the gate. Default is the same as name.
             is_controlled_by (bool): ``True`` if the gate was created using the
                 :meth:`qibo.gates.abstract.Gate.controlled_by` method,
                 otherwise ``False``.
@@ -30,6 +31,7 @@ class Gate:
         from qibo import config
 
         self.name = None
+        self.label = None
         self.is_controlled_by = False
         # args for creating gate
         self.init_args = []

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -1,6 +1,4 @@
 import collections
-from abc import ABC, abstractmethod
-from collections.abc import Iterable
 from typing import List, Sequence, Tuple
 
 import sympy
@@ -18,7 +16,8 @@ class Gate:
         """
         Attributes:
             name (str): Name of the gate.
-            draw_label (str): Optional label for drawing the gate in a circuit with :func:`qibo.models.Circuit.draw`.
+            draw_label (str): Optional label for drawing the gate in a circuit
+                with :func:`qibo.models.Circuit.draw`.
             is_controlled_by (bool): ``True`` if the gate was created using the
                 :meth:`qibo.gates.abstract.Gate.controlled_by` method,
                 otherwise ``False``.
@@ -78,8 +77,7 @@ class Gate:
             repeated = self._find_repeated(qubits)
             raise_error(
                 ValueError,
-                "Target qubit {} was given twice for gate {}."
-                "".format(repeated, self.__class__.__name__),
+                f"Target qubit {repeated} was given twice for gate {self.__class__.__name__}.",
             )
 
     def _set_control_qubits(self, qubits: Sequence[int]):
@@ -89,8 +87,7 @@ class Gate:
             repeated = self._find_repeated(qubits)
             raise_error(
                 ValueError,
-                "Control qubit {} was given twice for gate {}."
-                "".format(repeated, self.__class__.__name__),
+                f"Control qubit {repeated} was given twice for gate {self.__class__.__name__}.",
             )
 
     @target_qubits.setter
@@ -133,8 +130,8 @@ class Gate:
         if common:
             raise_error(
                 ValueError,
-                "{} qubits are both targets and controls for "
-                "gate {}.".format(common, self.__class__.__name__),
+                f"{common} qubits are both targets and controls "
+                + f"for gate {self.__class__.__name__}.",
             )
 
     @property
@@ -223,9 +220,8 @@ class Gate:
                 raise_error(
                     RuntimeError,
                     "Cannot use `controlled_by` method "
-                    "on gate {} because it is already "
-                    "controlled by {}."
-                    "".format(self, self.control_qubits),
+                    + f"on gate {self} because it is already "
+                    + f"controlled by {self.control_qubits}.",
                 )
             return func(self, *args)  # pylint: disable=E1102
 
@@ -357,9 +353,8 @@ class ParametrizedGate(Gate):
         if len(x) != nparams:
             raise_error(
                 ValueError,
-                "Parametrized gate has {} parameters "
-                "but {} update values were given."
-                "".format(nparams, len(x)),
+                f"Parametrized gate has {nparams} parameters "
+                + f"but {len(x)} update values were given.",
             )
         for i, v in enumerate(x):
             if isinstance(v, sympy.Expr):

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -67,7 +67,8 @@ class Gate:
     def qasm_label(self):
         """String corresponding to OpenQASM operation of the gate."""
         raise_error(
-            NotImplementedError, f"{self.__class__.__name__} is not supported by OpenQASM"
+            NotImplementedError,
+            f"{self.__class__.__name__} is not supported by OpenQASM",
         )
 
     def _set_target_qubits(self, qubits: Sequence[int]):

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -18,7 +18,7 @@ class Gate:
         """
         Attributes:
             name (str): Name of the gate.
-            label (str): Optional label of the gate. Default is the same as name.
+            draw_label (str): Optional label for drawing the gate in a circuit with :func:`qibo.models.Circuit.draw`.
             is_controlled_by (bool): ``True`` if the gate was created using the
                 :meth:`qibo.gates.abstract.Gate.controlled_by` method,
                 otherwise ``False``.
@@ -31,7 +31,7 @@ class Gate:
         from qibo import config
 
         self.name = None
-        self.label = None
+        self.draw_label = None
         self.is_controlled_by = False
         # args for creating gate
         self.init_args = []
@@ -71,7 +71,7 @@ class Gate:
             raise_error(
                 ValueError,
                 "Target qubit {} was given twice for gate {}."
-                "".format(repeated, self.name),
+                "".format(repeated, __class__.__name__),
             )
 
     def _set_control_qubits(self, qubits: Sequence[int]):
@@ -82,7 +82,7 @@ class Gate:
             raise_error(
                 ValueError,
                 "Control qubit {} was given twice for gate {}."
-                "".format(repeated, self.name),
+                "".format(repeated, __class__.__name__),
             )
 
     @target_qubits.setter
@@ -126,7 +126,7 @@ class Gate:
             raise_error(
                 ValueError,
                 "{} qubits are both targets and controls for "
-                "gate {}.".format(common, self.name),
+                "gate {}.".format(common, __class__.__name__),
             )
 
     @property
@@ -269,13 +269,14 @@ class Gate:
 
         raise_error(
             NotImplementedError,
-            f"Generator eigenvalue is not implemented for {self.name}",
+            f"Generator eigenvalue is not implemented for {__class__.__name__}",
         )
 
     def basis_rotation(self):
         """Transformation required to rotate the basis for measuring the gate."""
         raise_error(
-            NotImplementedError, f"Basis rotation is not implemented for {self.name}"
+            NotImplementedError,
+            f"Basis rotation is not implemented for {__class__.__name__}",
         )
 
     @property

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -63,6 +63,13 @@ class Gate:
         """Tuple with ids of all qubits (control and target) that the gate acts."""
         return self.control_qubits + self.target_qubits
 
+    @property
+    def qasm_label(self):
+        """String corresponding to OpenQASM operation of the gate."""
+        raise_error(
+            NotImplementedError, f"{self.__class__.__name__} is not supported by OpenQASM"
+        )
+
     def _set_target_qubits(self, qubits: Sequence[int]):
         """Helper method for setting target qubits."""
         self._target_qubits = tuple(qubits)
@@ -71,7 +78,7 @@ class Gate:
             raise_error(
                 ValueError,
                 "Target qubit {} was given twice for gate {}."
-                "".format(repeated, __class__.__name__),
+                "".format(repeated, self.__class__.__name__),
             )
 
     def _set_control_qubits(self, qubits: Sequence[int]):
@@ -82,7 +89,7 @@ class Gate:
             raise_error(
                 ValueError,
                 "Control qubit {} was given twice for gate {}."
-                "".format(repeated, __class__.__name__),
+                "".format(repeated, self.__class__.__name__),
             )
 
     @target_qubits.setter
@@ -126,7 +133,7 @@ class Gate:
             raise_error(
                 ValueError,
                 "{} qubits are both targets and controls for "
-                "gate {}.".format(common, __class__.__name__),
+                "gate {}.".format(common, self.__class__.__name__),
             )
 
     @property
@@ -269,14 +276,14 @@ class Gate:
 
         raise_error(
             NotImplementedError,
-            f"Generator eigenvalue is not implemented for {__class__.__name__}",
+            f"Generator eigenvalue is not implemented for {self.__class__.__name__}",
         )
 
     def basis_rotation(self):
         """Transformation required to rotate the basis for measuring the gate."""
         raise_error(
             NotImplementedError,
-            f"Basis rotation is not implemented for {__class__.__name__}",
+            f"Basis rotation is not implemented for {self.__class__.__name__}",
         )
 
     @property

--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -30,7 +30,8 @@ class Channel(Gate):
 
     def apply(self, backend, state, nqubits):  # pragma: no cover
         raise_error(
-            NotImplementedError, f"{self.name} cannot be applied to state vector."
+            NotImplementedError,
+            f"{__class__.__name__} cannot be applied to state vector.",
         )
 
     def apply_density_matrix(self, backend, state, nqubits):
@@ -205,7 +206,7 @@ class KrausChannel(Channel):
     def __init__(self, ops):
         super().__init__()
         self.name = "KrausChannel"
-        self.label = "KrausChannel"
+        self.draw_label = "K"
         if isinstance(ops[0], Gate):
             self.gates = tuple(ops)
             self.target_qubits = tuple(
@@ -270,7 +271,7 @@ class UnitaryChannel(KrausChannel):
                 )
         super().__init__(ops)
         self.name = "UnitaryChannel"
-        self.label = "UnitaryChannel"
+        self.draw_label = "U"
         self.coefficients = tuple(probabilities)
         self.coefficient_sum = sum(probabilities)
         if self.coefficient_sum > 1 + PRECISION_TOL or self.coefficient_sum <= 0:
@@ -322,7 +323,7 @@ class PauliNoiseChannel(UnitaryChannel):
 
         super().__init__(probs, gates)
         self.name = "PauliNoiseChannel"
-        self.label = "PauliNoiseChannel"
+        self.draw_label = "PN"
         assert self.target_qubits == (q,)
 
         self.init_args = [q]
@@ -405,7 +406,7 @@ class GeneralizedPauliNoiseChannel(UnitaryChannel):
 
         super().__init__(probabilities, gates)
         self.name = "GeneralizedPauliNoiseChannel"
-        self.label = "GeneralizedPauliNoiseChannel"
+        self.draw_label = "GPN"
         self.init_args = qubits
         self.init_kwargs = dict(operators)
 
@@ -445,7 +446,7 @@ class DepolarizingChannel(Channel):
             )
 
         self.name = "DepolarizingChannel"
-        self.label = "DepolarizingChannel"
+        self.draw_label = "D"
         self.target_qubits = q
 
         self.init_args = [q]
@@ -585,7 +586,7 @@ class ThermalRelaxationChannel(KrausChannel):
         self.init_kwargs["p1"] = preset1
 
         self.name = "ThermalRelaxationChannel"
-        self.label = "ThermalRelaxationChannel"
+        self.draw_label = "TR"
 
     def apply_density_matrix(self, backend, state, nqubits):
         q = self.target_qubits[0]
@@ -659,7 +660,7 @@ class ReadoutErrorChannel(KrausChannel):
 
         super().__init__(ops=operators)
         self.name = "ReadoutErrorChannel"
-        self.label = "ReadoutErrorChannel"
+        self.draw_label = "RE"
 
 
 class ResetChannel(KrausChannel):
@@ -701,7 +702,7 @@ class ResetChannel(KrausChannel):
         super().__init__(ops=operators)
         self.init_kwargs = {"p0": p0, "p1": p1}
         self.name = "ResetChannel"
-        self.label = "ResetChannel"
+        self.draw_label = "R"
 
     def apply_density_matrix(self, backend, state, nqubits):
         return backend.reset_error_density_matrix(self, state, nqubits)

--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -205,6 +205,7 @@ class KrausChannel(Channel):
     def __init__(self, ops):
         super().__init__()
         self.name = "KrausChannel"
+        self.label = "KrausChannel"
         if isinstance(ops[0], Gate):
             self.gates = tuple(ops)
             self.target_qubits = tuple(
@@ -269,6 +270,7 @@ class UnitaryChannel(KrausChannel):
                 )
         super().__init__(ops)
         self.name = "UnitaryChannel"
+        self.label = "UnitaryChannel"
         self.coefficients = tuple(probabilities)
         self.coefficient_sum = sum(probabilities)
         if self.coefficient_sum > 1 + PRECISION_TOL or self.coefficient_sum <= 0:
@@ -320,6 +322,7 @@ class PauliNoiseChannel(UnitaryChannel):
 
         super().__init__(probs, gates)
         self.name = "PauliNoiseChannel"
+        self.label = "PauliNoiseChannel"
         assert self.target_qubits == (q,)
 
         self.init_args = [q]
@@ -402,6 +405,7 @@ class GeneralizedPauliNoiseChannel(UnitaryChannel):
 
         super().__init__(probabilities, gates)
         self.name = "GeneralizedPauliNoiseChannel"
+        self.label = "GeneralizedPauliNoiseChannel"
         self.init_args = qubits
         self.init_kwargs = dict(operators)
 
@@ -441,6 +445,7 @@ class DepolarizingChannel(Channel):
             )
 
         self.name = "DepolarizingChannel"
+        self.label = "DepolarizingChannel"
         self.target_qubits = q
 
         self.init_args = [q]
@@ -511,8 +516,6 @@ class ThermalRelaxationChannel(KrausChannel):
     """
 
     def __init__(self, q, t1, t2, time, excited_population=0):
-        self.name = "ThermalRelaxationChannel"
-
         # check given parameters
         if excited_population < 0 or excited_population > 1:
             raise_error(
@@ -580,6 +583,9 @@ class ThermalRelaxationChannel(KrausChannel):
         self.init_kwargs["excited_population"] = excited_population
         self.init_kwargs["p0"] = preset0
         self.init_kwargs["p1"] = preset1
+
+        self.name = "ThermalRelaxationChannel"
+        self.label = "ThermalRelaxationChannel"
 
     def apply_density_matrix(self, backend, state, nqubits):
         q = self.target_qubits[0]
@@ -653,6 +659,7 @@ class ReadoutErrorChannel(KrausChannel):
 
         super().__init__(ops=operators)
         self.name = "ReadoutErrorChannel"
+        self.label = "ReadoutErrorChannel"
 
 
 class ResetChannel(KrausChannel):
@@ -694,6 +701,7 @@ class ResetChannel(KrausChannel):
         super().__init__(ops=operators)
         self.init_kwargs = {"p0": p0, "p1": p1}
         self.name = "ResetChannel"
+        self.label = "ResetChannel"
 
     def apply_density_matrix(self, backend, state, nqubits):
         return backend.reset_error_density_matrix(self, state, nqubits)

--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -31,7 +31,7 @@ class Channel(Gate):
     def apply(self, backend, state, nqubits):  # pragma: no cover
         raise_error(
             NotImplementedError,
-            f"{__class__.__name__} cannot be applied to state vector.",
+            f"{self.__class__.__name__} cannot be applied to state vector.",
         )
 
     def apply_density_matrix(self, backend, state, nqubits):

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -55,58 +55,6 @@ PARAMETRIZED_GATES = {
     "cu1",
     "cu3",
 }
-DRAW_LABELS = {
-    "h": "H",
-    "x": "X",
-    "y": "Y",
-    "z": "Z",
-    "s": "S",
-    "sdg": "SDG",
-    "t": "T",
-    "tdg": "TDG",
-    "rx": "RX",
-    "ry": "RY",
-    "rz": "RZ",
-    "gpi": "GPI",
-    "gpi2": "GPI2",
-    "u1": "U1",
-    "u2": "U2",
-    "u3": "U3",
-    "cx": "X",
-    "swap": "x",
-    "iswap": "i",
-    "cz": "Z",
-    "crx": "RX",
-    "cry": "RY",
-    "crz": "RZ",
-    "cu1": "U1",
-    "cu3": "U3",
-    "ccx": "X",
-    "id": "I",
-    "measure": "M",
-    "fsim": "f",
-    "generalizedfsim": "gf",
-    "rxx": "RXX",
-    "ryy": "RYY",
-    "rzz": "RZZ",
-    "Unitary": "U",
-    "fswap": "fx",
-    "ms": "MS",
-    "PauliNoiseChannel": "PN",
-    "GeneralizedPauliNoiseChannel": "GPN",
-    "KrausChannel": "K",
-    "UnitaryChannel": "U",
-    "ThermalRelaxationChannel": "TR",
-    "DepolarizingChannel": "D",
-    "ReadoutErrorChannel": "RE",
-    "ResetChannel": "R",
-    "PartialTrace": "PT",
-    "EntanglementEntropy": "EE",
-    "Norm": "N",
-    "Overlap": "O",
-    "Energy": "E",
-    "Fused Gate": "[]",
-}
 
 
 class H(Gate):
@@ -119,7 +67,8 @@ class H(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "h"
-        self.label = "h"
+        self.draw_label = "H"
+        self.qasm_label = "h"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -134,7 +83,8 @@ class X(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "x"
-        self.label = "x"
+        self.draw_label = "X"
+        self.qasm_label = "x"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -233,7 +183,8 @@ class Y(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "y"
-        self.label = "y"
+        self.draw_label = "Y"
+        self.qasm_label = "y"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -254,7 +205,8 @@ class Z(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "z"
-        self.label = "z"
+        self.draw_label = "Z"
+        self.qasm_label = "z"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -289,7 +241,8 @@ class S(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "s"
-        self.label = "s"
+        self.draw_label = "S"
+        self.qasm_label = "s"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -315,7 +268,8 @@ class SDG(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "sdg"
-        self.label = "sdg"
+        self.draw_label = "SDG"
+        self.qasm_label = "sdg"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -341,7 +295,8 @@ class T(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "t"
-        self.label = "t"
+        self.draw_label = "T"
+        self.qasm_label = "t"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -367,7 +322,8 @@ class TDG(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "tdg"
-        self.label = "tdg"
+        self.draw_label = "TDG"
+        self.qasm_label = "tdg"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -385,7 +341,8 @@ class I(ParametrizedGate):
     def __init__(self, *q):
         super().__init__()
         self.name = "id"
-        self.label = "id"
+        self.draw_label = "I"
+        self.qasm_label = "id"
         self.target_qubits = tuple(q)
         self.init_args = q
         # save the number of target qubits as parameter
@@ -397,7 +354,7 @@ class Align(ParametrizedGate):
     def __init__(self, *q):
         super().__init__()
         self.name = "align"
-        self.label = "align"
+        self.draw_label = "A"
         self.target_qubits = tuple(q)
         self.init_args = q
         # save the number of target qubits as parameter
@@ -419,7 +376,6 @@ class _Rn_(ParametrizedGate):
     def __init__(self, q, theta, trainable=True):
         super().__init__(trainable)
         self.name = None
-        self.label = None
         self._controlled_gate = None
         self.target_qubits = (q,)
 
@@ -469,7 +425,8 @@ class RX(_Rn_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, theta, trainable)
         self.name = "rx"
-        self.label = "rx"
+        self.draw_label = "RX"
+        self.qasm_label = "rx"
         self._controlled_gate = CRX
 
     def generator_eigenvalue(self):
@@ -500,7 +457,8 @@ class RY(_Rn_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, theta, trainable)
         self.name = "ry"
-        self.label = "ry"
+        self.draw_label = "RY"
+        self.qasm_label = "ry"
         self._controlled_gate = CRY
 
     def generator_eigenvalue(self):
@@ -529,7 +487,8 @@ class RZ(_Rn_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, theta, trainable)
         self.name = "rz"
-        self.label = "rz"
+        self.draw_label = "RZ"
+        self.qasm_label = "rz"
         self._controlled_gate = CRZ
 
     def generator_eigenvalue(self):
@@ -558,7 +517,7 @@ class GPI(ParametrizedGate):
     def __init__(self, q, phi, trainable=True):
         super().__init__(trainable)
         self.name = "gpi"
-        self.label = "gpi"
+        self.draw_label = "GPI"
         self.target_qubits = (q,)
 
         self.parameter_names = "phi"
@@ -590,8 +549,8 @@ class GPI2(ParametrizedGate):
 
     def __init__(self, q, phi, trainable=True):
         super().__init__(trainable)
-        self.name = "gpi"
-        self.label = "gpi"
+        self.name = "gpi2"
+        self.draw_label = "GPI2"
         self.target_qubits = (q,)
 
         self.parameter_names = "phi"
@@ -619,7 +578,6 @@ class _Un_(ParametrizedGate):
     def __init__(self, q, trainable=True):
         super().__init__(trainable)
         self.name = None
-        self.label = None
         self._controlled_gate = None
         self.nparams = 0
         self.target_qubits = (q,)
@@ -660,7 +618,8 @@ class U1(_Un_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, trainable=trainable)
         self.name = "u1"
-        self.label = "u1"
+        self.draw_label = "U1"
+        self.qasm_label = "u1"
         self._controlled_gate = CU1
         self.nparams = 1
         self.parameters = theta
@@ -695,7 +654,8 @@ class U2(_Un_):
     def __init__(self, q, phi, lam, trainable=True):
         super().__init__(q, trainable=trainable)
         self.name = "u2"
-        self.label = "u2"
+        self.draw_label = "U2"
+        self.qasm_label = "u2"
         self._controlled_gate = CU2
         self.nparams = 2
         self._phi, self._lam = None, None
@@ -734,7 +694,8 @@ class U3(_Un_):
     def __init__(self, q, theta, phi, lam, trainable=True):
         super().__init__(q, trainable=trainable)
         self.name = "u3"
-        self.label = "u3"
+        self.draw_label = "U3"
+        self.qasm_label = "u3"
         self._controlled_gate = CU3
         self.nparams = 3
         self._theta, self._phi, self._lam = None, None, None
@@ -774,7 +735,8 @@ class CNOT(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "cx"
-        self.label = "cx"
+        self.draw_label = "X"
+        self.qasm_label = "cx"
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
@@ -805,7 +767,8 @@ class CZ(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "cz"
-        self.label = "cz"
+        self.draw_label = "Z"
+        self.qasm_label = "cz"
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
@@ -826,7 +789,6 @@ class _CRn_(ParametrizedGate):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(trainable)
         self.name = None
-        self.label = None
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.parameters = theta
@@ -867,7 +829,8 @@ class CRX(_CRn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "crx"
-        self.label = "crx"
+        self.draw_label = "RX"
+        self.qasm_label = "crx"
 
 
 class CRY(_CRn_):
@@ -897,7 +860,8 @@ class CRY(_CRn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "cry"
-        self.label = "cry"
+        self.draw_label = "RY"
+        self.qasm_label = "cry"
 
 
 class CRZ(_CRn_):
@@ -925,7 +889,8 @@ class CRZ(_CRn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "crz"
-        self.label = "crz"
+        self.draw_label = "RZ"
+        self.qasm_label = "crz"
 
 
 class _CUn_(ParametrizedGate):
@@ -942,7 +907,6 @@ class _CUn_(ParametrizedGate):
     def __init__(self, q0, q1, trainable=True):
         super().__init__(trainable)
         self.name = None
-        self.label = None
         self.nparams = 0
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
@@ -977,7 +941,8 @@ class CU1(_CUn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu1"
-        self.label = "cu1"
+        self.draw_label = "U1"
+        self.qasm_label = "cu1"
         self.nparams = 1
         self.parameters = theta
         self.init_kwargs = {"theta": theta, "trainable": trainable}
@@ -1017,7 +982,7 @@ class CU2(_CUn_):
     def __init__(self, q0, q1, phi, lam, trainable=True):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu2"
-        self.label = "cu2"
+        self.draw_label = "U2"
         self.nparams = 2
         self.init_kwargs = {"phi": phi, "lam": lam, "trainable": trainable}
 
@@ -1060,7 +1025,8 @@ class CU3(_CUn_):
     def __init__(self, q0, q1, theta, phi, lam, trainable=True):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu3"
-        self.label = "cu3"
+        self.draw_label = "U3"
+        self.qasm_label = "cu3"
         self.nparams = 3
         self._theta, self._phi, self._lam = None, None, None
         self.init_kwargs = {
@@ -1101,7 +1067,8 @@ class SWAP(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "swap"
-        self.label = "swap"
+        self.draw_label = "x"
+        self.qasm_label = "swap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
 
@@ -1127,7 +1094,8 @@ class iSWAP(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "iswap"
-        self.label = "iswap"
+        self.draw_label = "i"
+        self.qasm_label = "iswap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
 
@@ -1153,7 +1121,8 @@ class FSWAP(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "fswap"
-        self.label = "fswap"
+        self.draw_label = "fx"
+        self.qasm_label = "fswap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
 
@@ -1186,7 +1155,7 @@ class fSim(ParametrizedGate):
     def __init__(self, q0, q1, theta, phi, trainable=True):
         super().__init__(trainable)
         self.name = "fsim"
-        self.label = "fsim"
+        self.draw_label = "f"
         self.target_qubits = (q0, q1)
 
         self.parameter_names = ["theta", "phi"]
@@ -1229,7 +1198,7 @@ class GeneralizedfSim(ParametrizedGate):
     def __init__(self, q0, q1, unitary, phi, trainable=True):
         super().__init__(trainable)
         self.name = "generalizedfsim"
-        self.label = "generalizedfsim"
+        self.draw_label = "gf"
         self.target_qubits = (q0, q1)
 
         self.parameter_names = ["unitary", "phi"]
@@ -1275,7 +1244,6 @@ class _Rnn_(ParametrizedGate):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(trainable)
         self.name = None
-        self.label = None
         self._controlled_gate = None
         self.target_qubits = (q0, q1)
 
@@ -1314,7 +1282,8 @@ class RXX(_Rnn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "rxx"
-        self.label = "rxx"
+        self.draw_label = "RXX"
+        self.qasm_label = "rxx"
 
 
 class RYY(_Rnn_):
@@ -1341,7 +1310,8 @@ class RYY(_Rnn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "ryy"
-        self.label = "ryy"
+        self.draw_label = "RYY"
+        self.qasm_label = "ryy"
 
 
 class RZZ(_Rnn_):
@@ -1369,7 +1339,8 @@ class RZZ(_Rnn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "rzz"
-        self.label = "rzz"
+        self.draw_label = "RZZ"
+        self.qasm_label = "rzz"
 
 
 class MS(ParametrizedGate):
@@ -1400,7 +1371,7 @@ class MS(ParametrizedGate):
     def __init__(self, q0, q1, phi0, phi1, trainable=True):
         super().__init__(trainable)
         self.name = "ms"
-        self.label = "ms"
+        self.draw_label = "MS"
         self.target_qubits = (q0, q1)
 
         self.parameter_names = ["phi0", "phi1"]
@@ -1429,7 +1400,8 @@ class TOFFOLI(Gate):
     def __init__(self, q0, q1, q2):
         super().__init__()
         self.name = "ccx"
-        self.label = "ccx"
+        self.draw_label = "X"
+        self.qasm_label = "ccx"
         self.control_qubits = (q0, q1)
         self.target_qubits = (q2,)
         self.init_args = [q0, q1, q2]
@@ -1491,7 +1463,7 @@ class Unitary(ParametrizedGate):
     def __init__(self, unitary, *q, trainable=True, name=None):
         super().__init__(trainable)
         self.name = "Unitary" if name is None else name
-        self.label = self.name
+        self.draw_label = "U"
         self.target_qubits = tuple(q)
 
         # TODO: Check that given ``unitary`` has proper shape?

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -4,26 +4,6 @@ from typing import List
 from qibo.config import raise_error
 from qibo.gates.abstract import Gate, ParametrizedGate
 
-PARAMETRIZED_GATES = {
-    "rx",
-    "ry",
-    "rz",
-    "gpi",
-    "gpi2",
-    "rxx",
-    "ryy",
-    "rzz",
-    "ms",
-    "u1",
-    "u2",
-    "u3",
-    "crx",
-    "cry",
-    "crz",
-    "cu1",
-    "cu3",
-}
-
 
 class H(Gate):
     """The Hadamard gate.

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -119,6 +119,7 @@ class H(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "h"
+        self.label = "h"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -133,6 +134,7 @@ class X(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "x"
+        self.label = "x"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -231,6 +233,7 @@ class Y(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "y"
+        self.label = "y"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -251,6 +254,7 @@ class Z(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "z"
+        self.label = "z"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -285,6 +289,7 @@ class S(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "s"
+        self.label = "s"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -310,6 +315,7 @@ class SDG(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "sdg"
+        self.label = "sdg"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -335,6 +341,7 @@ class T(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "t"
+        self.label = "t"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -360,6 +367,7 @@ class TDG(Gate):
     def __init__(self, q):
         super().__init__()
         self.name = "tdg"
+        self.label = "tdg"
         self.target_qubits = (q,)
         self.init_args = [q]
 
@@ -377,6 +385,7 @@ class I(ParametrizedGate):
     def __init__(self, *q):
         super().__init__()
         self.name = "id"
+        self.label = "id"
         self.target_qubits = tuple(q)
         self.init_args = q
         # save the number of target qubits as parameter
@@ -388,6 +397,7 @@ class Align(ParametrizedGate):
     def __init__(self, *q):
         super().__init__()
         self.name = "align"
+        self.label = "align"
         self.target_qubits = tuple(q)
         self.init_args = q
         # save the number of target qubits as parameter
@@ -409,6 +419,7 @@ class _Rn_(ParametrizedGate):
     def __init__(self, q, theta, trainable=True):
         super().__init__(trainable)
         self.name = None
+        self.label = None
         self._controlled_gate = None
         self.target_qubits = (q,)
 
@@ -458,6 +469,7 @@ class RX(_Rn_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, theta, trainable)
         self.name = "rx"
+        self.label = "rx"
         self._controlled_gate = CRX
 
     def generator_eigenvalue(self):
@@ -488,6 +500,7 @@ class RY(_Rn_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, theta, trainable)
         self.name = "ry"
+        self.label = "ry"
         self._controlled_gate = CRY
 
     def generator_eigenvalue(self):
@@ -516,6 +529,7 @@ class RZ(_Rn_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, theta, trainable)
         self.name = "rz"
+        self.label = "rz"
         self._controlled_gate = CRZ
 
     def generator_eigenvalue(self):
@@ -544,6 +558,7 @@ class GPI(ParametrizedGate):
     def __init__(self, q, phi, trainable=True):
         super().__init__(trainable)
         self.name = "gpi"
+        self.label = "gpi"
         self.target_qubits = (q,)
 
         self.parameter_names = "phi"
@@ -576,6 +591,7 @@ class GPI2(ParametrizedGate):
     def __init__(self, q, phi, trainable=True):
         super().__init__(trainable)
         self.name = "gpi"
+        self.label = "gpi"
         self.target_qubits = (q,)
 
         self.parameter_names = "phi"
@@ -603,6 +619,7 @@ class _Un_(ParametrizedGate):
     def __init__(self, q, trainable=True):
         super().__init__(trainable)
         self.name = None
+        self.label = None
         self._controlled_gate = None
         self.nparams = 0
         self.target_qubits = (q,)
@@ -643,6 +660,7 @@ class U1(_Un_):
     def __init__(self, q, theta, trainable=True):
         super().__init__(q, trainable=trainable)
         self.name = "u1"
+        self.label = "u1"
         self._controlled_gate = CU1
         self.nparams = 1
         self.parameters = theta
@@ -677,6 +695,7 @@ class U2(_Un_):
     def __init__(self, q, phi, lam, trainable=True):
         super().__init__(q, trainable=trainable)
         self.name = "u2"
+        self.label = "u2"
         self._controlled_gate = CU2
         self.nparams = 2
         self._phi, self._lam = None, None
@@ -715,6 +734,7 @@ class U3(_Un_):
     def __init__(self, q, theta, phi, lam, trainable=True):
         super().__init__(q, trainable=trainable)
         self.name = "u3"
+        self.label = "u3"
         self._controlled_gate = CU3
         self.nparams = 3
         self._theta, self._phi, self._lam = None, None, None
@@ -754,6 +774,7 @@ class CNOT(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "cx"
+        self.label = "cx"
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
@@ -784,6 +805,7 @@ class CZ(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "cz"
+        self.label = "cz"
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
@@ -804,6 +826,7 @@ class _CRn_(ParametrizedGate):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(trainable)
         self.name = None
+        self.label = None
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.parameters = theta
@@ -844,6 +867,7 @@ class CRX(_CRn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "crx"
+        self.label = "crx"
 
 
 class CRY(_CRn_):
@@ -873,6 +897,7 @@ class CRY(_CRn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "cry"
+        self.label = "cry"
 
 
 class CRZ(_CRn_):
@@ -900,6 +925,7 @@ class CRZ(_CRn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "crz"
+        self.label = "crz"
 
 
 class _CUn_(ParametrizedGate):
@@ -916,6 +942,7 @@ class _CUn_(ParametrizedGate):
     def __init__(self, q0, q1, trainable=True):
         super().__init__(trainable)
         self.name = None
+        self.label = None
         self.nparams = 0
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
@@ -950,6 +977,7 @@ class CU1(_CUn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu1"
+        self.label = "cu1"
         self.nparams = 1
         self.parameters = theta
         self.init_kwargs = {"theta": theta, "trainable": trainable}
@@ -989,6 +1017,7 @@ class CU2(_CUn_):
     def __init__(self, q0, q1, phi, lam, trainable=True):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu2"
+        self.label = "cu2"
         self.nparams = 2
         self.init_kwargs = {"phi": phi, "lam": lam, "trainable": trainable}
 
@@ -1031,6 +1060,7 @@ class CU3(_CUn_):
     def __init__(self, q0, q1, theta, phi, lam, trainable=True):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu3"
+        self.label = "cu3"
         self.nparams = 3
         self._theta, self._phi, self._lam = None, None, None
         self.init_kwargs = {
@@ -1071,6 +1101,7 @@ class SWAP(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "swap"
+        self.label = "swap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
 
@@ -1096,6 +1127,7 @@ class iSWAP(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "iswap"
+        self.label = "iswap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
 
@@ -1121,6 +1153,7 @@ class FSWAP(Gate):
     def __init__(self, q0, q1):
         super().__init__()
         self.name = "fswap"
+        self.label = "fswap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
 
@@ -1153,6 +1186,7 @@ class fSim(ParametrizedGate):
     def __init__(self, q0, q1, theta, phi, trainable=True):
         super().__init__(trainable)
         self.name = "fsim"
+        self.label = "fsim"
         self.target_qubits = (q0, q1)
 
         self.parameter_names = ["theta", "phi"]
@@ -1195,6 +1229,7 @@ class GeneralizedfSim(ParametrizedGate):
     def __init__(self, q0, q1, unitary, phi, trainable=True):
         super().__init__(trainable)
         self.name = "generalizedfsim"
+        self.label = "generalizedfsim"
         self.target_qubits = (q0, q1)
 
         self.parameter_names = ["unitary", "phi"]
@@ -1240,6 +1275,7 @@ class _Rnn_(ParametrizedGate):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(trainable)
         self.name = None
+        self.label = None
         self._controlled_gate = None
         self.target_qubits = (q0, q1)
 
@@ -1278,6 +1314,7 @@ class RXX(_Rnn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "rxx"
+        self.label = "rxx"
 
 
 class RYY(_Rnn_):
@@ -1304,6 +1341,7 @@ class RYY(_Rnn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "ryy"
+        self.label = "ryy"
 
 
 class RZZ(_Rnn_):
@@ -1331,6 +1369,7 @@ class RZZ(_Rnn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super().__init__(q0, q1, theta, trainable)
         self.name = "rzz"
+        self.label = "rzz"
 
 
 class MS(ParametrizedGate):
@@ -1361,6 +1400,7 @@ class MS(ParametrizedGate):
     def __init__(self, q0, q1, phi0, phi1, trainable=True):
         super().__init__(trainable)
         self.name = "ms"
+        self.label = "ms"
         self.target_qubits = (q0, q1)
 
         self.parameter_names = ["phi0", "phi1"]
@@ -1389,6 +1429,7 @@ class TOFFOLI(Gate):
     def __init__(self, q0, q1, q2):
         super().__init__()
         self.name = "ccx"
+        self.label = "ccx"
         self.control_qubits = (q0, q1)
         self.target_qubits = (q2,)
         self.init_args = [q0, q1, q2]
@@ -1450,6 +1491,7 @@ class Unitary(ParametrizedGate):
     def __init__(self, unitary, *q, trainable=True, name=None):
         super().__init__(trainable)
         self.name = "Unitary" if name is None else name
+        self.label = self.name
         self.target_qubits = tuple(q)
 
         # TODO: Check that given ``unitary`` has proper shape?

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -68,9 +68,12 @@ class H(Gate):
         super().__init__()
         self.name = "h"
         self.draw_label = "H"
-        self.qasm_label = "h"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "h"
 
 
 class X(Gate):
@@ -84,9 +87,12 @@ class X(Gate):
         super().__init__()
         self.name = "x"
         self.draw_label = "X"
-        self.qasm_label = "x"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "x"
 
     @Gate.check_controls
     def controlled_by(self, *q):
@@ -184,9 +190,12 @@ class Y(Gate):
         super().__init__()
         self.name = "y"
         self.draw_label = "Y"
-        self.qasm_label = "y"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "y"
 
     def basis_rotation(self):
         from qibo import matrices
@@ -206,9 +215,12 @@ class Z(Gate):
         super().__init__()
         self.name = "z"
         self.draw_label = "Z"
-        self.qasm_label = "z"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "z"
 
     @Gate.check_controls
     def controlled_by(self, *q):
@@ -242,9 +254,12 @@ class S(Gate):
         super().__init__()
         self.name = "s"
         self.draw_label = "S"
-        self.qasm_label = "s"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "s"
 
     def _dagger(self):
         return SDG(*self.init_args)
@@ -269,9 +284,12 @@ class SDG(Gate):
         super().__init__()
         self.name = "sdg"
         self.draw_label = "SDG"
-        self.qasm_label = "sdg"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "sdg"
 
     def _dagger(self):
         return S(*self.init_args)
@@ -296,9 +314,12 @@ class T(Gate):
         super().__init__()
         self.name = "t"
         self.draw_label = "T"
-        self.qasm_label = "t"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "t"
 
     def _dagger(self):
         return TDG(*self.init_args)
@@ -323,9 +344,12 @@ class TDG(Gate):
         super().__init__()
         self.name = "tdg"
         self.draw_label = "TDG"
-        self.qasm_label = "tdg"
         self.target_qubits = (q,)
         self.init_args = [q]
+
+    @property
+    def qasm_label(self):
+        return "tdg"
 
     def _dagger(self):
         return T(*self.init_args)
@@ -342,12 +366,15 @@ class I(ParametrizedGate):
         super().__init__()
         self.name = "id"
         self.draw_label = "I"
-        self.qasm_label = "id"
         self.target_qubits = tuple(q)
         self.init_args = q
         # save the number of target qubits as parameter
         # for proper identity matrix construction
         self.parameters = 2 ** len(self.target_qubits)
+
+    @property
+    def qasm_label(self):
+        return "id"
 
 
 class Align(ParametrizedGate):
@@ -426,8 +453,11 @@ class RX(_Rn_):
         super().__init__(q, theta, trainable)
         self.name = "rx"
         self.draw_label = "RX"
-        self.qasm_label = "rx"
         self._controlled_gate = CRX
+
+    @property
+    def qasm_label(self):
+        return "rx"
 
     def generator_eigenvalue(self):
         return 0.5
@@ -458,8 +488,11 @@ class RY(_Rn_):
         super().__init__(q, theta, trainable)
         self.name = "ry"
         self.draw_label = "RY"
-        self.qasm_label = "ry"
         self._controlled_gate = CRY
+
+    @property
+    def qasm_label(self):
+        return "ry"
 
     def generator_eigenvalue(self):
         return 0.5
@@ -488,8 +521,11 @@ class RZ(_Rn_):
         super().__init__(q, theta, trainable)
         self.name = "rz"
         self.draw_label = "RZ"
-        self.qasm_label = "rz"
         self._controlled_gate = CRZ
+
+    @property
+    def qasm_label(self):
+        return "rz"
 
     def generator_eigenvalue(self):
         return 0.5
@@ -619,11 +655,14 @@ class U1(_Un_):
         super().__init__(q, trainable=trainable)
         self.name = "u1"
         self.draw_label = "U1"
-        self.qasm_label = "u1"
         self._controlled_gate = CU1
         self.nparams = 1
         self.parameters = theta
         self.init_kwargs = {"theta": theta, "trainable": trainable}
+
+    @property
+    def qasm_label(self):
+        return "u1"
 
     def _dagger(self) -> "Gate":
         theta = -self.parameters[0]
@@ -655,13 +694,16 @@ class U2(_Un_):
         super().__init__(q, trainable=trainable)
         self.name = "u2"
         self.draw_label = "U2"
-        self.qasm_label = "u2"
         self._controlled_gate = CU2
         self.nparams = 2
         self._phi, self._lam = None, None
         self.init_kwargs = {"phi": phi, "lam": lam, "trainable": trainable}
         self.parameter_names = ["phi", "lam"]
         self.parameters = phi, lam
+
+    @property
+    def qasm_label(self):
+        return "u2"
 
     def _dagger(self) -> "Gate":
         """"""
@@ -695,7 +737,6 @@ class U3(_Un_):
         super().__init__(q, trainable=trainable)
         self.name = "u3"
         self.draw_label = "U3"
-        self.qasm_label = "u3"
         self._controlled_gate = CU3
         self.nparams = 3
         self._theta, self._phi, self._lam = None, None, None
@@ -707,6 +748,10 @@ class U3(_Un_):
         }
         self.parameter_names = ["theta", "phi", "lam"]
         self.parameters = theta, phi, lam
+
+    @property
+    def qasm_label(self):
+        return "u3"
 
     def _dagger(self) -> "Gate":
         """"""
@@ -736,10 +781,13 @@ class CNOT(Gate):
         super().__init__()
         self.name = "cx"
         self.draw_label = "X"
-        self.qasm_label = "cx"
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
+
+    @property
+    def qasm_label(self):
+        return "cx"
 
     def decompose(self, *free, use_toffolis: bool = True) -> List[Gate]:
         q0, q1 = self.control_qubits[0], self.target_qubits[0]
@@ -768,10 +816,13 @@ class CZ(Gate):
         super().__init__()
         self.name = "cz"
         self.draw_label = "Z"
-        self.qasm_label = "cz"
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
+
+    @property
+    def qasm_label(self):
+        return "cz"
 
 
 class _CRn_(ParametrizedGate):
@@ -830,7 +881,10 @@ class CRX(_CRn_):
         super().__init__(q0, q1, theta, trainable)
         self.name = "crx"
         self.draw_label = "RX"
-        self.qasm_label = "crx"
+
+    @property
+    def qasm_label(self):
+        return "crx"
 
 
 class CRY(_CRn_):
@@ -861,7 +915,10 @@ class CRY(_CRn_):
         super().__init__(q0, q1, theta, trainable)
         self.name = "cry"
         self.draw_label = "RY"
-        self.qasm_label = "cry"
+
+    @property
+    def qasm_label(self):
+        return "cry"
 
 
 class CRZ(_CRn_):
@@ -890,7 +947,10 @@ class CRZ(_CRn_):
         super().__init__(q0, q1, theta, trainable)
         self.name = "crz"
         self.draw_label = "RZ"
-        self.qasm_label = "crz"
+
+    @property
+    def qasm_label(self):
+        return "crz"
 
 
 class _CUn_(ParametrizedGate):
@@ -942,10 +1002,13 @@ class CU1(_CUn_):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu1"
         self.draw_label = "U1"
-        self.qasm_label = "cu1"
         self.nparams = 1
         self.parameters = theta
         self.init_kwargs = {"theta": theta, "trainable": trainable}
+
+    @property
+    def qasm_label(self):
+        return "cu1"
 
     def _dagger(self) -> "Gate":
         """"""
@@ -1026,7 +1089,6 @@ class CU3(_CUn_):
         super().__init__(q0, q1, trainable=trainable)
         self.name = "cu3"
         self.draw_label = "U3"
-        self.qasm_label = "cu3"
         self.nparams = 3
         self._theta, self._phi, self._lam = None, None, None
         self.init_kwargs = {
@@ -1037,6 +1099,10 @@ class CU3(_CUn_):
         }
         self.parameter_names = ["theta", "phi", "lam"]
         self.parameters = theta, phi, lam
+
+    @property
+    def qasm_label(self):
+        return "cu3"
 
     def _dagger(self) -> "Gate":
         """"""
@@ -1068,9 +1134,12 @@ class SWAP(Gate):
         super().__init__()
         self.name = "swap"
         self.draw_label = "x"
-        self.qasm_label = "swap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
+
+    @property
+    def qasm_label(self):
+        return "swap"
 
 
 class iSWAP(Gate):
@@ -1095,9 +1164,12 @@ class iSWAP(Gate):
         super().__init__()
         self.name = "iswap"
         self.draw_label = "i"
-        self.qasm_label = "iswap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
+
+    @property
+    def qasm_label(self):
+        return "iswap"
 
 
 class FSWAP(Gate):
@@ -1122,9 +1194,12 @@ class FSWAP(Gate):
         super().__init__()
         self.name = "fswap"
         self.draw_label = "fx"
-        self.qasm_label = "fswap"
         self.target_qubits = (q0, q1)
         self.init_args = [q0, q1]
+
+    @property
+    def qasm_label(self):
+        return "fswap"
 
 
 class fSim(ParametrizedGate):
@@ -1283,7 +1358,10 @@ class RXX(_Rnn_):
         super().__init__(q0, q1, theta, trainable)
         self.name = "rxx"
         self.draw_label = "RXX"
-        self.qasm_label = "rxx"
+
+    @property
+    def qasm_label(self):
+        return "rxx"
 
 
 class RYY(_Rnn_):
@@ -1311,7 +1389,10 @@ class RYY(_Rnn_):
         super().__init__(q0, q1, theta, trainable)
         self.name = "ryy"
         self.draw_label = "RYY"
-        self.qasm_label = "ryy"
+
+    @property
+    def qasm_label(self):
+        return "ryy"
 
 
 class RZZ(_Rnn_):
@@ -1340,7 +1421,10 @@ class RZZ(_Rnn_):
         super().__init__(q0, q1, theta, trainable)
         self.name = "rzz"
         self.draw_label = "RZZ"
-        self.qasm_label = "rzz"
+
+    @property
+    def qasm_label(self):
+        return "rzz"
 
 
 class MS(ParametrizedGate):
@@ -1401,10 +1485,13 @@ class TOFFOLI(Gate):
         super().__init__()
         self.name = "ccx"
         self.draw_label = "X"
-        self.qasm_label = "ccx"
         self.control_qubits = (q0, q1)
         self.target_qubits = (q2,)
         self.init_args = [q0, q1, q2]
+
+    @property
+    def qasm_label(self):
+        return "ccx"
 
     def decompose(self, *free, use_toffolis: bool = True) -> List[Gate]:
         c0, c1 = self.control_qubits

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -4,38 +4,6 @@ from typing import List
 from qibo.config import raise_error
 from qibo.gates.abstract import Gate, ParametrizedGate
 
-# TODO: Make these dictionaries gate properties
-QASM_GATES = {
-    "h": "H",
-    "x": "X",
-    "y": "Y",
-    "z": "Z",
-    "rx": "RX",
-    "ry": "RY",
-    "rz": "RZ",
-    "u1": "U1",
-    "u2": "U2",
-    "u3": "U3",
-    "cx": "CNOT",
-    "swap": "SWAP",
-    "iswap": "iSWAP",
-    "fswap": "FSWAP",
-    "rxx": "RXX",
-    "ryy": "RYY",
-    "rzz": "RZZ",
-    "cz": "CZ",
-    "crx": "CRX",
-    "cry": "CRY",
-    "crz": "CRZ",
-    "cu1": "CU1",
-    "cu3": "CU3",
-    "ccx": "TOFFOLI",
-    "id": "I",
-    "s": "S",
-    "sdg": "SDG",
-    "t": "T",
-    "tdg": "TDG",
-}
 PARAMETRIZED_GATES = {
     "rx",
     "ry",

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, List, Optional, Tuple
+from typing import List
 
 from qibo.config import raise_error
 from qibo.gates.abstract import Gate, ParametrizedGate
@@ -169,7 +169,7 @@ class X(Gate):
             # impractical case
             raise_error(
                 NotImplementedError,
-                "X decomposition not implemented " "for zero free qubits.",
+                "X decomposition not implemented for zero free qubits.",
             )
 
         decomp_gates.extend(decomp_gates)
@@ -719,8 +719,10 @@ class U3(_Un_):
 
     .. math::
         \\begin{pmatrix}
-        e^{-i(\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) & -e^{-i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) \\\\
-        e^{i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) & e^{i (\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) \\\\
+        e^{-i(\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) &
+            -e^{-i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) \\\\
+        e^{i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) &
+            e^{i (\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) \\\\
         \\end{pmatrix}
 
     Args:
@@ -1070,8 +1072,10 @@ class CU3(_CUn_):
         \\begin{pmatrix}
         1 & 0 & 0 & 0 \\\\
         0 & 1 & 0 & 0 \\\\
-        0 & 0 & e^{-i(\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) & -e^{-i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) \\\\
-        0 & 0 & e^{i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) & e^{i (\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) \\\\
+        0 & 0 & e^{-i(\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) &
+            -e^{-i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) \\\\
+        0 & 0 & e^{i(\\phi - \\lambda )/2}\\sin\\left (\\frac{\\theta }{2}\\right ) &
+            e^{i (\\phi + \\lambda )/2}\\cos\\left (\\frac{\\theta }{2}\\right ) \\\\
         \\end{pmatrix}
 
     Args:
@@ -1517,8 +1521,6 @@ class TOFFOLI(Gate):
         """
         if use_toffolis:
             return self.decompose()
-
-        import importlib
 
         control0, control1 = self.control_qubits
         target = self.target_qubits[0]

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -70,7 +70,7 @@ class M(Gate):
             if p0 is not None or p1 is not None:
                 raise_error(
                     NotImplementedError,
-                    "Bitflip measurement noise is not " "available when collapsing.",
+                    "Bitflip measurement noise is not available when collapsing.",
                 )
 
         if p1 is None:
@@ -99,18 +99,15 @@ class M(Gate):
     def _get_bitflip_tuple(qubits: Tuple[int], probs: "ProbsType") -> Tuple[float]:
         if isinstance(probs, float):
             if probs < 0 or probs > 1:  # pragma: no cover
-                raise_error(
-                    ValueError, "Invalid bitflip probability {}." "".format(probs)
-                )
+                raise_error(ValueError, f"Invalid bitflip probability {probs}.")
             return len(qubits) * (probs,)
 
         if isinstance(probs, (tuple, list)):
             if len(probs) != len(qubits):
                 raise_error(
                     ValueError,
-                    "{} qubits were measured but the given "
-                    "bitflip probability list contains {} "
-                    "values.".format(len(qubits), len(probs)),
+                    f"{len(qubits)} qubits were measured but the given "
+                    + f"bitflip probability list contains {len(probs)} values.",
                 )
             return tuple(probs)
 
@@ -119,8 +116,7 @@ class M(Gate):
             if diff:
                 raise_error(
                     KeyError,
-                    "Bitflip map contains {} qubits that are "
-                    "not measured.".format(diff),
+                    f"Bitflip map contains {diff} qubits that are not measured.",
                 )
             return tuple(probs[q] if q in probs else 0.0 for q in qubits)
 
@@ -131,7 +127,7 @@ class M(Gate):
         if p is None:
             return {q: 0 for q in self.qubits}
         pt = self._get_bitflip_tuple(self.qubits, p)
-        return {q: p for q, p in zip(self.qubits, pt)}
+        return dict(zip(self.qubits, pt))
 
     def has_bitflip_noise(self):
         return (

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -50,7 +50,7 @@ class M(Gate):
     ):
         super().__init__()
         self.name = "measure"
-        self.label = "measure"
+        self.draw_label = "M"
         self.target_qubits = tuple(q)
         self.register_name = register_name
         self.collapse = collapse

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -50,6 +50,7 @@ class M(Gate):
     ):
         super().__init__()
         self.name = "measure"
+        self.label = "measure"
         self.target_qubits = tuple(q)
         self.register_name = register_name
         self.collapse = collapse

--- a/src/qibo/gates/special.py
+++ b/src/qibo/gates/special.py
@@ -15,6 +15,7 @@ class CallbackGate(SpecialGate):
     def __init__(self, callback: "Callback"):
         super().__init__()
         self.name = callback.__class__.__name__
+        self.label = callback.__class__.__name__
         self.callback = callback
         self.init_args = [callback]
 
@@ -39,6 +40,7 @@ class FusedGate(SpecialGate):
     def __init__(self, *q):
         super().__init__()
         self.name = "Fused Gate"
+        self.label = "Fused Gate"
         self.target_qubits = tuple(sorted(q))
         self.init_args = list(q)
         self.qubit_set = set(q)

--- a/src/qibo/gates/special.py
+++ b/src/qibo/gates/special.py
@@ -15,7 +15,7 @@ class CallbackGate(SpecialGate):
     def __init__(self, callback: "Callback"):
         super().__init__()
         self.name = callback.__class__.__name__
-        self.label = callback.__class__.__name__
+        self.draw_label = "".join([c for c in self.name if c.isupper()])
         self.callback = callback
         self.init_args = [callback]
 
@@ -40,7 +40,7 @@ class FusedGate(SpecialGate):
     def __init__(self, *q):
         super().__init__()
         self.name = "Fused Gate"
-        self.label = "Fused Gate"
+        self.draw_label = "[]"
         self.target_qubits = tuple(sorted(q))
         self.init_args = list(q)
         self.qubit_set = set(q)

--- a/src/qibo/gates/special.py
+++ b/src/qibo/gates/special.py
@@ -1,5 +1,4 @@
-from qibo.config import raise_error
-from qibo.gates.abstract import Gate, ParametrizedGate, SpecialGate
+from qibo.gates.abstract import SpecialGate
 from qibo.gates.measurements import M
 
 

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -133,12 +133,12 @@ class Circuit:
         if not isinstance(nqubits, int):
             raise_error(
                 TypeError,
-                "Number of qubits must be an integer but " "is {}.".format(nqubits),
+                f"Number of qubits must be an integer but is {nqubits}.",
             )
         if nqubits < 1:
             raise_error(
                 ValueError,
-                "Number of qubits must be positive but is " "{}.".format(nqubits),
+                f"Number of qubits must be positive but is {nqubits}.",
             )
         self.nqubits = nqubits
         self.init_kwargs = {
@@ -168,7 +168,7 @@ class Circuit:
             if density_matrix:
                 raise_error(
                     NotImplementedError,
-                    "Distributed circuit is not implemented " "for density matrices.",
+                    "Distributed circuit is not implemented for density matrices.",
                 )
             self._distributed_init(nqubits, accelerators)
 
@@ -209,7 +209,7 @@ class Circuit:
             raise_error(
                 ValueError,
                 "Number of calculation devices should be a power "
-                "of 2 but is {}.".format(self.ndevices),
+                + f"of 2 but is {self.ndevices}.",
             )
         self.nglobal = int(self.nglobal)
         self.nlocal = self.nqubits - self.nglobal
@@ -233,8 +233,8 @@ class Circuit:
                 raise_error(
                     ValueError,
                     "Cannot add circuits with different kwargs. "
-                    "{} is {} for first circuit and {} for the "
-                    "second.".format(k, kwarg1, kwarg2),
+                    + f"{k} is {kwarg1} for first circuit and {kwarg2} "
+                    + "for the second.",
                 )
 
         newcircuit = self.__class__(**self.init_kwargs)
@@ -278,15 +278,13 @@ class Circuit:
         if len(qubits) != self.nqubits:
             raise_error(
                 ValueError,
-                "Cannot return gates on {} qubits because "
-                "the circuit contains {} qubits."
-                "".format(len(qubits), self.nqubits),
+                f"Cannot return gates on {len(qubits)} qubits because "
+                + f"the circuit contains {self.nqubits} qubits.",
             )
         if self.accelerators and self.queues.queues:  # pragma: no cover
             raise_error(
                 RuntimeError,
-                "Cannot use distributed circuit as a "
-                "subroutine after it was executed.",
+                "Cannot use distributed circuit as a subroutine after it was executed.",
             )
 
         qubit_map = {i: q for i, q in enumerate(qubits)}
@@ -406,28 +404,26 @@ class Circuit:
                 raise_error(
                     ValueError,
                     "Noise map expects three probabilities "
-                    "but received {}.".format(len(noise_map)),
+                    + f"but received {len(noise_map)}.",
                 )
             return {q: noise_map for q in range(self.nqubits)}
         elif isinstance(noise_map, dict):
             if len(noise_map) != self.nqubits:
                 raise_error(
                     ValueError,
-                    "Noise map has {} qubits while the circuit "
-                    "has {}.".format(len(noise_map), self.nqubits),
+                    f"Noise map has {len(noise_map)} qubits while the circuit has {self.nqubits}.",
                 )
             for v in noise_map.values():
                 if len(v) != 3:
                     raise_error(
                         ValueError,
-                        "Noise map expects three probabilities "
-                        "but received {}.".format(v),
+                        f"Noise map expects three probabilities but received {v}.",
                     )
             return noise_map
 
         raise_error(
             TypeError,
-            "Type {} of noise map is not recognized." "".format(type(noise_map)),
+            f"Type {type(noise_map)} of noise map is not recognized.",
         )
 
     def decompose(self, *free: int):
@@ -558,7 +554,7 @@ class Circuit:
                     )
 
             if not isinstance(gate, gates.Gate):
-                raise_error(TypeError, "Unknown gate type {}.".format(type(gate)))
+                raise_error(TypeError, f"Unknown gate type {type(gate)}.")
 
             if self._final_state is not None:
                 raise_error(
@@ -570,9 +566,8 @@ class Circuit:
                 if q >= self.nqubits:
                     raise_error(
                         ValueError,
-                        "Attempting to add gate with target qubits {} "
-                        "on a circuit of {} qubits."
-                        "".format(gate.target_qubits, self.nqubits),
+                        f"Attempting to add gate with target qubits {gate.target_qubits} "
+                        + f"on a circuit of {self.nqubits} qubits.",
                     )
 
             if isinstance(gate, gates.M):
@@ -658,7 +653,7 @@ class Circuit:
             return [(i, g) for i, g in enumerate(self.queue) if g.name == gate]
         if isinstance(gate, type) and issubclass(gate, gates.Gate):
             return [(i, g) for i, g in enumerate(self.queue) if isinstance(g, gate)]
-        raise_error(TypeError, "Gate identifier {} not recognized.".format(gate))
+        raise_error(TypeError, f"Gate identifier {gate} not recognized.")
 
     def _set_parameters_list(self, parameters, n):
         """Helper method for ``set_parameters`` when a list is given.
@@ -680,9 +675,8 @@ class Circuit:
         else:
             raise_error(
                 ValueError,
-                "Given list of parameters has length {} while "
-                "the circuit contains {} parametrized gates."
-                "".format(n, len(self.trainable_gates)),
+                f"Given list of parameters has length {n} while "
+                + f"the circuit contains {len(self.trainable_gates)} parametrized gates.",
             )
 
     def set_parameters(self, parameters):
@@ -736,9 +730,8 @@ class Circuit:
             if diff:
                 raise_error(
                     KeyError,
-                    "Dictionary contains gates {} which are "
-                    "not on the list of parametrized gates "
-                    "of the circuit.".format(diff),
+                    f"Dictionary contains gates {diff} which are "
+                    + "not on the list of parametrized gates of the circuit.",
                 )
             for gate, params in parameters.items():
                 gate.parameters = params
@@ -751,9 +744,7 @@ class Circuit:
                 nparams = len(parameters)
             self._set_parameters_list(parameters, nparams)
         else:
-            raise_error(
-                TypeError, "Invalid type of parameters {}." "".format(type(parameters))
-            )
+            raise_error(TypeError, f"Invalid type of parameters {type(parameters)}.")
 
     def get_parameters(
         self, format: str = "list", include_not_trainable: bool = False
@@ -803,7 +794,7 @@ class Circuit:
         else:
             raise_error(
                 ValueError,
-                "Unknown format {} given in " "``get_parameters``.".format(format),
+                f"Unknown format {format} given in ``get_parameters``.",
             )
         return params
 
@@ -831,8 +822,8 @@ class Circuit:
         Example:
             .. testcode::
 
-                from qibo.models import Circuit
                 from qibo import gates
+                from qibo.models import Circuit
                 c = Circuit(3)
                 c.add(gates.H(0))
                 c.add(gates.H(1))
@@ -870,7 +861,7 @@ class Circuit:
             "Most common gates:",
         ]
         common_gates = self.gate_names.most_common()
-        logs.extend("{}: {}".format(g, n) for g, n in common_gates)
+        logs.extend(f"{g}: {n}" for g, n in common_gates)
         return "\n".join(logs)
 
     def fuse(self, max_qubits=2):
@@ -889,7 +880,7 @@ class Circuit:
         Example:
             .. testcode::
 
-                from qibo import models, gates
+                from qibo import gates, models
                 c = models.Circuit(2)
                 c.add([gates.H(0), gates.H(1)])
                 c.add(gates.CNOT(0, 1))
@@ -1035,7 +1026,7 @@ class Circuit:
                 raise_error(
                     NameError,
                     "OpenQASM does not support capital letters in "
-                    "register names but {} was used".format(reg_name),
+                    + f"register names but {reg_name} was used",
                 )
             code.append(f"creg {reg_name}[{len(reg_qubits)}];")
 
@@ -1052,7 +1043,7 @@ class Circuit:
             qubits = ",".join(f"q[{i}]" for i in gate.qubits)
             if gate.qasm_label in gates.PARAMETRIZED_GATES:
                 params = (str(x) for x in gate.parameters)
-                name = "{}({})".format(gate.qasm_label, ", ".join(params))
+                name = f"{gate.qasm_label}({', '.join(params)})"
             else:
                 name = gate.qasm_label
             code.append(f"{name} {qubits};")
@@ -1080,7 +1071,7 @@ class Circuit:
 
             .. testcode::
 
-                from qibo import models, gates
+                from qibo import gates, models
                 qasm_code = '''OPENQASM 2.0;
                 include "qelib1.inc";
                 qreg q[2];
@@ -1178,29 +1169,26 @@ class Circuit:
                 if qubit not in qubits:
                     raise_error(
                         ValueError,
-                        "Qubit {} is not defined in QASM code." "".format(qubit),
+                        f"Qubit {qubit} is not defined in QASM code.",
                     )
 
                 register, idx = next(read_args(args[1]))
                 if register not in cregs_size:
                     raise_error(
                         ValueError,
-                        "Classical register name {} is not defined "
-                        "in QASM code.".format(register),
+                        f"Classical register name {register} is not defined in QASM code.",
                     )
                 if idx >= cregs_size[register]:
                     raise_error(
                         ValueError,
-                        "Cannot access index {} of register {} "
-                        "with {} qubits."
-                        "".format(idx, register, cregs_size[register]),
+                        f"Cannot access index {idx} of register {register} "
+                        + f"with {cregs_size[register]} qubits.",
                     )
                 if register in registers:
                     if idx in registers[register]:
                         raise_error(
                             KeyError,
-                            "Key {} of register {} has already "
-                            "been used.".format(idx, register),
+                            f"Key {idx} of register {register} has already been used.",
                         )
                     registers[register][idx] = qubits[qubit]
                 else:
@@ -1214,20 +1202,18 @@ class Circuit:
                     if gatename not in gates.QASM_GATES:
                         raise_error(
                             ValueError,
-                            "QASM command {} is not recognized." "".format(command),
+                            f"QASM command {command} is not recognized.",
                         )
                     if gatename in gates.PARAMETRIZED_GATES:
                         raise_error(
                             ValueError,
-                            "Missing parameters for QASM " "gate {}.".format(gatename),
+                            f"Missing parameters for QASM gate {gatename}.",
                         )
 
                 elif len(pieces) == 2:
                     gatename, params = pieces
                     if gatename not in gates.PARAMETRIZED_GATES:
-                        raise_error(
-                            ValueError, "Invalid QASM command {}." "".format(command)
-                        )
+                        raise_error(ValueError, f"Invalid QASM command {command}.")
                     params = params.replace(" ", "").split(",")
                     try:
                         for i, p in enumerate(params):
@@ -1241,13 +1227,13 @@ class Circuit:
                     except ValueError:
                         raise_error(
                             ValueError,
-                            "Invalid value {} for gate parameters." "".format(params),
+                            f"Invalid value {params} for gate parameters.",
                         )
 
                 else:
                     raise_error(
                         ValueError,
-                        "QASM command {} is not recognized." "".format(command),
+                        f"QASM command {command} is not recognized.",
                     )
 
                 # Add gate to gate list
@@ -1256,7 +1242,7 @@ class Circuit:
                     if qubit not in qubits:
                         raise_error(
                             ValueError,
-                            "Qubit {} is not defined in QASM " "code.".format(qubit),
+                            f"Qubit {qubit} is not defined in QASM code.",
                         )
                     qubit_list.append(qubits[qubit])
                 gate_list.append((gates.QASM_GATES[gatename], list(qubit_list), params))

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1373,14 +1373,14 @@ class Circuit:
         if legend:
             from tabulate import tabulate
 
-            legend_values = {
+            legend_rows = {
                 (i.name, i.draw_label)
                 for i in self.queue
                 if isinstance(i, (gates.SpecialGate, gates.Channel))
             }
 
             table = tabulate(
-                [list(l) for l in legend_values],
+                [list(l) for l in sorted(legend_rows)],
                 headers=["Gate", "Symbol"],
                 tablefmt="orgtbl",
             )

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1272,12 +1272,15 @@ class Circuit:
     def _update_draw_matrix(self, matrix, idx, gate, gate_symbol=None):
         """Helper method for :meth:`qibo.models.circuit.Circuit.draw`."""
         if gate_symbol is None:
-            if gate.name not in gates.DRAW_LABELS:  # pragma: no cover
+            if gate.label is not None and gate.label != gate.name:
+                gate_symbol = gate.label[:4]
+            elif gate.name in gates.DRAW_LABELS:  # pragma: no cover
+                gate_symbol = gates.DRAW_LABELS.get(gate.name)
+            else:
                 raise_error(
                     NotImplementedError,
                     f"{gate.name} gate is not supported by `circuit.draw`",
                 )
-            gate_symbol = gates.DRAW_LABELS.get(gate.name)
 
         if isinstance(gate, gates.CallbackGate):
             targets = list(range(self.nqubits))

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1043,12 +1043,7 @@ class Circuit:
         for gate in self.queue:
             if isinstance(gate, gates.M):
                 continue
-
-            if not hasattr(gate, "qasm_label"):
-                raise_error(
-                    ValueError,
-                    f"Gate {gate.__class__.__name__} is not supported by OpenQASM.",
-                )
+                
             if gate.is_controlled_by:
                 raise_error(
                     ValueError, "OpenQASM does not support multi-controlled gates."
@@ -1278,7 +1273,7 @@ class Circuit:
     def _update_draw_matrix(self, matrix, idx, gate, gate_symbol=None):
         """Helper method for :meth:`qibo.models.circuit.Circuit.draw`."""
         if gate_symbol is None:
-            if hasattr(gate, "draw_label") and gate.draw_label:
+            if gate.draw_label:
                 gate_symbol = gate.draw_label[:4]
             elif gate.name:
                 gate_symbol = gate.name[:4]

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1043,7 +1043,7 @@ class Circuit:
         for gate in self.queue:
             if isinstance(gate, gates.M):
                 continue
-                
+
             if gate.is_controlled_by:
                 raise_error(
                     ValueError, "OpenQASM does not support multi-controlled gates."

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -119,14 +119,18 @@ class Circuit:
         trainable_gates (_ParametrizedGates): List of trainable gates.
         measurements (list): List of non-collapsible measurements
         _final_state (CircuitResult): Final state after full simulation of the circuit
-        compiled (CompiledExecutor): Circuit executor. Defaults to `None`.
-        repeated_execution (bool): If `True`, the circuit would be re-executed when sampling. Defaults to `False`.
-        density_matrix (bool): If `True`, the circuit would evolve density matrices. Defaults to `False`.
-        accelerators (dict): Dictionary that maps device names to the number of times each device will be used. Defaults to `None`.
-        ndevices (int): Total number of devices. Defaults to `None`.
-        nglobal (int): Base two logarithm of the number of devices. Defaults to `None`.
-        nlocal (int): Total number of available qubits in each device. Defaults to `None`.
-        queues (DistributedQueues): Gate queues for each accelerator device. Defaults to `None`.
+        compiled (CompiledExecutor): Circuit executor. Defaults to ``None``.
+        repeated_execution (bool): If `True`, the circuit would be re-executed when sampling.
+            Defaults to ``False``.
+        density_matrix (bool): If `True`, the circuit would evolve density matrices.
+            Defaults to ``False``.
+        accelerators (dict): Dictionary that maps device names to the number of times each
+            device will be used. Defaults to ``None``.
+        ndevices (int): Total number of devices. Defaults to ``None``.
+        nglobal (int): Base two logarithm of the number of devices. Defaults to ``None``.
+        nlocal (int): Total number of available qubits in each device. Defaults to ``None``.
+        queues (DistributedQueues): Gate queues for each accelerator device.
+            Defaults to ``None``.
     """
 
     def __init__(self, nqubits, accelerators=None, density_matrix=False):
@@ -245,7 +249,8 @@ class Circuit:
         for gate in circuit.queue:
             newcircuit.add(gate)
 
-        # Re-execute full circuit when sampling if one of the circuit has repeated_execution ``True``
+        # Re-execute full circuit when sampling if one of the circuits
+        # has repeated_execution ``True``
         newcircuit.repeated_execution = (
             self.repeated_execution or circuit.repeated_execution
         )
@@ -312,21 +317,21 @@ class Circuit:
         # original qubits that are in the light cone
         qubits = set(qubits)
         # original gates that are in the light cone
-        gates = []
+        list_of_gates = []
         for gate in reversed(self.queue):
             gate_qubits = set(gate.qubits)
             if gate_qubits & qubits:
                 # if the gate involves any qubit included in the
                 # light cone, add all its qubits in the light cone
                 qubits |= gate_qubits
-                gates.append(gate)
+                list_of_gates.append(gate)
 
         # Create a new circuit ignoring gates that are not in the light cone
         qubit_map = {q: i for i, q in enumerate(sorted(qubits))}
         kwargs = dict(self.init_kwargs)
         kwargs["nqubits"] = len(qubits)
         circuit = self.__class__(**kwargs)
-        circuit.add(gate.on_qubits(qubit_map) for gate in reversed(gates))
+        circuit.add(gate.on_qubits(qubit_map) for gate in reversed(list_of_gates))
         return circuit, qubit_map
 
     def _shallow_copy(self):
@@ -467,8 +472,8 @@ class Circuit:
         Example:
             .. testcode::
 
-                from qibo.models import Circuit
                 from qibo import gates
+                from qibo.models import Circuit
                 # use density matrices for noise simulation
                 c = Circuit(2, density_matrix=True)
                 c.add([gates.H(0), gates.H(1), gates.CNOT(0, 1)])
@@ -487,7 +492,7 @@ class Circuit:
         if self.accelerators:  # pragma: no cover
             raise_error(
                 NotImplementedError,
-                "Distributed circuit does not support " "density matrices yet.",
+                "Distributed circuit does not support density matrices yet.",
             )
 
         noise_map = self._check_noise_map(noise_map)
@@ -541,7 +546,7 @@ class Circuit:
                 if isinstance(gate, gates.KrausChannel):
                     raise_error(
                         NotImplementedError,
-                        "Distributed circuits do not " "support channels.",
+                        "Distributed circuits do not support channels.",
                     )
                 elif self.nqubits - len(
                     gate.target_qubits
@@ -549,8 +554,7 @@ class Circuit:
                     # Check if there is sufficient number of local qubits
                     raise_error(
                         ValueError,
-                        "Insufficient qubits to use for global in "
-                        "distributed circuit.",
+                        "Insufficient qubits to use for global in distributed circuit.",
                     )
 
             if not isinstance(gate, gates.Gate):
@@ -702,8 +706,8 @@ class Circuit:
         Example:
             .. testcode::
 
-                from qibo.models import Circuit
                 from qibo import gates
+                from qibo.models import Circuit
                 # create a circuit with all parameters set to 0.
                 c = Circuit(3)
                 c.add(gates.RX(0, theta=0))
@@ -893,7 +897,7 @@ class Circuit:
         if self.accelerators:  # pragma: no cover
             raise_error(
                 NotImplementedError,
-                "Fusion is not implemented for " "distributed circuits.",
+                "Fusion is not implemented for distributed circuits.",
             )
 
         queue = self.queue.to_fused()
@@ -919,12 +923,12 @@ class Circuit:
         This is a ``(2 ** nqubits, 2 ** nqubits)`` matrix obtained by
         multiplying all circuit gates.
         """
-        from qibo import gates
 
         if backend is None:
             from qibo.backends import GlobalBackend
 
             backend = GlobalBackend()
+
         fgate = gates.FusedGate(*range(self.nqubits))
         for gate in self.queue:
             if not isinstance(gate, (gates.SpecialGate, gates.M)):
@@ -941,7 +945,7 @@ class Circuit:
         if self._final_state is None:
             raise_error(
                 RuntimeError,
-                "Cannot access final state before the " "circuit is executed.",
+                "Cannot access final state before the circuit is executed.",
             )
         return self._final_state
 
@@ -981,9 +985,10 @@ class Circuit:
         """Executes the circuit. Exact implementation depends on the backend.
 
         Args:
-            initial_state (`np.ndarray` or :class:`qibo.models.circuit.Circuit`): Initial configuration.
-                Can be specified by the setting the state vector using an array or a circuit. If ``None``
-                the initial state is ``|000..00>``.
+            initial_state (`np.ndarray` or :class:`qibo.models.circuit.Circuit`):
+                Initial configuration. It can be specified by the setting the state
+                vector using an array or a circuit. If ``None``, the initial state
+                is ``|000..00>``.
             nshots (int): Number of shots.
         """
         if self.compiled:

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1274,7 +1274,7 @@ class Circuit:
         """Helper method for :meth:`qibo.models.circuit.Circuit.draw`."""
         if gate_symbol is None:
             if gate.draw_label:
-                gate_symbol = gate.draw_label[:4]
+                gate_symbol = gate.draw_label
             elif gate.name:
                 gate_symbol = gate.name[:4]
             else:

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -30,6 +30,7 @@ def test_h(backend):
     final_state = apply_gates(backend, [gates.H(0), gates.H(1)], nqubits=2)
     target_state = np.ones_like(final_state) / 2
     backend.assert_allclose(final_state, target_state)
+    assert gates.H(1).qasm_label == 'h'
 
 
 def test_x(backend):
@@ -37,6 +38,7 @@ def test_x(backend):
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0
     backend.assert_allclose(final_state, target_state)
+    assert gates.X(0).qasm_label == 'x'
 
 
 def test_y(backend):
@@ -44,6 +46,7 @@ def test_y(backend):
     target_state = np.zeros_like(final_state)
     target_state[1] = 1j
     backend.assert_allclose(final_state, target_state)
+    assert gates.Y(1).qasm_label == 'y'
 
 
 def test_z(backend):
@@ -52,12 +55,14 @@ def test_z(backend):
     target_state[2] *= -1.0
     target_state[3] *= -1.0
     backend.assert_allclose(final_state, target_state)
+    assert gates.Z(0).qasm_label == 'z'
 
 
 def test_s(backend):
     final_state = apply_gates(backend, [gates.H(0), gates.H(1), gates.S(1)], nqubits=2)
     target_state = np.array([0.5, 0.5j, 0.5, 0.5j])
     backend.assert_allclose(final_state, target_state)
+    assert gates.S(1).qasm_label == 's'
 
 
 def test_sdg(backend):
@@ -66,12 +71,14 @@ def test_sdg(backend):
     )
     target_state = np.array([0.5, -0.5j, 0.5, -0.5j])
     backend.assert_allclose(final_state, target_state)
+    assert gates.SDG(1).qasm_label == 'sdg'
 
 
 def test_t(backend):
     final_state = apply_gates(backend, [gates.H(0), gates.H(1), gates.T(1)], nqubits=2)
     target_state = np.array([0.5, (1 + 1j) / np.sqrt(8), 0.5, (1 + 1j) / np.sqrt(8)])
     backend.assert_allclose(final_state, target_state)
+    assert gates.T(1).qasm_label == 't'
 
 
 def test_tdg(backend):
@@ -80,6 +87,7 @@ def test_tdg(backend):
     )
     target_state = np.array([0.5, (1 - 1j) / np.sqrt(8), 0.5, (1 - 1j) / np.sqrt(8)])
     backend.assert_allclose(final_state, target_state)
+    assert gates.TDG(1).qasm_label == 'tdg'
 
 
 def test_identity(backend):
@@ -90,6 +98,7 @@ def test_identity(backend):
     gatelist = [gates.H(0), gates.H(1), gates.I(0, 1)]
     final_state = apply_gates(backend, gatelist, nqubits=2)
     backend.assert_allclose(final_state, target_state)
+    assert gates.I(1).qasm_label == 'id'
 
 
 def test_align(backend):
@@ -100,6 +109,8 @@ def test_align(backend):
     backend.assert_allclose(final_state, target_state)
     gate_matrix = gate.asmatrix(backend)
     backend.assert_allclose(gate_matrix, np.eye(4))
+    with pytest.raises(NotImplementedError):
+        gate.qasm_label
 
 
 # :class:`qibo.core.cgates.M` is tested seperately in `test_measurement_gate.py`
@@ -114,6 +125,7 @@ def test_rx(backend):
     gate = np.array([[phase.real, -1j * phase.imag], [-1j * phase.imag, phase.real]])
     target_state = gate.dot(np.ones(2)) / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
+    assert gates.RX(0, theta=theta).qasm_label == 'rx'
 
 
 def test_ry(backend):
@@ -125,6 +137,7 @@ def test_ry(backend):
     gate = np.array([[phase.real, -phase.imag], [phase.imag, phase.real]])
     target_state = gate.dot(np.ones(2)) / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
+    assert gates.RY(0, theta=theta).qasm_label == 'ry'
 
 
 @pytest.mark.parametrize("applyx", [True, False])
@@ -140,6 +153,7 @@ def test_rz(backend, applyx):
     p = int(applyx)
     target_state[p] = np.exp((2 * p - 1) * 1j * theta / 2.0)
     backend.assert_allclose(final_state, target_state)
+    assert gates.RZ(0, theta).qasm_label == 'rz'
 
 
 def test_gpi(backend):
@@ -153,6 +167,9 @@ def test_gpi(backend):
 
     target_state = matrix.dot(initial_state)
     backend.assert_allclose(final_state, target_state)
+
+    with pytest.raises(NotImplementedError):
+        gates.GPI(0, phi).qasm_label
 
 
 def test_gpi2(backend):
@@ -169,6 +186,9 @@ def test_gpi2(backend):
     target_state = matrix.dot(initial_state)
     backend.assert_allclose(final_state, target_state)
 
+    with pytest.raises(NotImplementedError):
+        gates.GPI2(0, phi).qasm_label
+
 
 def test_u1(backend):
     theta = 0.1234
@@ -176,6 +196,7 @@ def test_u1(backend):
     target_state = np.zeros_like(final_state)
     target_state[1] = np.exp(1j * theta)
     backend.assert_allclose(final_state, target_state)
+    assert gates.U1(0, theta).qasm_label == 'u1'
 
 
 def test_u2(backend):
@@ -194,6 +215,7 @@ def test_u2(backend):
     )
     target_state = matrix.dot(initial_state) / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
+    assert gates.U2(0, phi, lam).qasm_label == 'u2'
 
 
 def test_u3(backend):
@@ -211,6 +233,7 @@ def test_u3(backend):
     matrix = np.array([[ep.conj() * cost, -em.conj() * sint], [em * sint, ep * cost]])
     target_state = matrix.dot(initial_state)
     backend.assert_allclose(final_state, target_state)
+    assert gates.U3(0, theta, phi, lam).qasm_label == 'u3'
 
 
 @pytest.mark.parametrize("applyx", [False, True])
@@ -224,6 +247,7 @@ def test_cnot(backend, applyx):
     target_state = np.zeros_like(final_state)
     target_state[3 * int(applyx)] = 1.0
     backend.assert_allclose(final_state, target_state)
+    assert gates.CNOT(0, 1).qasm_label == 'cx'
 
 
 @pytest.mark.parametrize("controlled_by", [False, True])
@@ -240,6 +264,7 @@ def test_cz(backend, controlled_by):
     final_state = apply_gates(backend, [gate], initial_state=initial_state)
     assert gate.name == "cz"
     backend.assert_allclose(final_state, target_state)
+    assert gates.CZ(0, 1).qasm_label == 'cz'
 
 
 @pytest.mark.parametrize(
@@ -260,6 +285,11 @@ def test_cun(backend, name, params):
     final_state = apply_gates(backend, [gate], initial_state=initial_state)
     target_state = np.dot(gate.asmatrix(backend), initial_state)
     backend.assert_allclose(final_state, target_state)
+    if gate.name in gates.QASM_GATES:
+        assert gate.qasm_label == gate.name
+    else:
+        with pytest.raises(NotImplementedError):
+            gate.qasm_label
 
 
 def test_swap(backend):
@@ -267,6 +297,7 @@ def test_swap(backend):
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0
     backend.assert_allclose(final_state, target_state)
+    assert gates.SWAP(0, 1).qasm_label == 'swap'
 
 
 def test_iswap(backend):
@@ -274,6 +305,7 @@ def test_iswap(backend):
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0j
     backend.assert_allclose(final_state, target_state)
+    assert gates.iSWAP(0, 1).qasm_label == 'iswap'
 
 
 def test_fswap(backend):
@@ -284,6 +316,7 @@ def test_fswap(backend):
     target_state[2] = 1.0 / np.sqrt(2)
     target_state[3] = -1.0 / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
+    assert gates.FSWAP(0, 1).qasm_label == 'fswap'
 
 
 def test_multiple_swap(backend):
@@ -308,6 +341,8 @@ def test_fsim(backend):
     matrix[3, 3] = np.exp(-1j * phi)
     target_state = matrix.dot(target_state)
     backend.assert_allclose(final_state, target_state)
+    with pytest.raises(NotImplementedError):
+        gates.fSim(0, 1, theta, phi).qasm_label
 
 
 def test_generalized_fsim(backend):
@@ -323,6 +358,8 @@ def test_generalized_fsim(backend):
     target_state[:4] = matrix.dot(target_state[:4])
     target_state[4:] = matrix.dot(target_state[4:])
     backend.assert_allclose(final_state, target_state)
+    with pytest.raises(NotImplementedError):
+       gatelist[-1].qasm_label
 
 
 def test_generalized_fsim_parameter_setter(backend):
@@ -333,7 +370,9 @@ def test_generalized_fsim_parameter_setter(backend):
     assert gate.parameters[1] == phi
     matrix = np.random.random((4, 4))
     with pytest.raises(ValueError):
-        gate = gates.GeneralizedfSim(0, 1, matrix, phi)
+        gates.GeneralizedfSim(0, 1, matrix, phi)
+    with pytest.raises(NotImplementedError):
+        gate.qasm_label
 
 
 def test_rxx(backend):
@@ -352,6 +391,7 @@ def test_rxx(backend):
     )
     target_state = gate.dot(np.ones(4)) / 2.0
     backend.assert_allclose(final_state, target_state)
+    assert gates.RXX(0, 1, theta=theta).qasm_label == 'rxx'
 
 
 def test_ryy(backend):
@@ -370,6 +410,7 @@ def test_ryy(backend):
     )
     target_state = gate.dot(np.ones(4)) / 2.0
     backend.assert_allclose(final_state, target_state)
+    assert gates.RYY(0, 1, theta=theta).qasm_label == 'ryy'
 
 
 def test_rzz(backend):
@@ -380,6 +421,7 @@ def test_rzz(backend):
     target_state = np.zeros_like(final_state)
     target_state[3] = np.exp(-1j * theta / 2.0)
     backend.assert_allclose(final_state, target_state)
+    assert gates.RZZ(0, 1, theta=theta).qasm_label == 'rzz'
 
 
 def test_ms(backend):
@@ -404,6 +446,9 @@ def test_ms(backend):
 
     backend.assert_allclose(final_state, target_state)
 
+    with pytest.raises(NotImplementedError):
+        gates.MS(0, 1, phi0=phi0, phi1=phi1).qasm_label
+
 
 @pytest.mark.parametrize("applyx", [False, True])
 def test_toffoli(backend, applyx):
@@ -418,6 +463,7 @@ def test_toffoli(backend, applyx):
     else:
         target_state[2] = 1
     backend.assert_allclose(final_state, target_state)
+    assert gatelist[-1].qasm_label == 'ccx'
 
 
 @pytest.mark.parametrize("nqubits", [2, 3])
@@ -435,6 +481,8 @@ def test_unitary_initialization(backend):
     matrix = np.random.random((4, 4))
     gate = gates.Unitary(matrix, 0, 1)
     backend.assert_allclose(gate.parameters[0], matrix)
+    with pytest.raises(NotImplementedError):
+        gates.Unitary(matrix, 0, 1).qasm_label
 
 
 def test_unitary_common_gates(backend):

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -285,7 +285,7 @@ def test_cun(backend, name, params):
     final_state = apply_gates(backend, [gate], initial_state=initial_state)
     target_state = np.dot(gate.asmatrix(backend), initial_state)
     backend.assert_allclose(final_state, target_state)
-    if gate.name in gates.QASM_GATES:
+    if name != "CU2":
         assert gate.qasm_label == gate.name
     else:
         with pytest.raises(NotImplementedError):

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -30,7 +30,7 @@ def test_h(backend):
     final_state = apply_gates(backend, [gates.H(0), gates.H(1)], nqubits=2)
     target_state = np.ones_like(final_state) / 2
     backend.assert_allclose(final_state, target_state)
-    assert gates.H(1).qasm_label == 'h'
+    assert gates.H(1).qasm_label == "h"
 
 
 def test_x(backend):
@@ -38,7 +38,7 @@ def test_x(backend):
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0
     backend.assert_allclose(final_state, target_state)
-    assert gates.X(0).qasm_label == 'x'
+    assert gates.X(0).qasm_label == "x"
 
 
 def test_y(backend):
@@ -46,7 +46,7 @@ def test_y(backend):
     target_state = np.zeros_like(final_state)
     target_state[1] = 1j
     backend.assert_allclose(final_state, target_state)
-    assert gates.Y(1).qasm_label == 'y'
+    assert gates.Y(1).qasm_label == "y"
 
 
 def test_z(backend):
@@ -55,14 +55,14 @@ def test_z(backend):
     target_state[2] *= -1.0
     target_state[3] *= -1.0
     backend.assert_allclose(final_state, target_state)
-    assert gates.Z(0).qasm_label == 'z'
+    assert gates.Z(0).qasm_label == "z"
 
 
 def test_s(backend):
     final_state = apply_gates(backend, [gates.H(0), gates.H(1), gates.S(1)], nqubits=2)
     target_state = np.array([0.5, 0.5j, 0.5, 0.5j])
     backend.assert_allclose(final_state, target_state)
-    assert gates.S(1).qasm_label == 's'
+    assert gates.S(1).qasm_label == "s"
 
 
 def test_sdg(backend):
@@ -71,14 +71,14 @@ def test_sdg(backend):
     )
     target_state = np.array([0.5, -0.5j, 0.5, -0.5j])
     backend.assert_allclose(final_state, target_state)
-    assert gates.SDG(1).qasm_label == 'sdg'
+    assert gates.SDG(1).qasm_label == "sdg"
 
 
 def test_t(backend):
     final_state = apply_gates(backend, [gates.H(0), gates.H(1), gates.T(1)], nqubits=2)
     target_state = np.array([0.5, (1 + 1j) / np.sqrt(8), 0.5, (1 + 1j) / np.sqrt(8)])
     backend.assert_allclose(final_state, target_state)
-    assert gates.T(1).qasm_label == 't'
+    assert gates.T(1).qasm_label == "t"
 
 
 def test_tdg(backend):
@@ -87,7 +87,7 @@ def test_tdg(backend):
     )
     target_state = np.array([0.5, (1 - 1j) / np.sqrt(8), 0.5, (1 - 1j) / np.sqrt(8)])
     backend.assert_allclose(final_state, target_state)
-    assert gates.TDG(1).qasm_label == 'tdg'
+    assert gates.TDG(1).qasm_label == "tdg"
 
 
 def test_identity(backend):
@@ -98,7 +98,7 @@ def test_identity(backend):
     gatelist = [gates.H(0), gates.H(1), gates.I(0, 1)]
     final_state = apply_gates(backend, gatelist, nqubits=2)
     backend.assert_allclose(final_state, target_state)
-    assert gates.I(1).qasm_label == 'id'
+    assert gates.I(1).qasm_label == "id"
 
 
 def test_align(backend):
@@ -125,7 +125,7 @@ def test_rx(backend):
     gate = np.array([[phase.real, -1j * phase.imag], [-1j * phase.imag, phase.real]])
     target_state = gate.dot(np.ones(2)) / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
-    assert gates.RX(0, theta=theta).qasm_label == 'rx'
+    assert gates.RX(0, theta=theta).qasm_label == "rx"
 
 
 def test_ry(backend):
@@ -137,7 +137,7 @@ def test_ry(backend):
     gate = np.array([[phase.real, -phase.imag], [phase.imag, phase.real]])
     target_state = gate.dot(np.ones(2)) / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
-    assert gates.RY(0, theta=theta).qasm_label == 'ry'
+    assert gates.RY(0, theta=theta).qasm_label == "ry"
 
 
 @pytest.mark.parametrize("applyx", [True, False])
@@ -153,7 +153,7 @@ def test_rz(backend, applyx):
     p = int(applyx)
     target_state[p] = np.exp((2 * p - 1) * 1j * theta / 2.0)
     backend.assert_allclose(final_state, target_state)
-    assert gates.RZ(0, theta).qasm_label == 'rz'
+    assert gates.RZ(0, theta).qasm_label == "rz"
 
 
 def test_gpi(backend):
@@ -196,7 +196,7 @@ def test_u1(backend):
     target_state = np.zeros_like(final_state)
     target_state[1] = np.exp(1j * theta)
     backend.assert_allclose(final_state, target_state)
-    assert gates.U1(0, theta).qasm_label == 'u1'
+    assert gates.U1(0, theta).qasm_label == "u1"
 
 
 def test_u2(backend):
@@ -215,7 +215,7 @@ def test_u2(backend):
     )
     target_state = matrix.dot(initial_state) / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
-    assert gates.U2(0, phi, lam).qasm_label == 'u2'
+    assert gates.U2(0, phi, lam).qasm_label == "u2"
 
 
 def test_u3(backend):
@@ -233,7 +233,7 @@ def test_u3(backend):
     matrix = np.array([[ep.conj() * cost, -em.conj() * sint], [em * sint, ep * cost]])
     target_state = matrix.dot(initial_state)
     backend.assert_allclose(final_state, target_state)
-    assert gates.U3(0, theta, phi, lam).qasm_label == 'u3'
+    assert gates.U3(0, theta, phi, lam).qasm_label == "u3"
 
 
 @pytest.mark.parametrize("applyx", [False, True])
@@ -247,7 +247,7 @@ def test_cnot(backend, applyx):
     target_state = np.zeros_like(final_state)
     target_state[3 * int(applyx)] = 1.0
     backend.assert_allclose(final_state, target_state)
-    assert gates.CNOT(0, 1).qasm_label == 'cx'
+    assert gates.CNOT(0, 1).qasm_label == "cx"
 
 
 @pytest.mark.parametrize("controlled_by", [False, True])
@@ -264,7 +264,7 @@ def test_cz(backend, controlled_by):
     final_state = apply_gates(backend, [gate], initial_state=initial_state)
     assert gate.name == "cz"
     backend.assert_allclose(final_state, target_state)
-    assert gates.CZ(0, 1).qasm_label == 'cz'
+    assert gates.CZ(0, 1).qasm_label == "cz"
 
 
 @pytest.mark.parametrize(
@@ -297,7 +297,7 @@ def test_swap(backend):
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0
     backend.assert_allclose(final_state, target_state)
-    assert gates.SWAP(0, 1).qasm_label == 'swap'
+    assert gates.SWAP(0, 1).qasm_label == "swap"
 
 
 def test_iswap(backend):
@@ -305,7 +305,7 @@ def test_iswap(backend):
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0j
     backend.assert_allclose(final_state, target_state)
-    assert gates.iSWAP(0, 1).qasm_label == 'iswap'
+    assert gates.iSWAP(0, 1).qasm_label == "iswap"
 
 
 def test_fswap(backend):
@@ -316,7 +316,7 @@ def test_fswap(backend):
     target_state[2] = 1.0 / np.sqrt(2)
     target_state[3] = -1.0 / np.sqrt(2)
     backend.assert_allclose(final_state, target_state)
-    assert gates.FSWAP(0, 1).qasm_label == 'fswap'
+    assert gates.FSWAP(0, 1).qasm_label == "fswap"
 
 
 def test_multiple_swap(backend):
@@ -359,7 +359,7 @@ def test_generalized_fsim(backend):
     target_state[4:] = matrix.dot(target_state[4:])
     backend.assert_allclose(final_state, target_state)
     with pytest.raises(NotImplementedError):
-       gatelist[-1].qasm_label
+        gatelist[-1].qasm_label
 
 
 def test_generalized_fsim_parameter_setter(backend):
@@ -391,7 +391,7 @@ def test_rxx(backend):
     )
     target_state = gate.dot(np.ones(4)) / 2.0
     backend.assert_allclose(final_state, target_state)
-    assert gates.RXX(0, 1, theta=theta).qasm_label == 'rxx'
+    assert gates.RXX(0, 1, theta=theta).qasm_label == "rxx"
 
 
 def test_ryy(backend):
@@ -410,7 +410,7 @@ def test_ryy(backend):
     )
     target_state = gate.dot(np.ones(4)) / 2.0
     backend.assert_allclose(final_state, target_state)
-    assert gates.RYY(0, 1, theta=theta).qasm_label == 'ryy'
+    assert gates.RYY(0, 1, theta=theta).qasm_label == "ryy"
 
 
 def test_rzz(backend):
@@ -421,7 +421,7 @@ def test_rzz(backend):
     target_state = np.zeros_like(final_state)
     target_state[3] = np.exp(-1j * theta / 2.0)
     backend.assert_allclose(final_state, target_state)
-    assert gates.RZZ(0, 1, theta=theta).qasm_label == 'rzz'
+    assert gates.RZZ(0, 1, theta=theta).qasm_label == "rzz"
 
 
 def test_ms(backend):
@@ -463,7 +463,7 @@ def test_toffoli(backend, applyx):
     else:
         target_state[2] = 1
     backend.assert_allclose(final_state, target_state)
-    assert gatelist[-1].qasm_label == 'ccx'
+    assert gatelist[-1].qasm_label == "ccx"
 
 
 @pytest.mark.parametrize("nqubits", [2, 3])

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -681,3 +681,24 @@ def test_circuit_draw_callbacks(legend):
         )
 
     assert c.draw(legend=legend) == ref
+
+
+def test_circuit_draw_labels():
+    """Test circuit text draw."""
+    ref = (
+        "q0: ─H─G1─G2─G3─G4───────────────────────────x───\n"
+        "q1: ───o──|──|──|──H─G2─G3─G4────────────────|─x─\n"
+        "q2: ──────o──|──|────o──|──|──H─G3─G4────────|─|─\n"
+        "q3: ─────────o──|───────o──|────o──|──H─G4───|─x─\n"
+        "q4: ────────────o──────────o───────o────o──H─x───"
+    )
+    circuit = Circuit(5)
+    for i1 in range(5):
+        circuit.add(gates.H(i1))
+        for i2 in range(i1 + 1, 5):
+            gate = gates.CNOT(i2, i1)
+            gate.label = f"G{i2}"
+            circuit.add(gate)
+    circuit.add(gates.SWAP(0, 4))
+    circuit.add(gates.SWAP(1, 3))
+    assert circuit.draw() == ref

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -1,4 +1,6 @@
 """Test all methods defined in `qibo/models/circuit.py`."""
+from collections import Counter
+
 import pytest
 
 from qibo import gates
@@ -43,7 +45,7 @@ def test_circuit_init():
 @pytest.mark.parametrize("nqubits", [0, -10, 2.5])
 def test_circuit_init_errors(nqubits):
     with pytest.raises((ValueError, TypeError)):
-        c = Circuit(nqubits)
+        Circuit(nqubits)
 
 
 def test_circuit_constructor():
@@ -55,7 +57,7 @@ def test_circuit_constructor():
     assert c.density_matrix
     c = Circuit(5, accelerators={"/GPU:0": 2})
     with pytest.raises(NotImplementedError):
-        c = Circuit(5, accelerators={"/GPU:0": 2}, density_matrix=True)
+        Circuit(5, accelerators={"/GPU:0": 2}, density_matrix=True)
 
 
 def test_circuit_add():
@@ -157,8 +159,6 @@ def test_add_measurement_collapse():
 
 
 def test_gate_types():
-    import collections
-
     c = Circuit(3)
     c.add(gates.H(0))
     c.add(gates.H(1))
@@ -166,16 +166,12 @@ def test_gate_types():
     c.add(gates.CNOT(0, 2))
     c.add(gates.CNOT(1, 2))
     c.add(gates.TOFFOLI(0, 1, 2))
-    target_counter = collections.Counter(
-        {gates.H: 2, gates.X: 1, gates.CNOT: 2, gates.TOFFOLI: 1}
-    )
+    target_counter = Counter({gates.H: 2, gates.X: 1, gates.CNOT: 2, gates.TOFFOLI: 1})
     assert c.ngates == 6
     assert c.gate_types == target_counter
 
 
 def test_gate_names():
-    import collections
-
     c = Circuit(3)
     c.add(gates.H(0))
     c.add(gates.H(1))
@@ -183,7 +179,7 @@ def test_gate_names():
     c.add(gates.CNOT(0, 2))
     c.add(gates.CNOT(1, 2))
     c.add(gates.TOFFOLI(0, 1, 2))
-    target_counter = collections.Counter({"h": 2, "x": 1, "cx": 2, "ccx": 1})
+    target_counter = Counter({"h": 2, "x": 1, "cx": 2, "ccx": 1})
     assert c.ngates == 6
     assert c.gate_names == target_counter
 
@@ -257,7 +253,7 @@ def test_circuit_addition_errors():
     c2.add(gates.X(0))
 
     with pytest.raises(ValueError):
-        c3 = c1 + c2
+        c1 + c2
 
 
 def test_circuit_on_qubits():

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -667,8 +667,8 @@ def test_circuit_draw_channels(legend):
             "\n\n Legend for callbacks and channels: \n"
             "| Gate                | Symbol   |\n"
             "|---------------------+----------|\n"
-            "| PauliNoiseChannel   | PN       |\n"
-            "| DepolarizingChannel | D        |"
+            "| DepolarizingChannel | D        |\n"
+            "| PauliNoiseChannel   | PN       |"
         )
 
     assert c.draw(legend=legend) == ref

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -166,9 +166,26 @@ def test_gate_types():
     c.add(gates.CNOT(0, 2))
     c.add(gates.CNOT(1, 2))
     c.add(gates.TOFFOLI(0, 1, 2))
-    target_counter = collections.Counter({"h": 2, "x": 1, "cx": 2, "ccx": 1})
+    target_counter = collections.Counter(
+        {gates.H: 2, gates.X: 1, gates.CNOT: 2, gates.TOFFOLI: 1}
+    )
     assert c.ngates == 6
     assert c.gate_types == target_counter
+
+
+def test_gate_names():
+    import collections
+
+    c = Circuit(3)
+    c.add(gates.H(0))
+    c.add(gates.H(1))
+    c.add(gates.X(2))
+    c.add(gates.CNOT(0, 2))
+    c.add(gates.CNOT(1, 2))
+    c.add(gates.TOFFOLI(0, 1, 2))
+    target_counter = collections.Counter({"h": 2, "x": 1, "cx": 2, "ccx": 1})
+    assert c.ngates == 6
+    assert c.gate_names == target_counter
 
 
 def test_gates_of_type():
@@ -697,8 +714,20 @@ def test_circuit_draw_labels():
         circuit.add(gates.H(i1))
         for i2 in range(i1 + 1, 5):
             gate = gates.CNOT(i2, i1)
-            gate.label = f"G{i2}"
+            gate.draw_label = f"G{i2}"
             circuit.add(gate)
     circuit.add(gates.SWAP(0, 4))
     circuit.add(gates.SWAP(1, 3))
     assert circuit.draw() == ref
+
+
+def test_circuit_draw_error():
+    """Test NotImplementedError in circuit draw"""
+    circuit = Circuit(1)
+    error_gate = gates.X(0)
+    error_gate.name = ""
+    error_gate.draw_label = ""
+    circuit.add(error_gate)
+
+    with pytest.raises(NotImplementedError):
+        circuit.draw()

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -721,6 +721,27 @@ def test_circuit_draw_labels():
     assert circuit.draw() == ref
 
 
+def test_circuit_draw_names():
+    """Test circuit text draw."""
+    ref = (
+        "q0: ─H─cx─cx─cx─cx───────────────────────────x───\n"
+        "q1: ───o──|──|──|──H─cx─cx─cx────────────────|─x─\n"
+        "q2: ──────o──|──|────o──|──|──H─cx─cx────────|─|─\n"
+        "q3: ─────────o──|───────o──|────o──|──H─cx───|─x─\n"
+        "q4: ────────────o──────────o───────o────o──H─x───"
+    )
+    circuit = Circuit(5)
+    for i1 in range(5):
+        circuit.add(gates.H(i1))
+        for i2 in range(i1 + 1, 5):
+            gate = gates.CNOT(i2, i1)
+            gate.draw_label = ""
+            circuit.add(gate)
+    circuit.add(gates.SWAP(0, 4))
+    circuit.add(gates.SWAP(1, 3))
+    assert circuit.draw() == ref
+
+
 def test_circuit_draw_error():
     """Test NotImplementedError in circuit draw"""
     circuit = Circuit(1)

--- a/tests/test_models_circuit_qasm.py
+++ b/tests/test_models_circuit_qasm.py
@@ -160,7 +160,7 @@ cu3(0.2, 0.3, 0.4) q[2],q[1];"""
 
     c = Circuit(2)
     c.add(gates.CU2(0, 1, 0.1, 0.2))
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         target = c.to_qasm()
 
 
@@ -182,7 +182,7 @@ cry(0.3) q[2],q[1];"""
 
     c = Circuit(2)
     c.add(gates.CU2(0, 1, 0.1, 0.2))
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         target = c.to_qasm()
 
 


### PR DESCRIPTION
Related to issue #850. This PR allows to change `name` parameter of `qibo.gates.Gate` and 2 other labels are added:
- `name`: label of the gate. Can be changed by a user.
- `draw_label`: a symbol for drawing a circuit. If `None` or empty, `gate.name[:4]` is used.
    This parameter allows to remove `qibo.gates.DRAW_LABELS` dictionary.
- `@property qasm_label`: for gates supported by OpenQASM.

For example:
```python
from math import pi 
from qibo import gates
from qibo.models import Circuit

rx1 = gates.RX(0, pi/2)
rx1.name = "RX90"
rx1.draw_label = "RX1"
rx2 = gates.RX(1, 3 * pi/2)
rx2.name = "RX270"
rx2. draw_label = "RX2"

circuit = Circuit(2)
circuit.add(rx1)
circuit.add(rx2)
print(circuit.draw())
```
prints
```python
q0: ─RX1─
q1: ─RX2─
```
instead of 
```python
q0: ─RX─
q1: ─RX─
```
As mentioned in #850, the `name` can be used for NoiseModels or for controlling parameters of the quantum hardware.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
