### PR TITLE
Drop cached property replacement

### DIFF
--- a/src/qibo/backends/npmatrices.py
+++ b/src/qibo/backends/npmatrices.py
@@ -1,19 +1,6 @@
-import sys
+from functools import cached_property
 
 from qibo.config import raise_error
-
-if sys.version_info.minor >= 8:
-    from functools import cached_property  # pylint: disable=E0611
-else:  # pragma: no cover
-    # Custom ``cached_property`` because it is not available for Python < 3.8
-    from functools import lru_cache
-
-    def cached_property(func):
-        @property
-        def wrapper(self):
-            return lru_cache()(func)(self)
-
-        return wrapper
 
 
 class NumpyMatrices:


### PR DESCRIPTION
While I was looking through the code, I found this relic. I guess there is no reason to keep it there, since py3.7 is officially dead, and we do not support it since a while. 

This is just a minor simplification (just maintenance), and should change literally nothing in runtime operations (apart from parsing that code, importing `sys`, and make a trivial check... but they are all irrelevant operations...).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
