### PR TITLE
Rename `Circuit.with_noise` method as `Circuit.with_pauli_noise`

### DIFF
--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -931,7 +931,7 @@ Adding noise after every gate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In practical applications noise typically occurs after every gate.
-Qibo provides the :meth:`qibo.models.circuit.Circuit.with_noise` method
+Qibo provides the :meth:`qibo.models.circuit.Circuit.with_pauli_noise` method
 which automatically creates a new circuit that contains a
 :class:`qibo.gates.PauliNoiseChannel` after every gate.
 The user can control the probabilities of the noise channel using a noise map,
@@ -947,7 +947,7 @@ triplets. For example, the following script
 
       # Define a noise map that maps qubit IDs to noise probabilities
       noise_map = {0: list(zip(["X", "Z"], [0.1, 0.2])), 1: list(zip(["Y", "Z"], [0.2, 0.1]))}
-      noisy_c = c.with_noise(noise_map)
+      noisy_c = c.with_pauli_noise(noise_map)
 
 will create a new circuit ``noisy_c`` that is equivalent to:
 
@@ -972,11 +972,11 @@ That is ``noise_map = list(zip(["X", "Z"], [0.1, 0.1]))`` is equivalent to
 ``noise_map = {0: list(zip(["X", "Z"], [0.1, 0.1])), 1: list(zip(["X", "Z"], [0.1, 0.1])), ...}``.
 
 As described in the previous sections, if
-:meth:`qibo.models.circuit.Circuit.with_noise` is used in a circuit
+:meth:`qibo.models.circuit.Circuit.with_pauli_noise` is used in a circuit
 that uses state vectors then noise will be simulated with repeated execution.
 If the user wishes to use density matrices instead, this is possible by
 passing the ``density_matrix=True`` flag during the circuit initialization and call
-``.with_noise`` on the new circuit.
+``.with_pauli_noise`` on the new circuit.
 
 .. _noisemodel-example:
 

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -438,13 +438,13 @@ class Circuit:
             decomp_circuit.add(gate.decompose(*free))
         return decomp_circuit
 
-    def with_noise(self, noise_map: NoiseMapType):
-        """Creates a copy of the circuit with noise gates after each gate.
+    def with_pauli_noise(self, noise_map: NoiseMapType):
+        """Creates a copy of the circuit with Pauli noise gates after each gate.
 
         If the original circuit uses state vectors then noise simulation will
         be done using sampling and repeated circuit execution.
         In order to use density matrices the original circuit should be created
-        using the ``density_matrix`` flag set to ``True``.
+        setting  the flag ``density_matrix=True``.
         For more information we refer to the
         :ref:`How to perform noisy simulation? <noisy-example>` example.
 
@@ -470,7 +470,7 @@ class Circuit:
                     0: list(zip(["X", "Z"], [0.1, 0.2])),
                     1: list(zip(["Y", "Z"], [0.2, 0.1]))
                 }
-                noisy_c = c.with_noise(noise_map)
+                noisy_c = c.with_pauli_noise(noise_map)
                 # ``noisy_c`` will be equivalent to the following circuit
                 c2 = Circuit(2, density_matrix=True)
                 c2.add(gates.H(0))
@@ -494,7 +494,7 @@ class Circuit:
             if isinstance(gate, gates.KrausChannel):
                 raise_error(
                     ValueError,
-                    "`.with_noise` method is not available "
+                    "`.with_pauli_noise` method is not available "
                     + "for circuits that already contain "
                     + "channels.",
                 )

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -441,17 +441,17 @@ def test_circuit_decompose(measurements):
         {0: list(zip(["X", "Z"], [0.1, 0.2])), 1: list(zip(["Y", "Z"], [0.2, 0.1]))},
     ],
 )
-def test_circuit_with_noise(measurements, noise_map):
+def test_circuit_with_pauli_noise(measurements, noise_map):
     with pytest.raises(TypeError):
         n_map = ["X", 0.2]
         circuit = Circuit(1)
-        circuit.with_noise(n_map)
+        circuit.with_pauli_noise(n_map)
 
     c = Circuit(2)
     c.add([gates.H(0), gates.H(1), gates.CNOT(0, 1)])
     if measurements:
         c.add(gates.M(0, 1))
-    noisyc = c.with_noise(noise_map)
+    noisyc = c.with_pauli_noise(noise_map)
 
     if not isinstance(noise_map, dict):
         noise_map = {0: noise_map, 1: noise_map}

--- a/tests/test_models_circuit_features.py
+++ b/tests/test_models_circuit_features.py
@@ -295,11 +295,11 @@ def test_repeated_execute_pauli_noise_channel(backend):
     backend.assert_allclose(final_state, target_state)
 
 
-def test_repeated_execute_with_noise(backend):
+def test_repeated_execute_with_pauli_noise(backend):
     thetas = np.random.random(4)
     c = Circuit(4)
     c.add((gates.RY(i, t) for i, t in enumerate(thetas)))
