### PR TITLE
Revert changes to `DepolarizingChannel`

### DIFF
--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -439,7 +439,7 @@ class PauliNoiseChannel(UnitaryChannel):
         self.init_kwargs = dict(operators)
 
 
-class DepolarizingChannel(Channel):
+class DepolarizingChannel(PauliNoiseChannel):
     """:math:`n`-qubit Depolarizing quantum error channel,
 
     .. math::
@@ -464,7 +464,6 @@ class DepolarizingChannel(Channel):
         if isinstance(qubits, int) is True:
             qubits = (qubits,)
 
-        super().__init__()
         num_qubits = len(qubits)
         num_terms = 4**num_qubits
         max_param = num_terms / (num_terms - 1)
@@ -473,6 +472,12 @@ class DepolarizingChannel(Channel):
                 ValueError,
                 f"Depolarizing parameter must be in between 0 and {max_param}.",
             )
+
+        pauli_noise_params = list(product(["I", "X", "Y", "Z"], repeat=num_qubits))[1::]
+        pauli_noise_params = zip(
+            pauli_noise_params, [lam / num_terms] * (num_terms - 1)
+        )
+        super().__init__(qubits, pauli_noise_params)
 
         self.name = "DepolarizingChannel"
         self.draw_label = "D"
@@ -483,22 +488,6 @@ class DepolarizingChannel(Channel):
 
     def apply_density_matrix(self, backend, state, nqubits):
         return backend.depolarizing_error_density_matrix(self, state, nqubits)
-
-    def apply(self, backend, state, nqubits):
-        num_qubits = len(self.target_qubits)
-        num_terms = 4**num_qubits
-        prob_pauli = self.init_kwargs["lam"] / num_terms
-        probs = (num_terms - 1) * [prob_pauli]
-        gates = []
-        for pauli_list in list(product([I, X, Y, Z], repeat=num_qubits))[1::]:
-            fgate = FusedGate(*self.target_qubits)
-            for j, pauli in enumerate(pauli_list):
-                fgate.append(pauli(j))
-            gates.append(fgate)
-        self.gates = tuple(gates)
-        self.coefficients = tuple(probs)
-
-        return backend.apply_channel(self, state, nqubits)
 
 
 class ThermalRelaxationChannel(KrausChannel):

--- a/tests/test_gates_channels.py
+++ b/tests/test_gates_channels.py
@@ -207,7 +207,7 @@ def test_pauli_noise_channel(backend):
     test_representation = np.diag([a0, a1, a2, a3])
 
     liouville = gates.PauliNoiseChannel(0, list(zip(basis, pnp))).to_pauli_liouville(
-        True, backend
+        normalize=True, backend=backend
     )
     norm = backend.calculate_norm(backend.to_numpy(liouville) - test_representation)
 


### PR DESCRIPTION
Somehow #890 reverted the changes implemented by #889 and we didn't notice. This PR reimplement those changes.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
