### PR TITLE
Calibration matrix for readout mitigation

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -232,9 +232,10 @@ The effect of the error is modeled by the matrix composed of the noisy frequenci
 .. math::
    F_i^{noisy} = M \cdot F_i^{ideal}
 
-and, therefore, the calibration matrix obtained as :math:`M_{cal}=M^{-1}` can be used to recover the noise-free frequencies.
+and, therefore, the calibration matrix obtained as :math:`M_{\text{cal}}=M^{-1}` can be used to recover the noise-free frequencies.
 
-.. autofunction:: qibo.models.error_mitigation.get_calibration_matrix
+.. autofunction:: qibo.models.error_mitigation.calibration_matrix
+
 
 .. autofunction:: qibo.models.error_mitigation.apply_readout_mitigation
 
@@ -247,6 +248,7 @@ This approach converts the effect of any noise map :math:`A` into a single multi
    \langle O\rangle_{ideal} = \frac{\langle O\rangle_{noisy}}{\lambda}
 
 .. autofunction:: qibo.models.error_mitigation.apply_randomized_readout_mitigation
+
 
 Zero Noise Extrapolation (ZNE)
 """"""""""""""""""""""""""""""
@@ -267,7 +269,9 @@ This implementation of ZNE relies on the insertion of gate pairs (that resolve t
 
 .. autofunction:: qibo.models.error_mitigation.ZNE
 
+
 .. autofunction:: qibo.models.error_mitigation.get_gammas
+
 
 .. autofunction:: qibo.models.error_mitigation.get_noisy_circuit
 
@@ -287,6 +291,8 @@ and learn the mapping :math:`a^{noisy}\rightarrow a^{exact}`. The mitigated expe
 In this implementation the initial circuit is expected to be decomposed in the three Clifford gates :math:`RX(\frac{\pi}{2})`, :math:`CNOT`, :math:`X` and in :math:`RZ(\theta)` (which is Clifford only for :math:`\theta=\frac{n\pi}{2}`). By default the set of Clifford gates used for substitution is :math:`\{RZ(0),RZ(\frac{\pi}{2}),RZ(\pi),RZ(\frac{3}{2}\pi)\}`. See `Sopena et al <https://arxiv.org/abs/2103.12680>`_ for more details.
 
 .. autofunction:: qibo.models.error_mitigation.CDR
+
+
 .. autofunction:: qibo.models.error_mitigation.sample_training_circuit
 
 

--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -217,6 +217,33 @@ Error Mitigation
 
 Qibo allows for mitigating noise in circuits via error mitigation methods. Unlike error correction, error mitigation does not aim to correct qubit errors, but rather it provides the means to estimate the noise-free expected value of an observable measured at the end of a noisy circuit.
 
+Readout Mitigation
+""""""""""""""""""
+
+A common kind of error happening in quantum circuits is readout error, i.e. the error in the measurement of the qubits at the end of the computation. In Qibo there are currently two methods implemented for mitigating readout errors, and both can be used as standalone functions or in combination with the other general mitigation methods by setting the paramter `readout`.
+
+
+Calibration Matrix
+""""""""""""""""""
+Given :math:`n` qubits, all the possible :math:`2^n` states are constructed via the application of the corresponding sequence of :math:`X` gates :math:`X_0\otimes I_1\otimes\cdot\cdot\cdot\otimes X_{n-1}`. In the presence of readout errors, we will measure for each state :math:`i` some noisy frequencies :math:`F_i^{noisy}` different from the ideal ones :math:`F_i^{ideal}=\delta_{i,j}`.
+
+The effect of the error is modeled by the matrix composed of the noisy frequencies as columns :math:`M=\big(F_0^{noisy},...,F_{n-1}^{noisy}\big)`. We have indeed that:
+
+.. math::
+   F_i^{noisy} = M \cdot F_i^{ideal}
+
+and, therefore, the calibration matrix obtained as :math:`M_{cal}=M^{-1}` can be used to recover the noise-free frequencies.
+
+.. autofunction:: qibo.models.error_mitigation.get_calibration_matrix
+
+.. autofunction:: qibo.models.error_mitigation.apply_readout_mitigation
+
+
+Randomized
+""""""""""
+
+.. autofunction:: qibo.models.error_mitigation.apply_randomized_readout_mitigation
+
 Zero Noise Extrapolation (ZNE)
 """"""""""""""""""""""""""""""
 

--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -241,6 +241,10 @@ and, therefore, the calibration matrix obtained as :math:`M_{cal}=M^{-1}` can be
 
 Randomized
 """"""""""
+This approach converts the effect of any noise map :math:`A` into a single multiplication factor for each Pauli observable, that is, diagonalizes the measurement channel. The multiplication factor :math:`\lambda` can be directly measured even without the quantum circuit. Dividing the measured value :math:`\langle O\rangle_{noisy}` by these factor results in the mitigated Pauli expectation value :math:`\langle O\rangle_{ideal}`,
+
+.. math::
+   \langle O\rangle_{ideal} = \frac{\langle O\rangle_{noisy}}{\lambda}
 
 .. autofunction:: qibo.models.error_mitigation.apply_randomized_readout_mitigation
 

--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -1377,8 +1377,8 @@ For example if we use the five levels ``[0,1,2,3,4]`` :
        noise_levels=np.arange(5),
        noise_model=noise,
        nshots=10000,
-       insertion_gate='CNOT'
-       backend=backend
+       insertion_gate='CNOT',
+       backend=backend,
    )
    print(estimate)
    # 0.8332843749999996

--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -1225,7 +1225,7 @@ Let's see how to use them. For starters, let's define a dummy circuit with some 
    c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(1, nqubits, 2))
    c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
    # Include the measurements
-   c.add(gates.M(q) for q in range(nqubits))
+   c.add(gates.M(*range(nqubits)))
 
    # visualize the circuit
    print(c.draw())
@@ -1275,13 +1275,13 @@ the real quantum hardware, instead, we can use a noise model:
    # readout error
    # randomly initialize the bitflip probabilities
    prob = random_stochastic_matrix(
-       2, diagonally_dominant=True, seed=2, backend=backend
+       2**nqubits, diagonally_dominant=True, seed=2, backend=backend
    )
    noise.add(ReadoutError(probabilities=prob), gate=gates.M)
    # Noisy expected value without mitigation
    noisy = obs.expectation(backend.execute_circuit(noise.apply(c)).state())
    print(noisy)
