### PR TITLE
Fix double callbacks in evolution models

### DIFF
--- a/src/qibo/callbacks.py
+++ b/src/qibo/callbacks.py
@@ -206,8 +206,10 @@ class Overlap(Callback):
         self.append(overlap)
         return overlap
 
-    def apply_density_matrix(self, backend, state):
-        return backend.calculate_overlap_density_matrix(self.state, state)
+    def apply_density_matrix(self, backend, state):  # pragma: no cover
+        overlap = backend.calculate_overlap_density_matrix(self.state, state)
+        self.append(overlap)
+        return overlap
 
 
 class Energy(Callback):

--- a/src/qibo/callbacks.py
+++ b/src/qibo/callbacks.py
@@ -324,7 +324,9 @@ class Gap(Callback):
         hamiltonian.eigenvectors()
         eigvals = hamiltonian.eigenvalues()
         if isinstance(self.mode, int):
-            return backend.np.real(eigvals[self.mode])
+            gap = backend.np.real(eigvals[self.mode])
+            self.append(gap)
+            return gap
 
         # case: self.mode == "gap"
         excited = 1

--- a/src/qibo/callbacks.py
+++ b/src/qibo/callbacks.py
@@ -208,7 +208,6 @@ class Overlap(Callback):
 
     def apply_density_matrix(self, backend, state):
         overlap = backend.calculate_overlap_density_matrix(self.state, state)
-        self.append(overlap)
         return overlap
 
 

--- a/src/qibo/callbacks.py
+++ b/src/qibo/callbacks.py
@@ -329,7 +329,9 @@ class Gap(Callback):
         # case: self.mode == "gap"
         excited = 1
         gap = backend.np.real(eigvals[excited] - eigvals[0])
+
         if not self.check_degenerate:
+            self.append(gap)
             return gap
 
         while backend.np.less(gap, EIGVAL_CUTOFF):

--- a/src/qibo/callbacks.py
+++ b/src/qibo/callbacks.py
@@ -207,8 +207,7 @@ class Overlap(Callback):
         return overlap
 
     def apply_density_matrix(self, backend, state):
-        overlap = backend.calculate_overlap_density_matrix(self.state, state)
-        return overlap
+        return backend.calculate_overlap_density_matrix(self.state, state)
 
 
 class Energy(Callback):

--- a/src/qibo/callbacks.py
+++ b/src/qibo/callbacks.py
@@ -117,7 +117,6 @@ class EntanglementEntropy(Callback):
             self.partition = [
                 i for i in range(self._nqubits) if i not in set(self.partition)
             ]
-        return self._nqubits
 
     def apply(self, backend, state):
         rho = backend.partial_trace(state, self.partition, self.nqubits)
@@ -179,7 +178,7 @@ class Norm(Callback):
         return norm
 
     def apply_density_matrix(self, backend, state):
-        norm = backend.calculate_norm(state)
+        norm = backend.calculate_norm_density_matrix(state)
         self.append(norm)
         return norm
 

--- a/src/qibo/models/evolution.py
+++ b/src/qibo/models/evolution.py
@@ -89,7 +89,9 @@ class StateEvolution:
     def _create_calculate_callbacks(self, accelerators):
         def calculate_callbacks(state):
             for callback in self.callbacks:
-                callback.append(callback.apply(self.backend, state))
+                # by executing callbacks.apply we also append the object to history
+                # see callbacks module for this
+                callback.apply(self.backend, state)
 
         if accelerators is None:
             return calculate_callbacks

--- a/src/qibo/models/evolution.py
+++ b/src/qibo/models/evolution.py
@@ -89,6 +89,7 @@ class StateEvolution:
     def _create_calculate_callbacks(self, accelerators):
         def calculate_callbacks(state):
             for callback in self.callbacks:
+                callback.nqubits = self.nqubits
                 # by executing callbacks.apply we also append the object to history
                 # see callbacks module for this
                 callback.apply(self.backend, state)


### PR DESCRIPTION
Fixes #973.

I am still puzzled about the `nqubit` setter in the `EntanglementEntropy` function. I think it works well if the callback is used in "circuit mode", but it doesn't if we track che entropy during an evolution. It seems to me is missing a step in which we calculate the number of qubits from the partition or from the hamiltonian. What do you think about it @stavros11?

I am testing the callbacks with the following script, if can help:

```python
import numpy as np
from qibo import models, callbacks, hamiltonians, gates, set_backend

set_backend("numpy")

nqubits = 2
T = 1
dt = 0.25

h0 = hamiltonians.X(2)
h1 = hamiltonians.TFIM(2)

c = models.Circuit(2)
c.add(gates.H(0))
c.add(gates.M(0,1))

callbacks_list = []

#callbacks_list.append(callbacks.EntanglementEntropy([0]))
callbacks_list.append(callbacks.State())
callbacks_list.append(callbacks.Norm())
callbacks_list.append(callbacks.Energy(h1))
callbacks_list.append(callbacks.Overlap(c.execute().state()))
callbacks_list.append(callbacks.Gap())

evolution = models.AdiabaticEvolution(h0=h0, h1=h1, s=lambda t: t, dt=dt, callbacks=callbacks_list)
_ = evolution(T)

for call in callbacks_list:
    print(f"CALLBACK: {call}\nVALUES:\n{call.results}")
```

which stops working if `EntanglementEntropy` is tracked.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