-    noisy_c = c.with_noise(list(zip(["X", "Z"], [0.2, 0.1])))
+    noisy_c = c.with_pauli_noise(list(zip(["X", "Z"], [0.2, 0.1])))
     backend.set_seed(1234)
     final_state = backend.execute_circuit(noisy_c, nshots=20)
 

--- a/tests/test_models_circuit_noise.py
+++ b/tests/test_models_circuit_noise.py
@@ -40,20 +40,20 @@ def test_noisy_circuit_reexecution(backend):
     backend.assert_allclose(final_rho, final_rho2)
 
 
-def test_circuit_with_noise_gates():
+def test_circuit_with_pauli_noise_gates():
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1), gates.CNOT(0, 1)])
-    noisy_c = c.with_noise(list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.3])))
+    noisy_c = c.with_pauli_noise(list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.3])))
     assert noisy_c.depth == 4
     assert noisy_c.ngates == 7
     for i in [1, 3, 5, 6]:
         assert noisy_c.queue[i].__class__.__name__ == "PauliNoiseChannel"
 
 
-def test_circuit_with_noise_execution(backend):
+def test_circuit_with_pauli_noise_execution(backend):
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1)])
-    noisy_c = c.with_noise(list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.3])))
+    noisy_c = c.with_pauli_noise(list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.3])))
     final_state = backend.execute_circuit(noisy_c)
 
     target_c = Circuit(2, density_matrix=True)
@@ -69,11 +69,11 @@ def test_circuit_with_noise_execution(backend):
     backend.assert_allclose(final_state, target_state)
 
 
-def test_circuit_with_noise_measurements(backend):
+def test_circuit_with_pauli_noise_measurements(backend):
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1)])
     c.add(gates.M(0))
-    noisy_c = c.with_noise(list(zip(["X", "Y", "Z"], [0.1, 0.1, 0.1])))
+    noisy_c = c.with_pauli_noise(list(zip(["X", "Y", "Z"], [0.1, 0.1, 0.1])))
     final_state = backend.execute_circuit(noisy_c)
 
     target_c = Circuit(2, density_matrix=True)
@@ -89,7 +89,7 @@ def test_circuit_with_noise_measurements(backend):
     backend.assert_allclose(final_state, target_state)
 
 
-def test_circuit_with_noise_noise_map(backend):
+def test_circuit_with_pauli_noise_noise_map(backend):
     noise_map = {
         0: list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.1])),
         1: list(zip(["X", "Y", "Z"], [0.2, 0.3, 0.0])),
@@ -99,7 +99,7 @@ def test_circuit_with_noise_noise_map(backend):
     c = Circuit(3, density_matrix=True)
     c.add([gates.H(0), gates.H(1), gates.X(2)])
     c.add(gates.M(2))
-    noisy_c = c.with_noise(noise_map)
+    noisy_c = c.with_pauli_noise(noise_map)
     final_state = backend.execute_circuit(noisy_c)
 
     target_c = Circuit(3, density_matrix=True)
@@ -116,17 +116,17 @@ def test_circuit_with_noise_noise_map(backend):
     backend.assert_allclose(final_state, target_state)
 
 
-def test_circuit_with_noise_errors():
+def test_circuit_with_pauli_noise_errors():
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1), gates.PauliNoiseChannel(0, [("X", 0.2)])])
     with pytest.raises(ValueError):
-        noisy_c = c.with_noise(list(zip(["X", "Y"], [0.2, 0.3])))
+        noisy_c = c.with_pauli_noise(list(zip(["X", "Y"], [0.2, 0.3])))
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1)])
     with pytest.raises(ValueError):
-        noisy_c = c.with_noise({0: list(zip(["X", "Y", "Z"], [0.2, 0.3, 0.1]))})
+        noisy_c = c.with_pauli_noise({0: list(zip(["X", "Y", "Z"], [0.2, 0.3, 0.1]))})
     with pytest.raises(TypeError):
-        noisy_c = c.with_noise({0, 1})
+        noisy_c = c.with_pauli_noise({0, 1})
 
 
 def test_density_matrix_circuit_measurement(backend):

--- a/tests/test_models_distcircuit.py
+++ b/tests/test_models_distcircuit.py
@@ -40,9 +40,9 @@ def test_distributed_circuit_add_gate():
 def test_distributed_circuit_various_errors():
     devices = {"/GPU:0": 2, "/GPU:1": 2}
     c = Circuit(5, devices)
-    # Attempt to use ``.with_noise``
+    # Attempt to use ``.with_pauli_noise``
     with pytest.raises(NotImplementedError):
-        c.with_noise(list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.1])))
+        c.with_pauli_noise(list(zip(["X", "Y", "Z"], [0.1, 0.2, 0.1])))
     # Attempt to compile
     with pytest.raises(RuntimeError):
         c.compile()


### PR DESCRIPTION
Since the `Circuit.with_noise` method works exclusively with `PauliNoiseChannel`, the method is better named as `Circuit.with_pauli_noise` in order to not create any confusion about using the method with other noise channels.

This was discussed in #898.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