-   # 0.3771847008790268
+   # 0.5647937721701448
 
 .. testoutput::
    :hide:
@@ -1313,6 +1313,7 @@ calibration matrix and use it modify the final state after the circuit execution
    mit_state = apply_readout_mitigation(state, calibration_matrix)
    mit_val = mit_state.expectation_from_samples(obs)
    print(mit_val)
+   # 0.5945794816381054
 
 .. testoutput::
    :hide:
@@ -1323,6 +1324,8 @@ Or use the randomized readout mitigation:
 
 .. testcode::
 
+   from qibo.models.error_mitigation import apply_randomized_readout_mitigation
+
    ncircuits = 10
    result, result_cal = apply_randomized_readout_mitigation(
        c, backend=backend, noise_model=noise, nshots=nshots, ncircuits=ncircuits
@@ -1331,6 +1334,7 @@ Or use the randomized readout mitigation:
        obs
    ) / result_cal.expectation_from_samples(obs)
    print(mit_val)
+   # 0.5860884499785314
 
 .. testoutput::
    :hide:
@@ -1377,7 +1381,7 @@ For example if we use the five levels ``[0,1,2,3,4]`` :
        insertion_gate='CNOT'
    )
    print(estimate)
-   # 0.538034375
+   # 0.8332843749999996
 
 .. testoutput::
    :hide:
@@ -1407,7 +1411,7 @@ combined with the readout mitigation:
        readout=readout,
    )
    print(estimate)
-   # 0.8859203125000003
+   # 0.8979124892467807
 
 .. testoutput::
    :hide:
@@ -1463,7 +1467,7 @@ caveat about the input circuit for CDR is valid here as well.
        noise_model=noise,
        nshots=10000,
        insertion_gate='CNOT',
-       readout=readdout,
+       readout=readout,
    )
    print(estimate)
    # 0.9085991439303123

--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -1300,17 +1300,17 @@ calibration matrix and use it modify the final state after the circuit execution
 
 .. testcode::
 
-   from qibo.models.error_mitigation import apply_readout_mitigation, get_calibration_matrix
+   from qibo.models.error_mitigation import apply_readout_mitigation, calibration_matrix
 
    nshots = 10000
    # compute the calibration matrix
-   calibration_matrix = get_calibration_matrix(
+   calibration = calibration_matrix(
        nqubits, backend=backend, noise_model=noise, nshots=nshots
    )
    # execute the circuit
    state = backend.execute_circuit(noise.apply(c), nshots=nshots)
    # mitigate the readout errors
-   mit_state = apply_readout_mitigation(state, calibration_matrix)
+   mit_state = apply_readout_mitigation(state, calibration)
    mit_val = mit_state.expectation_from_samples(obs)
    print(mit_val)
    # 0.5945794816381054
@@ -1374,11 +1374,11 @@ For example if we use the five levels ``[0,1,2,3,4]`` :
    estimate = ZNE(
        circuit=c,
        observable=obs,
-       backend=backend,
        noise_levels=np.arange(5),
        noise_model=noise,
        nshots=10000,
        insertion_gate='CNOT'
+       backend=backend
    )
    print(estimate)
    # 0.8332843749999996
@@ -1395,7 +1395,7 @@ combined with the readout mitigation:
 
    # we can either use
    # the calibration matrix computed earlier
-   readout = {'calibration_matrix': calibration_matrix}
+   readout = {'calibration_matrix': calibration}
    # or the randomized readout
    readout = {'ncircuits': 10}
 

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -145,7 +145,7 @@ def ZNE(
         )
         if "ncircuits" in readout.keys():
             circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
-                noisy_circuit, backend, noise_model, nshots, readout["ncircuits"]
+                noisy_circuit, noise_model, nshots, readout["ncircuits"], backend
             )
         else:
             if noise_model is not None and backend.name != "qibolab":
@@ -299,7 +299,7 @@ def CDR(
         train_val["noise-free"].append(val)
         if "ncircuits" in readout.keys():
             circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
-                c, backend, noise_model, nshots, readout["ncircuits"]
+                c, noise_model, nshots, readout["ncircuits"], backend
             )
         else:
             if noise_model is not None and backend.name != "qibolab":
@@ -318,7 +318,7 @@ def CDR(
     # Run the input circuit
     if "ncircuits" in readout.keys():
         circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
-            circuit, backend, noise_model, nshots, readout["ncircuits"]
+            circuit, noise_model, nshots, readout["ncircuits"], backend
         )
     else:
         if noise_model is not None and backend.name != "qibolab":
@@ -409,7 +409,7 @@ def vnCDR(
                     circuit_result,
                     circuit_result_cal,
                 ) = apply_randomized_readout_mitigation(
-                    noisy_c, backend, noise_model, nshots, readout["ncircuits"]
+                    noisy_c, noise_model, nshots, readout["ncircuits"], backend
                 )
             else:
                 if noise_model is not None and backend.name != "qibolab":
@@ -437,7 +437,7 @@ def vnCDR(
         noisy_c = get_noisy_circuit(circuit, level, insertion_gate=insertion_gate)
         if "ncircuits" in readout.keys():
             circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
-                noisy_c, backend, noise_model, nshots, readout["ncircuits"]
+                noisy_c, noise_model, nshots, readout["ncircuits"], backend
             )
         else:
             if noise_model is not None and backend.name != "qibolab":

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -37,6 +37,7 @@ def get_gammas(c, solve=True):
                 for i in c
             ]
         )
+
     return gammas
 
 
@@ -78,6 +79,7 @@ def get_noisy_circuit(circuit, cj, insertion_gate="CNOT"):
                 for i in range(cj):
                     noisy_circuit.add(gates.RX(qubit, theta=theta))
                     noisy_circuit.add(gates.RX(qubit, theta=-theta))
+
     return noisy_circuit
 
 
