### PR TITLE
Identity inherits `Gate`

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -104,7 +104,8 @@ class NumpyBackend(Backend):
     def asmatrix(self, gate):
         """Convert a gate to its matrix representation in the computational basis."""
         name = gate.__class__.__name__
-        return getattr(self.matrices, name)
+        matrix = getattr(self.matrices, name)
+        return matrix(2 ** len(gate.target_qubits)) if callable(matrix) else matrix
 
     def asmatrix_parametrized(self, gate):
         """Convert a parametrized gate to its matrix representation in the computational basis."""

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -303,7 +303,7 @@ class TDG(Gate):
         return T(*self.init_args)
 
 
-class I(ParametrizedGate):
+class I(Gate):
     """The identity gate.
 
     Args:
@@ -316,25 +316,19 @@ class I(ParametrizedGate):
         self.draw_label = "I"
         self.target_qubits = tuple(q)
         self.init_args = q
-        # save the number of target qubits as parameter
-        # for proper identity matrix construction
-        self.parameters = 2 ** len(self.target_qubits)
 
     @property
     def qasm_label(self):
         return "id"
 
 
-class Align(ParametrizedGate):
+class Align(Gate):
     def __init__(self, *q):
         super().__init__()
         self.name = "align"
         self.draw_label = "A"
         self.target_qubits = tuple(q)
         self.init_args = q
-        # save the number of target qubits as parameter
-        # for proper identity matrix construction
-        self.parameters = 2 ** len(self.target_qubits)
 
 
 class _Rn_(ParametrizedGate):


### PR DESCRIPTION
This PR changes `qibo.gates.I` and `qibo.gates.Align`to inherit `Gate` instead of `ParametrizedGate`.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
