### PR TITLE
Add delay pulse option to `Align` gate

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -462,6 +462,13 @@ Identity (I)
     :members:
     :member-order: bysource
 
+Align (A)
+"""""""""
+
+.. autoclass:: qibo.gates.Align
+    :members:
+    :member-order: bysource
+
 Measurement (M)
 """""""""""""""
 

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -462,7 +462,7 @@ class Align(Gate):
         delay (int): (optional) The time (in ns) for which to delay circuit execution on the specified qubits.
     """
 
-    def __init__(self, *q, delay=0):
+    def __init__(self, *q, delay: int = 0):
         super().__init__()
         self.name = "align"
         self.delay = delay

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -464,11 +464,12 @@ class Align(Gate):
     """
 
     def __init__(self, *q, delay: int = 0):
-        if delay < 0.0:
+        if not isinstance(delay, int):
             raise_error(
-                ValueError,
-                "Delay must not be negative.",
+                TypeError, f"delay must be type int, but it is type {type(delay)}."
             )
+        if delay < 0.0:
+            raise_error(ValueError, "Delay must not be negative.")
 
         super().__init__()
         self.name = "align"

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -455,12 +455,21 @@ class I(Gate):
 
 
 class Align(Gate):
-    def __init__(self, *q):
+    """Aligns proceeding qubit operations and (optionally) waits ``delay`` amount of time.
+
+    Args:
+        *q (int): The qubit ID numbers.
+        delay (int): (optional) The time (in ns) for which to delay circuit execution on the specified qubits.
+    """
+    def __init__(self, *q, delay=0):
         super().__init__()
         self.name = "align"
         self.draw_label = "A"
+        if delay != 0:
+            self.draw_label += f"({delay})"
+        self.init_kwargs = {"delay": delay}
         self.target_qubits = tuple(q)
-        self.init_args = q
+        self.init_args = (*q, delay)
 
 
 class _Rn_(ParametrizedGate):

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -465,12 +465,10 @@ class Align(Gate):
     def __init__(self, *q, delay=0):
         super().__init__()
         self.name = "align"
-        self.draw_label = "A"
-        if delay != 0:
-            self.draw_label += f"({delay})"
+        self.delay = delay
+        self.draw_label = f"A({delay})"
         self.init_kwargs = {"delay": delay}
         self.target_qubits = tuple(q)
-        self.init_args = (*q, delay)
 
 
 class _Rn_(ParametrizedGate):

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -464,6 +464,12 @@ class Align(Gate):
     """
 
     def __init__(self, *q, delay: int = 0):
+        if delay < 0.0:
+            raise_error(
+                ValueError,
+                "Delay must not be negative.",
+            )
+
         super().__init__()
         self.name = "align"
         self.delay = delay

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -460,7 +460,7 @@ class Align(Gate):
     Args:
         *q (int): The qubit ID numbers.
         delay (int, optional): The time (in ns) for which to delay circuit execution on the specified qubits.
-            Defaults to ``0`` (zero).        
+            Defaults to ``0`` (zero).
     """
 
     def __init__(self, *q, delay: int = 0):

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -461,6 +461,7 @@ class Align(Gate):
         *q (int): The qubit ID numbers.
         delay (int): (optional) The time (in ns) for which to delay circuit execution on the specified qubits.
     """
+
     def __init__(self, *q, delay=0):
         super().__init__()
         self.name = "align"

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -459,7 +459,8 @@ class Align(Gate):
 
     Args:
         *q (int): The qubit ID numbers.
-        delay (int): (optional) The time (in ns) for which to delay circuit execution on the specified qubits.
+        delay (int, optional): The time (in ns) for which to delay circuit execution on the specified qubits.
+            Defaults to ``0`` (zero).        
     """
 
     def __init__(self, *q, delay: int = 0):

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -215,8 +215,8 @@ def test_align(backend, delay):
     with pytest.raises(NotImplementedError):
         gate.qasm_label
 