@@ -135,6 +137,7 @@ def ZNE(
             val /= circuit_result_cal.expectation_from_samples(observable)
         expected_val.append(val)
     gamma = get_gammas(noise_levels, solve=solve_for_gammas)
+
     return (gamma * expected_val).sum()
 
 
@@ -206,6 +209,7 @@ def sample_training_circuit(
             sampled_circuit.add(replacement[i])
         else:
             sampled_circuit.add(gate)
+
     return sampled_circuit
 
 
@@ -289,6 +293,7 @@ def CDR(
     if "ncircuits" in readout.keys():
         val /= circuit_result_cal.expectation_from_samples(observable)
     mit_val = model(val, *optimal_params)
+
     # Return data
     if full_output == True:
         return mit_val, val, optimal_params, train_val
@@ -392,6 +397,7 @@ def vnCDR(
             expval /= circuit_result_cal.expectation_from_samples(observable)
         val.append(expval)
     mit_val = model(np.array(val).reshape(-1, 1), *optimal_params[0])[0]
+
     # Return data
     if full_output == True:
         return mit_val, val, optimal_params, train_val
@@ -434,6 +440,7 @@ def get_calibration_matrix(nqubits, backend=None, noise_model=None, nshots=1000)
             f = freq[key] / nshots
             column[int(key, 2)] = f
         matrix[:, i] = column
+
     return np.linalg.inv(matrix)
 
 
@@ -453,6 +460,7 @@ def apply_readout_mitigation(state, calibration_matrix):
     freq = freq.reshape(-1, 1)
     for i, val in enumerate(calibration_matrix @ freq):
         state._frequencies[i] = float(val)
+
     return state
 
 
@@ -501,7 +509,7 @@ def apply_randomized_readout_mitigation(
         for circ in circuits:
             circ.add(x_gate)
             circ.add(gates.M(*qubits))
-            if noise_model != None and backend.name != "qibolab":
+            if noise_model is not None and backend.name != "qibolab":
                 circ = noise_model.apply(circ)
             result = backend.execute_circuit(circ, nshots=nshots_r)
             result._samples = result.apply_bitflips(error_map)
@@ -514,4 +522,5 @@ def apply_randomized_readout_mitigation(
         for f in freq[1::, j]:
             freq_sum += f
         results[j]._frequencies = freq_sum
+
     return results

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -119,7 +119,7 @@ def ZNE(
     for cj in noise_levels:
         noisy_circuit = get_noisy_circuit(circuit, cj, insertion_gate=insertion_gate)
         if "ncircuits" in readout.keys():
-            circuit_result, circuit_result_cal = apply_temme_readout_mitigation(
+            circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
                 noisy_circuit, backend, noise_model, nshots, readout["ncircuits"]
             )
         else:
@@ -255,7 +255,7 @@ def CDR(
         val = c(nshots=nshots).expectation_from_samples(observable)
         train_val["noise-free"].append(val)
         if "ncircuits" in readout.keys():
-            circuit_result, circuit_result_cal = apply_temme_readout_mitigation(
+            circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
                 c, backend, noise_model, nshots, readout["ncircuits"]
             )
         else:
@@ -274,7 +274,7 @@ def CDR(
     optimal_params = curve_fit(model, train_val["noisy"], train_val["noise-free"])[0]
     # Run the input circuit
     if "ncircuits" in readout.keys():
-        circuit_result, circuit_result_cal = apply_temme_readout_mitigation(
+        circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
             circuit, backend, noise_model, nshots, readout["ncircuits"]
         )
     else:
@@ -348,7 +348,10 @@ def vnCDR(
         for level in noise_levels:
             noisy_c = get_noisy_circuit(c, level, insertion_gate=insertion_gate)
             if "ncircuits" in readout.keys():
-                circuit_result, circuit_result_cal = apply_temme_readout_mitigation(
+                (
+                    circuit_result,
+                    circuit_result_cal,
+                ) = apply_randomized_readout_mitigation(
                     noisy_c, backend, noise_model, nshots, readout["ncircuits"]
                 )
             else:
@@ -373,7 +376,7 @@ def vnCDR(
     for level in noise_levels:
         noisy_c = get_noisy_circuit(circuit, level, insertion_gate=insertion_gate)
         if "ncircuits" in readout.keys():
-            circuit_result, circuit_result_cal = apply_temme_readout_mitigation(
+            circuit_result, circuit_result_cal = apply_randomized_readout_mitigation(
                 noisy_c, backend, noise_model, nshots, readout["ncircuits"]
             )
         else:
@@ -416,9 +419,8 @@ def get_calibration_matrix(nqubits, backend=None, noise_model=None, nshots=1000)
 
     matrix = np.zeros((2**nqubits, 2**nqubits))
 
-    string = f"{0:0{nqubits}b}"
     for i in range(2**nqubits):
-        state = string.format(i)
+        state = format(i, f"0{nqubits}b")
         circuit = Circuit(nqubits, density_matrix=True)
         for q, bit in enumerate(state):
             if bit == "1":

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -414,9 +414,8 @@ def apply_readout_mitigation(state, calibration_matrix):
     """
     freq = np.zeros(2**state.nqubits)
     for k, v in state.frequencies().items():
-        f = v / state.nshots
-        freq[int(k, 2)] = f
+        freq[int(k, 2)] = v
     freq = freq.reshape(-1, 1)
-    for i, val in enumerate(calibration_matrix @ freq * state.nshots):
+    for i, val in enumerate(calibration_matrix @ freq):
         state._frequencies[i] = float(val)
     return state

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -8,12 +8,17 @@ from qibo.config import raise_error
 from qibo.models import Circuit
 
 
-def get_gammas(c, solve=True):
+def get_gammas(c, solve: bool = True):
     """Standalone function to compute the ZNE coefficients given the noise levels.
 
     Args:
-        c (numpy.ndarray): Array containing the different noise levels, note that in the CNOT insertion paradigm this corresponds to the number of CNOT pairs to be inserted. The canonical ZNE noise levels are obtained as 2*c + 1.
-        solve (bool): If ``True`` computes the coeffients by solving the linear system. Otherwise, use the analytical solution valid for the CNOT insertion method.
+        c (numpy.ndarray): array containing the different noise levels.
+            Note that in the CNOT insertion paradigm this corresponds to
+            the number of CNOT pairs to be inserted. The canonical ZNE
+            noise levels are obtained as ``2 * c + 1``.
+        solve (bool, optional): If ``True``, computes the coeffients by solving the
+            linear system. If ``False``, use the analytical solution valid
+            for the CNOT insertion method. Default is ``True``.
 
     Returns:
         numpy.ndarray: The computed coefficients.
@@ -41,13 +46,14 @@ def get_gammas(c, solve=True):
     return gammas
 
 
-def get_noisy_circuit(circuit, cj, insertion_gate="CNOT"):
+def get_noisy_circuit(circuit, cj: int, insertion_gate: str = "CNOT"):
     """Standalone function to generate the noisy circuit with the inverse gate pairs insertions.
 
     Args:
-        circuit (qibo.models.circuit.Circuit): Input circuit to modify.
+        circuit (:class:`qibo.models.circuit.Circuit`): Input circuit to modify.
         cj (int): Number of insertion gate pairs to add.
-        insertion_gate (str): Which gate to use for the insertion. Default value: 'CNOT', use 'RX' for the ``RX(pi/2)`` gate instead.
+        insertion_gate (str, optional): gate to be used in the insertion.
+            If ``insertion_gate="RX"``, the Default value: 'CNOT', use 'RX' for the ``RX(pi/2)`` gate instead.
 
     Returns:
         qibo.models.circuit.Circuit: The circuit with the inserted CNOT pairs.

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -123,7 +123,7 @@ def ZNE(
                 noisy_circuit, backend, noise_model, nshots, readout["ncircuits"]
             )
         else:
-            if noise_model != None and backend.name != "qibolab":
+            if noise_model is not None and backend.name != "qibolab":
                 noisy_circuit = noise_model.apply(noisy_circuit)
             circuit_result = backend.execute_circuit(noisy_circuit, nshots=nshots)
         if "calibration_matrix" in readout.keys() is not None:
@@ -259,7 +259,7 @@ def CDR(
                 c, backend, noise_model, nshots, readout["ncircuits"]
             )
         else:
-            if noise_model != None and backend.name != "qibolab":
+            if noise_model is not None and backend.name != "qibolab":
                 c = noise_model.apply(c)
             circuit_result = backend.execute_circuit(c, nshots=nshots)
         if "calibration_matrix" in readout.keys() is not None:
@@ -278,7 +278,7 @@ def CDR(
             circuit, backend, noise_model, nshots, readout["ncircuits"]
         )
     else:
-        if noise_model != None and backend.name != "qibolab":
+        if noise_model is not None and backend.name != "qibolab":
             noisy_circuit = noise_model.apply(circuit)
         circuit_result = backend.execute_circuit(noisy_circuit, nshots=nshots)
     if "calibration_matrix" in readout.keys() is not None:
@@ -352,7 +352,7 @@ def vnCDR(
                     noisy_c, backend, noise_model, nshots, readout["ncircuits"]
                 )
             else:
-                if noise_model != None and backend.name != "qibolab":
+                if noise_model is not None and backend.name != "qibolab":
                     noisy_c = noise_model.apply(noisy_c)
                 circuit_result = backend.execute_circuit(noisy_c, nshots=nshots)
             if "calibration_matrix" in readout.keys():
@@ -377,7 +377,7 @@ def vnCDR(
                 noisy_c, backend, noise_model, nshots, readout["ncircuits"]
             )
         else:
-            if noise_model != None and backend.name != "qibolab":
+            if noise_model is not None and backend.name != "qibolab":
                 noisy_c = noise_model.apply(noisy_c)
             circuit_result = backend.execute_circuit(noisy_c, nshots=nshots)
         if "calibration_matrix" in readout.keys():
@@ -416,7 +416,7 @@ def get_calibration_matrix(nqubits, backend=None, noise_model=None, nshots=1000)
 
     matrix = np.zeros((2**nqubits, 2**nqubits))
 
-    string = "{0:0" + str(nqubits) + "b}"
+    string = f"{0:0{nqubits}b}"
     for i in range(2**nqubits):
         state = string.format(i)
         circuit = Circuit(nqubits, density_matrix=True)
@@ -424,7 +424,7 @@ def get_calibration_matrix(nqubits, backend=None, noise_model=None, nshots=1000)
             if bit == "1":
                 circuit.add(gates.X(q))
         circuit.add(gates.M(*range(nqubits)))
-        if noise_model != None and backend.name != "qibolab":
+        if noise_model is not None and backend.name != "qibolab":
             circuit = noise_model.apply(circuit)
         freq = backend.execute_circuit(circuit, nshots=nshots).frequencies()
         column = np.zeros(2**nqubits)
@@ -454,7 +454,7 @@ def apply_readout_mitigation(state, calibration_matrix):
     return state
 
 
-def apply_temme_readout_mitigation(
+def apply_randomized_readout_mitigation(
     circuit, backend=None, noise_model=None, nshots=1000, ncircuits=10
 ):
     """Implements the readout mitigation method proposed in https://arxiv.org/abs/2012.09738.

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -412,7 +412,7 @@ def apply_readout_mitigation(state, calibration_matrix):
     Returns:
         qibo.states.CircuitResult : The input state with the updated frequencies.
     """
-    freq = np.zeros(state.nqubits)
+    freq = np.zeros(2**state.nqubits)
     for k, v in state.frequencies().items():
         f = v / state.nshots
         freq[int(k, 2)] = f

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -461,7 +461,7 @@ def vnCDR(
     return mit_val
 
 
-def get_calibration_matrix(nqubits, noise_model=None, nshots: int = 1000, backend=None):
+def calibration_matrix(nqubits, noise_model=None, nshots: int = 1000, backend=None):
     """Computes the calibration matrix for readout mitigation.
 
     Args:

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -67,7 +67,7 @@ cal_matrix_3q = random_stochastic_matrix(
             3,
             get_noise_model(DepolarizingError(0.1), gates.CNOT),
             "CNOT",
-            {"calibration_matrix": np.eye(8)},
+            {"calibration_matrix": cal_matrix_3q},
         ),
         (
             3,
@@ -78,9 +78,9 @@ cal_matrix_3q = random_stochastic_matrix(
         (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", {}),
         (
             1,
-            get_noise_model(DepolarizingError(0.1), gates.RX),
+            get_noise_model(DepolarizingError(0.3), gates.RX),
             "RX",
-            {"calibration_matrix": np.eye(2)},
+            {"calibration_matrix": cal_matrix_1q},
         ),
         (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", {"ncircuits": 2}),
     ],

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -22,17 +22,7 @@ def get_noise_model(error, gate):
     return noise
 
 
-@pytest.mark.parametrize(
-    "nqubits,noise,insertion_gate",
-    [
-        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT"),
-        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX"),
-    ],
-)
-@pytest.mark.parametrize("solve", [False, True])
-def test_zne(backend, nqubits, noise, solve, insertion_gate):
-    """Test that ZNE reduces the noise."""
-    backend.set_threads(1)
+def get_circuit(nqubits, p=None):
     # Define the circuit
     hz = 0.5
     hx = 0.5
@@ -49,14 +39,41 @@ def test_zne(backend, nqubits, noise, solve, insertion_gate):
     c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
     c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(1, nqubits, 2))
     c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.M(q) for q in range(nqubits))
+    c.add(gates.M(q, p0=p) for q in range(nqubits))
+    return c
+
+
+# Precompute the calibration matrices
+p0 = 0.2
+cal_matrix_1q = get_calibration_matrix(nqubits=1, nshots=10000, p0=p0)
+cal_matrix_3q = get_calibration_matrix(nqubits=3, nshots=10000, p0=p0)
+
+
+@pytest.mark.parametrize(
+    "nqubits,noise,insertion_gate,calibration_matrix",
+    [
+        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", None),
+        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", cal_matrix_3q),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", None),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", cal_matrix_1q),
+    ],
+)
+@pytest.mark.parametrize("solve", [False, True])
+def test_zne(backend, nqubits, noise, solve, insertion_gate, calibration_matrix):
+    """Test that ZNE reduces the noise."""
+    backend.set_threads(1)
+    # Define the circuit
+    c = get_circuit(nqubits)
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])
     obs = SymbolicHamiltonian(obs, backend=backend)
     # Noise-free expected value
     exact = obs.expectation(backend.execute_circuit(c).state())
     # Noisy expected value without mitigation
-    noisy = obs.expectation(backend.execute_circuit(noise.apply(c)).state())
+    if calibration_matrix is not None:
+        c = get_circuit(nqubits, p=p0)
+    state = backend.execute_circuit(noise.apply(c), nshots=10000)
+    noisy = state.expectation_from_samples(obs)
     # Mitigated expected value
     estimate = ZNE(
         circuit=c,
@@ -67,6 +84,7 @@ def test_zne(backend, nqubits, noise, solve, insertion_gate):
         nshots=10000,
         solve_for_gammas=solve,
         insertion_gate=insertion_gate,
+        calibration_matrix=calibration_matrix,
     )
     assert np.abs(exact - estimate) <= np.abs(exact - noisy)
 
@@ -77,33 +95,22 @@ def test_zne(backend, nqubits, noise, solve, insertion_gate):
     [get_noise_model(DepolarizingError(0.1), gates.CNOT)],
 )
 @pytest.mark.parametrize("full_output", [False, True])
-def test_cdr(backend, nqubits, noise, full_output):
+@pytest.mark.parametrize("calibration_matrix", [None, cal_matrix_3q])
+def test_cdr(backend, nqubits, noise, full_output, calibration_matrix):
     backend.set_threads(1)
     """Test that CDR reduces the noise."""
     # Define the circuit
-    hz = 0.5
-    hx = 0.5
-    dt = 0.25
-    c = Circuit(nqubits, density_matrix=True)
-    c.add(gates.RZ(q, theta=-2 * hz * dt - np.pi / 2) for q in range(nqubits))
-    c.add(gates.RX(q, theta=np.pi / 2) for q in range(nqubits))
-    c.add(gates.RZ(q, theta=-2 * hx * dt + np.pi) for q in range(nqubits))
-    c.add(gates.RX(q, theta=np.pi / 2) for q in range(nqubits))
-    c.add(gates.RZ(q, theta=-np.pi / 2) for q in range(nqubits))
-    c.add(gates.CNOT(q, q + 1) for q in range(0, nqubits - 1, 2))
-    c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(0, nqubits - 1, 2))
-    c.add(gates.CNOT(q, q + 1) for q in range(0, nqubits - 1, 2))
-    c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(1, nqubits, 2))
-    c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.M(q) for q in range(nqubits))
+    c = get_circuit(nqubits)
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])
     obs = SymbolicHamiltonian(obs, backend=backend)
     # Noise-free expected value
     exact = obs.expectation(backend.execute_circuit(c).state())
     # Noisy expected value without mitigation
-    noisy = obs.expectation(backend.execute_circuit(noise.apply(c)).state())
+    if calibration_matrix is not None:
+        c = get_circuit(nqubits, p=p0)
+    state = backend.execute_circuit(noise.apply(c), nshots=10000)
+    noisy = state.expectation_from_samples(obs)
     # Mitigated expected value
     estimate = CDR(
         circuit=c,
@@ -111,6 +118,7 @@ def test_cdr(backend, nqubits, noise, full_output):
         backend=backend,
         noise_model=noise,
         nshots=10000,
+        calibration_matrix=calibration_matrix,
         full_output=full_output,
     )
     if full_output:
@@ -142,40 +150,32 @@ def test_sample_training_circuit(nqubits):
 
 
 @pytest.mark.parametrize(
-    "nqubits,noise,insertion_gate",
+    "nqubits,noise,insertion_gate,calibration_matrix",
     [
-        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT"),
-        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX"),
+        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", None),
+        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", cal_matrix_3q),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", None),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", cal_matrix_1q),
     ],
 )
 @pytest.mark.parametrize("full_output", [False, True])
-def test_vncdr(backend, nqubits, noise, full_output, insertion_gate):
+def test_vncdr(
+    backend, nqubits, noise, full_output, insertion_gate, calibration_matrix
+):
     """Test that vnCDR reduces the noise."""
     backend.set_threads(1)
     # Define the circuit
-    hz = 0.5
-    hx = 0.5
-    dt = 0.25
-    c = Circuit(nqubits, density_matrix=True)
-    c.add(gates.RZ(q, theta=-2 * hz * dt - np.pi / 2) for q in range(nqubits))
-    c.add(gates.RX(q, theta=np.pi / 2) for q in range(nqubits))
-    c.add(gates.RZ(q, theta=-2 * hx * dt + np.pi) for q in range(nqubits))
-    c.add(gates.RX(q, theta=np.pi / 2) for q in range(nqubits))
-    c.add(gates.RZ(q, theta=-np.pi / 2) for q in range(nqubits))
-    c.add(gates.CNOT(q, q + 1) for q in range(0, nqubits - 1, 2))
-    c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(0, nqubits - 1, 2))
-    c.add(gates.CNOT(q, q + 1) for q in range(0, nqubits - 1, 2))
-    c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(1, nqubits, 2))
-    c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.M(q) for q in range(nqubits))
+    c = get_circuit(nqubits)
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])
     obs = SymbolicHamiltonian(obs, backend=backend)
     # Noise-free expected value
     exact = obs.expectation(backend.execute_circuit(c).state())
     # Noisy expected value without mitigation
-    noisy = obs.expectation(backend.execute_circuit(noise.apply(c)).state())
+    if calibration_matrix is not None:
+        c = get_circuit(nqubits, p=p0)
+    state = backend.execute_circuit(noise.apply(c), nshots=10000)
+    noisy = state.expectation_from_samples(obs)
     # Mitigated expected value
     estimate = vnCDR(
         circuit=c,
@@ -186,16 +186,17 @@ def test_vncdr(backend, nqubits, noise, full_output, insertion_gate):
         nshots=10000,
         insertion_gate=insertion_gate,
         full_output=full_output,
+        calibration_matrix=calibration_matrix,
     )
     if full_output:
         estimate = estimate[0]
     assert np.abs(exact - estimate) <= np.abs(exact - noisy)
 
 
-def test_readout_mitigation(backend):
+@pytest.mark.parametrize("nqubits", [3])
+def test_readout_mitigation(backend, nqubits):
     backend.set_threads(1)
-    nqubits = 3
-    nshots = 1000
+    nshots = 10000
     p0 = [0.1, 0.2, 0.3]
     p1 = [0.3, 0.1, 0.2]
     calibration_matrix = get_calibration_matrix(nqubits, nshots=nshots, p0=p0, p1=p1)

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -7,8 +7,8 @@ from qibo.models import Circuit
 from qibo.models.error_mitigation import (
     CDR,
     ZNE,
+    apply_randomized_readout_mitigation,
     apply_readout_mitigation,
-    apply_temme_readout_mitigation,
     get_calibration_matrix,
     sample_training_circuit,
     vnCDR,
@@ -302,7 +302,7 @@ def test_readout_mitigation(backend, nqubits, method):
         mit_val = mit_state.expectation_from_samples(obs)
     elif method == "temme":
         ncircuits = 10
-        result, result_cal = apply_temme_readout_mitigation(
+        result, result_cal = apply_randomized_readout_mitigation(
             c, backend, noise, nshots, ncircuits
         )
         mit_val = result.expectation_from_samples(

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -109,13 +109,13 @@ def test_zne(backend, nqubits, noise, solve, insertion_gate, readout):
     estimate = ZNE(
         circuit=c,
         observable=obs,
-        backend=backend,
         noise_levels=np.array(range(4)),
         noise_model=noise,
         nshots=10000,
         solve_for_gammas=solve,
         insertion_gate=insertion_gate,
         readout=readout,
+        backend=backend,
     )
     assert np.abs(exact - estimate) <= np.abs(exact - noisy)
 
@@ -159,12 +159,12 @@ def test_cdr(backend, nqubits, noise, full_output, readout):
     estimate = CDR(
         circuit=c,
         observable=obs,
-        backend=backend,
         noise_model=noise,
         nshots=10000,
         n_training_samples=20,
-        readout=readout,
         full_output=full_output,
+        readout=readout,
+        backend=backend,
     )
     if full_output:
         estimate = estimate[0]
@@ -285,7 +285,7 @@ def test_readout_mitigation(backend, nqubits, method):
     noise.add(ReadoutError(probabilities=p), gate=gates.M)
     if method == "cal_matrix":
         calibration_matrix = get_calibration_matrix(
-            nqubits, backend, noise, nshots=nshots
+            nqubits, noise, nshots=nshots, backend=backend
         )
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])
@@ -303,7 +303,7 @@ def test_readout_mitigation(backend, nqubits, method):
     elif method == "temme":
         ncircuits = 10
         result, result_cal = apply_randomized_readout_mitigation(
-            c, backend, noise, nshots, ncircuits
+            c, noise, nshots, ncircuits, backend
         )
         mit_val = result.expectation_from_samples(
             obs

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -8,17 +8,21 @@ from qibo.models.error_mitigation import (
     CDR,
     ZNE,
     apply_readout_mitigation,
+    apply_temme_readout_mitigation,
     get_calibration_matrix,
     sample_training_circuit,
     vnCDR,
 )
-from qibo.noise import DepolarizingError, NoiseModel
+from qibo.noise import DepolarizingError, NoiseModel, ReadoutError
+from qibo.quantum_info import random_stochastic_matrix
 from qibo.symbols import Z
 
 
-def get_noise_model(error, gate):
+def get_noise_model(error, gate, cal_matrix=[False, None]):
     noise = NoiseModel()
     noise.add(error, gate)
+    if cal_matrix[0]:
+        noise.add(ReadoutError(probabilities=cal_matrix[1]), gate=gates.M)
     return noise
 
 
@@ -39,29 +43,58 @@ def get_circuit(nqubits, p=None):
     c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
     c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(1, nqubits, 2))
     c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.M(q, p0=p) for q in range(nqubits))