-        assert not gates.Align(0, 1, delay=delay).clifford
-        assert not gates.Align(0, 1, delay=delay).unitary
+    assert not gates.Align(0, 1, delay=delay).clifford
+    assert not gates.Align(0, 1, delay=delay).unitary
 
 
 # :class:`qibo.core.cgates.M` is tested seperately in `test_measurement_gate.py`

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -199,13 +199,24 @@ def test_identity(backend):
 
 
 def test_align(backend):
+    with pytest.raises(TypeError):
+        gates.Align(0, "0.1")
+    with pytest.raises(ValueError):
+        gates.Align(0, -1)
+
+    nqubits = 2
+
     gate = gates.Align(0, 1)
-    gatelist = [gates.H(0), gates.H(1), gate]
-    final_state = apply_gates(backend, gatelist, nqubits=2)
-    target_state = np.ones_like(final_state) / 2.0
+    gate_list = [gates.H(0), gates.H(1), gate]
+
+    final_state = apply_gates(backend, gate_list, nqubits=2)
+    target_state = backend.plus_state(nqubits)
+
     backend.assert_allclose(final_state, target_state)
+
     gate_matrix = gate.asmatrix(backend)
-    backend.assert_allclose(gate_matrix, np.eye(4))
+    identity = backend.identity_density_matrix(nqubits, normalize=False)
+    backend.assert_allclose(gate_matrix, identity)
 
     with pytest.raises(NotImplementedError):
         gate.qasm_label

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -212,8 +212,8 @@ def test_align(backend, delay):
     identity = backend.identity_density_matrix(nqubits, normalize=False)
     backend.assert_allclose(gate_matrix, identity)
 
-        with pytest.raises(NotImplementedError):
-            gate.qasm_label
+    with pytest.raises(NotImplementedError):
+        gate.qasm_label
 
         assert not gates.Align(0, 1, delay=delay).clifford
         assert not gates.Align(0, 1, delay=delay).unitary

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -200,9 +200,9 @@ def test_identity(backend):
 
 def test_align(backend):
     with pytest.raises(TypeError):
-        gates.Align(0, "0.1")
+        gates.Align(0, delay="0.1")
     with pytest.raises(ValueError):
-        gates.Align(0, -1)
+        gates.Align(0, delay=-1)
 
     nqubits = 2
 

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -199,14 +199,18 @@ def test_identity(backend):
 
 @pytest.mark.parametrize("delay", [0, 1])
 def test_align(backend, delay):
-    for delay in [0, 1]:
-        gate = gates.Align(0, 1, delay=delay)
-        gatelist = [gates.H(0), gates.H(1), gate]
-        final_state = apply_gates(backend, gatelist, nqubits=2)
-        target_state = np.ones_like(final_state) / 2.0
-        backend.assert_allclose(final_state, target_state)
-        gate_matrix = gate.asmatrix(backend)
-        backend.assert_allclose(gate_matrix, np.eye(4))
+    nqubits = 2
+
+    gate = gates.Align(0, 1, delay=delay)
+    gatelist = [gates.H(0), gates.H(1), gate]
+    
+    final_state = apply_gates(backend, gatelist, nqubits=nqubits)
+    target_state = backend.plus_state(nqubits)
+    backend.assert_allclose(final_state, target_state)
+
+    gate_matrix = gate.asmatrix(backend)
+    identity = backend.identity_density_matrix(nqubits, normalize=False)
+    backend.assert_allclose(gate_matrix, identity)
 
         with pytest.raises(NotImplementedError):
             gate.qasm_label

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -199,19 +199,20 @@ def test_identity(backend):
 
 
 def test_align(backend):