+    c.add(gates.M(*range(nqubits), p0=p))
     return c
 
 
-# Precompute the calibration matrices
-p0 = 0.2
-cal_matrix_1q = get_calibration_matrix(nqubits=1, nshots=10000, p0=p0)
-cal_matrix_3q = get_calibration_matrix(nqubits=3, nshots=10000, p0=p0)
+from qibo.backends import construct_backend
+
+backend = construct_backend("numpy")
+# # Precompute the calibration matrices
+cal_matrix_1q = random_stochastic_matrix(
+    2, diagonally_dominant=True, seed=2, backend=backend
+)
+cal_matrix_3q = random_stochastic_matrix(
+    8, diagonally_dominant=True, seed=2, backend=backend
+)
 
 
 @pytest.mark.parametrize(
-    "nqubits,noise,insertion_gate,calibration_matrix",
+    "nqubits,noise,insertion_gate,readout",
     [
-        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", None),
-        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", cal_matrix_3q),
-        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", None),
-        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", cal_matrix_1q),
+        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", {}),
+        (
+            3,
+            get_noise_model(DepolarizingError(0.1), gates.CNOT),
+            "CNOT",
+            {"calibration_matrix": np.eye(8)},
+        ),
+        (
+            3,
+            get_noise_model(DepolarizingError(0.1), gates.CNOT),
+            "CNOT",
+            {"ncircuits": 2},
+        ),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", {}),
+        (
+            1,
+            get_noise_model(DepolarizingError(0.1), gates.RX),
+            "RX",
+            {"calibration_matrix": np.eye(2)},
+        ),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", {"ncircuits": 2}),
     ],
 )
 @pytest.mark.parametrize("solve", [False, True])