-    gate = gates.Align(0, 1)
-    gatelist = [gates.H(0), gates.H(1), gate]
-    final_state = apply_gates(backend, gatelist, nqubits=2)
-    target_state = np.ones_like(final_state) / 2.0
-    backend.assert_allclose(final_state, target_state)
-    gate_matrix = gate.asmatrix(backend)
-    backend.assert_allclose(gate_matrix, np.eye(4))
+    for delay in [0, 1]:
+        gate = gates.Align(0, 1, delay=delay)
+        gatelist = [gates.H(0), gates.H(1), gate]
+        final_state = apply_gates(backend, gatelist, nqubits=2)
+        target_state = np.ones_like(final_state) / 2.0
+        backend.assert_allclose(final_state, target_state)
+        gate_matrix = gate.asmatrix(backend)
+        backend.assert_allclose(gate_matrix, np.eye(4))
 
-    with pytest.raises(NotImplementedError):
-        gate.qasm_label
+        with pytest.raises(NotImplementedError):
+            gate.qasm_label
 
-    assert not gates.Align(0, 1).clifford
-    assert not gates.Align(0, 1).unitary
+        assert not gates.Align(0, 1, delay=delay).clifford
+        assert not gates.Align(0, 1, delay=delay).unitary
 
 
 # :class:`qibo.core.cgates.M` is tested seperately in `test_measurement_gate.py`

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -197,13 +197,14 @@ def test_identity(backend):
     assert gates.I(0).clifford
     assert gates.I(0).unitary
 
+
 @pytest.mark.parametrize("delay", [0, 1])
 def test_align(backend, delay):
     nqubits = 2
 
     gate = gates.Align(0, 1, delay=delay)
     gatelist = [gates.H(0), gates.H(1), gate]
-    
+
     final_state = apply_gates(backend, gatelist, nqubits=nqubits)
     target_state = backend.plus_state(nqubits)
     backend.assert_allclose(final_state, target_state)

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -197,8 +197,8 @@ def test_identity(backend):
     assert gates.I(0).clifford
     assert gates.I(0).unitary
 
-
-def test_align(backend):
+@pytest.mark.parametrize("delay", [0, 1])
+def test_align(backend, delay):
     for delay in [0, 1]:
         gate = gates.Align(0, 1, delay=delay)
         gatelist = [gates.H(0), gates.H(1), gate]

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -198,26 +198,20 @@ def test_identity(backend):
     assert gates.I(0).unitary
 
 
-@pytest.mark.parametrize("delay", [0, 1])
-def test_align(backend, delay):
-    nqubits = 2
-
-    gate = gates.Align(0, 1, delay=delay)
+def test_align(backend):
+    gate = gates.Align(0, 1)
     gatelist = [gates.H(0), gates.H(1), gate]
-
-    final_state = apply_gates(backend, gatelist, nqubits=nqubits)
-    target_state = backend.plus_state(nqubits)
+    final_state = apply_gates(backend, gatelist, nqubits=2)
+    target_state = np.ones_like(final_state) / 2.0
     backend.assert_allclose(final_state, target_state)
-
     gate_matrix = gate.asmatrix(backend)
-    identity = backend.identity_density_matrix(nqubits, normalize=False)
-    backend.assert_allclose(gate_matrix, identity)
+    backend.assert_allclose(gate_matrix, np.eye(4))
 
     with pytest.raises(NotImplementedError):
         gate.qasm_label
 
-    assert not gates.Align(0, 1, delay=delay).clifford
-    assert not gates.Align(0, 1, delay=delay).unitary
+    assert not gates.Align(0, 1).clifford
+    assert not gates.Align(0, 1).unitary
 
 
 # :class:`qibo.core.cgates.M` is tested seperately in `test_measurement_gate.py`


### PR DESCRIPTION
This adds a delay option to the Align gate, also implementing the Align gate in qibocal's compiler.

Currently, the only way to add delays in circuit operations is via constructing a pulse sequence.

The delay option causes the circuit execution to pause for a specified period of time. This is currently done by sending a pulse of zero frequency and zero amplitude so that the control hardware performs the timing.

Please see the corresponding PR in qiboteam/qibolab#541.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