-def test_zne(backend, nqubits, noise, solve, insertion_gate, calibration_matrix):
+def test_zne(backend, nqubits, noise, solve, insertion_gate, readout):
     """Test that ZNE reduces the noise."""
-    backend.set_threads(1)
+    if backend.name == "tensorflow":
+        import tensorflow as tf
+
+        tf.config.threading.set_inter_op_parallelism_threads = 1
+        tf.config.threading.set_intra_op_parallelism_threads = 1
+    else:
+        backend.set_threads(1)
     # Define the circuit
     c = get_circuit(nqubits)
     # Define the observable
@@ -70,8 +103,6 @@ def test_zne(backend, nqubits, noise, solve, insertion_gate, calibration_matrix)
     # Noise-free expected value
     exact = obs.expectation(backend.execute_circuit(c).state())
     # Noisy expected value without mitigation
-    if calibration_matrix is not None:
-        c = get_circuit(nqubits, p=p0)
     state = backend.execute_circuit(noise.apply(c), nshots=10000)
     noisy = state.expectation_from_samples(obs)
     # Mitigated expected value
@@ -79,25 +110,40 @@ def test_zne(backend, nqubits, noise, solve, insertion_gate, calibration_matrix)
         circuit=c,
         observable=obs,
         backend=backend,
-        noise_levels=np.array(range(5)),
+        noise_levels=np.array(range(4)),
         noise_model=noise,
         nshots=10000,
         solve_for_gammas=solve,
         insertion_gate=insertion_gate,
-        calibration_matrix=calibration_matrix,
+        readout=readout,
     )
     assert np.abs(exact - estimate) <= np.abs(exact - noisy)
 
 
 @pytest.mark.parametrize("nqubits", [3])
-@pytest.mark.parametrize(
-    "noise",
-    [get_noise_model(DepolarizingError(0.1), gates.CNOT)],
-)
 @pytest.mark.parametrize("full_output", [False, True])
-@pytest.mark.parametrize("calibration_matrix", [None, cal_matrix_3q])
-def test_cdr(backend, nqubits, noise, full_output, calibration_matrix):
-    backend.set_threads(1)
+@pytest.mark.parametrize(
+    "noise,readout",
+    [
+        (get_noise_model(DepolarizingError(0.1), gates.CNOT), {}),
+        (
+            get_noise_model(DepolarizingError(0.1), gates.CNOT, [True, cal_matrix_3q]),
+            {"calibration_matrix": cal_matrix_3q},
+        ),
+        (
+            get_noise_model(DepolarizingError(0.1), gates.CNOT, [True, cal_matrix_3q]),
+            {"ncircuits": 2},
+        ),
+    ],
+)
+def test_cdr(backend, nqubits, noise, full_output, readout):
+    if backend.name == "tensorflow":
+        import tensorflow as tf
+
+        tf.config.threading.set_inter_op_parallelism_threads = 1
+        tf.config.threading.set_intra_op_parallelism_threads = 1
+    else:
+        backend.set_threads(1)
     """Test that CDR reduces the noise."""
     # Define the circuit
     c = get_circuit(nqubits)
@@ -107,8 +153,6 @@ def test_cdr(backend, nqubits, noise, full_output, calibration_matrix):
     # Noise-free expected value
     exact = obs.expectation(backend.execute_circuit(c).state())
     # Noisy expected value without mitigation
-    if calibration_matrix is not None:
-        c = get_circuit(nqubits, p=p0)
     state = backend.execute_circuit(noise.apply(c), nshots=10000)
     noisy = state.expectation_from_samples(obs)
     # Mitigated expected value
@@ -118,7 +162,8 @@ def test_cdr(backend, nqubits, noise, full_output, calibration_matrix):
         backend=backend,
         noise_model=noise,
         nshots=10000,
-        calibration_matrix=calibration_matrix,
+        n_training_samples=20,
+        readout=readout,
         full_output=full_output,
     )
     if full_output:
@@ -150,20 +195,46 @@ def test_sample_training_circuit(nqubits):
 
 
 @pytest.mark.parametrize(
-    "nqubits,noise,insertion_gate,calibration_matrix",
+    "nqubits,noise,insertion_gate,readout",
     [
-        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", None),
-        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", cal_matrix_3q),
-        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", None),
-        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", cal_matrix_1q),
+        (3, get_noise_model(DepolarizingError(0.1), gates.CNOT), "CNOT", {}),
+        (
+            3,
+            get_noise_model(DepolarizingError(0.1), gates.CNOT, [True, cal_matrix_3q]),
+            "CNOT",
+            {"calibration_matrix": cal_matrix_3q},
+        ),
+        (
+            3,
+            get_noise_model(DepolarizingError(0.1), gates.CNOT, [True, cal_matrix_3q]),
+            "CNOT",
+            {"ncircuits": 2},
+        ),
+        (1, get_noise_model(DepolarizingError(0.1), gates.RX), "RX", {}),
+        (
+            1,
+            get_noise_model(DepolarizingError(0.1), gates.RX, [True, cal_matrix_1q]),
+            "RX",
+            {"calibration_matrix": cal_matrix_1q},
+        ),
+        (
+            1,
+            get_noise_model(DepolarizingError(0.1), gates.RX, [True, cal_matrix_1q]),
+            "RX",
+            {"ncircuits": 2},
+        ),
     ],
 )
 @pytest.mark.parametrize("full_output", [False, True])
-def test_vncdr(
-    backend, nqubits, noise, full_output, insertion_gate, calibration_matrix
-):
+def test_vncdr(backend, nqubits, noise, full_output, insertion_gate, readout):
     """Test that vnCDR reduces the noise."""
-    backend.set_threads(1)
+    if backend.name == "tensorflow":
+        import tensorflow as tf
+
+        tf.config.threading.set_inter_op_parallelism_threads = 1
+        tf.config.threading.set_intra_op_parallelism_threads = 1
+    else:
+        backend.set_threads(1)
     # Define the circuit
     c = get_circuit(nqubits)
     # Define the observable
@@ -172,8 +243,12 @@ def test_vncdr(
     # Noise-free expected value
     exact = obs.expectation(backend.execute_circuit(c).state())
     # Noisy expected value without mitigation
-    if calibration_matrix is not None:
-        c = get_circuit(nqubits, p=p0)
+    if "calibration_matrix" in readout.keys() or "ncircuits" in readout.keys():
+        if nqubits == 1:
+            p = cal_matrix_1q
+        elif nqubits == 3:
+            p = cal_matrix_3q
+        # noise.add(ReadoutError(probabilities=p),gate=gates.M)
     state = backend.execute_circuit(noise.apply(c), nshots=10000)
     noisy = state.expectation_from_samples(obs)
     # Mitigated expected value
@@ -184,9 +259,10 @@ def test_vncdr(
         noise_levels=range(3),
         noise_model=noise,
         nshots=10000,
+        n_training_samples=20,
         insertion_gate=insertion_gate,
         full_output=full_output,
-        calibration_matrix=calibration_matrix,
+        readout=readout,
     )
     if full_output:
         estimate = estimate[0]
@@ -194,27 +270,42 @@ def test_vncdr(
 
 
 @pytest.mark.parametrize("nqubits", [3])
-def test_readout_mitigation(backend, nqubits):
-    backend.set_threads(1)
+@pytest.mark.parametrize("method", ["cal_matrix", "temme"])
+def test_readout_mitigation(backend, nqubits, method):
+    if backend.name == "tensorflow":
+        import tensorflow as tf
+
+        tf.config.threading.set_inter_op_parallelism_threads = 1
+        tf.config.threading.set_intra_op_parallelism_threads = 1
+    else:
+        backend.set_threads(1)
     nshots = 10000
-    p0 = [0.1, 0.2, 0.3]
-    p1 = [0.3, 0.1, 0.2]
-    calibration_matrix = get_calibration_matrix(nqubits, nshots=nshots, p0=p0, p1=p1)
+    p = random_stochastic_matrix(2**nqubits, diagonally_dominant=True, seed=5)
+    noise = NoiseModel()
+    noise.add(ReadoutError(probabilities=p), gate=gates.M)
+    if method == "cal_matrix":
+        calibration_matrix = get_calibration_matrix(
+            nqubits, noise, backend, nshots=nshots
+        )
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])
     obs = SymbolicHamiltonian(obs, backend=backend)
     # get noise free expected val
-    c = Circuit(nqubits)
-    c.add(gates.X(0))
-    c.add(gates.M(*range(nqubits)))
+    c = get_circuit(nqubits)
     true_state = backend.execute_circuit(c, nshots=nshots)
     true_val = true_state.expectation_from_samples(obs)
     # get noisy expected val
-    c = Circuit(nqubits)
-    c.add(gates.X(0))
-    c.add(gates.M(*range(nqubits), p0=p0, p1=p1))
-    state = backend.execute_circuit(c, nshots=nshots)
+    state = backend.execute_circuit(noise.apply(c), nshots=nshots)
     noisy_val = state.expectation_from_samples(obs)
-    mit_state = apply_readout_mitigation(state, calibration_matrix)
-    mit_val = mit_state.expectation_from_samples(obs)
+    if method == "cal_matrix":
+        mit_state = apply_readout_mitigation(state, calibration_matrix)
+        mit_val = mit_state.expectation_from_samples(obs)
+    elif method == "temme":
+        ncircuits = 10
+        result, result_cal = apply_temme_readout_mitigation(
+            c, backend, noise, nshots, ncircuits
+        )
+        mit_val = result.expectation_from_samples(
+            obs
+        ) / result_cal.expectation_from_samples(obs)
     assert np.abs(true_val - mit_val) <= np.abs(true_val - noisy_val)

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -26,7 +26,7 @@ def get_noise_model(error, gate, cal_matrix=[False, None]):
     return noise
 
 
-def get_circuit(nqubits, p=None):
+def get_circuit(nqubits):
     # Define the circuit
     hz = 0.5
     hx = 0.5
@@ -43,14 +43,14 @@ def get_circuit(nqubits, p=None):
     c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
     c.add(gates.RZ(q + 1, theta=-2 * dt) for q in range(1, nqubits, 2))
     c.add(gates.CNOT(q, q + 1) for q in range(1, nqubits, 2))
-    c.add(gates.M(*range(nqubits), p0=p))
+    c.add(gates.M(*range(nqubits)))
     return c
 
 
 from qibo.backends import construct_backend
 
 backend = construct_backend("numpy")
-# # Precompute the calibration matrices
+# # Generate random calibration matrices
 cal_matrix_1q = random_stochastic_matrix(
     2, diagonally_dominant=True, seed=2, backend=backend
 )

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -9,7 +9,7 @@ from qibo.models.error_mitigation import (
     ZNE,
     apply_randomized_readout_mitigation,
     apply_readout_mitigation,
-    get_calibration_matrix,
+    calibration_matrix,
     sample_training_circuit,
     vnCDR,
 )
@@ -284,9 +284,7 @@ def test_readout_mitigation(backend, nqubits, method):
     noise = NoiseModel()
     noise.add(ReadoutError(probabilities=p), gate=gates.M)
     if method == "cal_matrix":
-        calibration_matrix = get_calibration_matrix(
-            nqubits, noise, nshots=nshots, backend=backend
-        )
+        calibration = calibration_matrix(nqubits, noise, nshots=nshots, backend=backend)
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])
     obs = SymbolicHamiltonian(obs, backend=backend)
@@ -298,7 +296,7 @@ def test_readout_mitigation(backend, nqubits, method):
     state = backend.execute_circuit(noise.apply(c), nshots=nshots)
     noisy_val = state.expectation_from_samples(obs)
     if method == "cal_matrix":
-        mit_state = apply_readout_mitigation(state, calibration_matrix)
+        mit_state = apply_readout_mitigation(state, calibration)
         mit_val = mit_state.expectation_from_samples(obs)
     elif method == "temme":
         ncircuits = 10

--- a/tests/test_models_error_mitigation.py
+++ b/tests/test_models_error_mitigation.py
@@ -285,7 +285,7 @@ def test_readout_mitigation(backend, nqubits, method):
     noise.add(ReadoutError(probabilities=p), gate=gates.M)
     if method == "cal_matrix":
         calibration_matrix = get_calibration_matrix(
-            nqubits, noise, backend, nshots=nshots
+            nqubits, backend, noise, nshots=nshots
         )
     # Define the observable
     obs = np.prod([Z(i) for i in range(nqubits)])


### PR DESCRIPTION
This PR implements two methods to mitigate readout errors. 
The first method involves estimating the columns of the calibration matrix by measuring the output frequencies  for all posible bit strings, and then applying its inverse to mitigate the noise.
The second method randomizes the circuit in such a way that it diagonalizes the measurement channel. This means that now the effect of readout noise on the expected value of a Pauli observable is a multiplicative factor.

An option to apply readout mitigation is added to all the error mitigation methods currently implemented.


Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
