### PR TITLE
Fix `apply_channel()` for statevector simulation

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -256,9 +256,13 @@ class NumpyBackend(Backend):
         return np.reshape(state, 2 * (2**nqubits,))
 
     def apply_channel(self, channel, state, nqubits):
-        for coeff, gate in zip(channel.coefficients, channel.gates):
-            if self.np.random.random() < coeff:
-                state = self.apply_gate(gate, state, nqubits)
+        index = np.random.choice(
+            range(len(channel.gates) + 1),
+            p=channel.coefficients + (1 - np.sum(channel.coefficients),),
+        )
+        if index != len(channel.gates):
+            gate = channel.gates[index]
+            state = self.apply_gate(gate, state, nqubits)
         return state
 
     def apply_channel_density_matrix(self, channel, state, nqubits):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -256,10 +256,8 @@ class NumpyBackend(Backend):
         return np.reshape(state, 2 * (2**nqubits,))
 
     def apply_channel(self, channel, state, nqubits):
-        index = np.random.choice(
-            range(len(channel.gates) + 1),
-            p=channel.coefficients + (1 - np.sum(channel.coefficients),),
-        )
+        probabilities = channel.coefficients + (1 - np.sum(channel.coefficients),)
+        index = self.sample_shots(probabilities, 1)[0]
         if index != len(channel.gates):
             gate = channel.gates[index]
             state = self.apply_gate(gate, state, nqubits)

--- a/tests/test_measurements_probabilistic.py
+++ b/tests/test_measurements_probabilistic.py
@@ -83,14 +83,15 @@ def test_measurements_with_probabilistic_noise(backend):
 
     backend.set_seed(123)
     target_samples = []
+    channel_gates = [gates.Y, gates.Z]
+    probs = [0.2, 0.4, 0.4]
     for _ in range(20):
         noiseless_c = models.Circuit(5)
         noiseless_c.add((gates.RX(i, t) for i, t in enumerate(thetas)))
         for i in range(5):
-            if backend.np.random.random() < 0.2:
-                noiseless_c.add(gates.Y(i))
-            if backend.np.random.random() < 0.4:
-                noiseless_c.add(gates.Z(i))
+            index = backend.sample_shots(probs, 1)[0]
+            if index != len(channel_gates):
+                noiseless_c.add(channel_gates[index](i))
         noiseless_c.add(gates.M(*range(5)))
         result = backend.execute_circuit(noiseless_c, nshots=1)
         target_samples.append(backend.to_numpy(result.samples()))

--- a/tests/test_models_circuit_features.py
+++ b/tests/test_models_circuit_features.py
@@ -350,7 +350,7 @@ def test_repeated_execute_probs_and_freqs(backend, nqubits):
             test_frequencies = Counter({"11": 618, "10": 169, "01": 185, "00": 52})
 
     test_probabilities = backend.cast(test_probabilities, dtype=float)
-
+    print(result.probabilities())
     backend.assert_allclose(
         backend.calculate_norm(result.probabilities() - test_probabilities)
         < PRECISION_TOL,

--- a/tests/test_models_circuit_features.py
+++ b/tests/test_models_circuit_features.py
@@ -336,11 +336,11 @@ def test_repeated_execute_probs_and_freqs(backend, nqubits):
     # Tensorflow seems to yield different results with same seed
     if backend.__class__.__name__ == "TensorflowBackend":
         if nqubits == 1:
-            test_probabilities = [0.21777344, 0.78222656]
-            test_frequencies = Counter({1: 801, 0: 223})
+            test_probabilities = [0.17578125, 0.82421875]
+            test_frequencies = Counter({1: 844, 0: 180})
         else:
-            test_probabilities = [0.03808594, 0.15625, 0.15917969, 0.64648438]
-            test_frequencies = Counter({11: 662, 10: 163, 1: 160, 0: 39})
+            test_probabilities = [0.04003906, 0.15039062, 0.15136719, 0.65820312]
+            test_frequencies = Counter({11: 674, 10: 155, 1: 154, 0: 41})
     else:
         if nqubits == 1:
             test_probabilities = [0.22851562, 0.77148438]

--- a/tests/test_models_circuit_features.py
+++ b/tests/test_models_circuit_features.py
@@ -277,16 +277,15 @@ def test_repeated_execute_pauli_noise_channel(backend):
 
     backend.set_seed(1234)
     target_state = []
+    channel_gates = [gates.X, gates.Y, gates.Z]
+    probs = [0.1, 0.2, 0.3, 0.4]
     for _ in range(20):
         noiseless_c = Circuit(4)
         noiseless_c.add((gates.RY(i, t) for i, t in enumerate(thetas)))
         for i in range(4):
-            if backend.np.random.random() < 0.1:
-                noiseless_c.add(gates.X(i))
-            if backend.np.random.random() < 0.2:
-                noiseless_c.add(gates.Y(i))
-            if backend.np.random.random() < 0.3:
-                noiseless_c.add(gates.Z(i))
+            index = backend.sample_shots(probs, 1)[0]
+            if index != len(channel_gates):
+                noiseless_c.add(channel_gates[index](i))
         result = backend.execute_circuit(noiseless_c)
         target_state.append(result.state(numpy=True))
     final_state = [backend.to_numpy(x) for x in final_state]
@@ -304,14 +303,15 @@ def test_repeated_execute_with_pauli_noise(backend):
 
     backend.set_seed(1234)
     target_state = []
+    channel_gates = [gates.X, gates.Z]
+    probs = [0.2, 0.1, 0.7]
     for _ in range(20):
         noiseless_c = Circuit(4)
         for i, t in enumerate(thetas):
             noiseless_c.add(gates.RY(i, theta=t))
-            if backend.np.random.random() < 0.2:
-                noiseless_c.add(gates.X(i))
-            if backend.np.random.random() < 0.1:
-                noiseless_c.add(gates.Z(i))
+            index = backend.sample_shots(probs, 1)[0]
+            if index != len(channel_gates):
+                noiseless_c.add(channel_gates[index](i))
         result = backend.execute_circuit(noiseless_c)
         target_state.append(result.state(numpy=True))
     target_state = np.stack(target_state)
@@ -336,22 +336,21 @@ def test_repeated_execute_probs_and_freqs(backend, nqubits):
     # Tensorflow seems to yield different results with same seed
     if backend.__class__.__name__ == "TensorflowBackend":
         if nqubits == 1:
-            test_probabilities = [0.171875, 0.828125]
-            test_frequencies = Counter({1: 848, 0: 176})
+            test_probabilities = [0.21777344, 0.78222656]
+            test_frequencies = Counter({1: 801, 0: 223})
         else:
-            test_probabilities = [0.04101562, 0.12695312, 0.140625, 0.69140625]
-            test_frequencies = Counter({11: 708, 10: 144, 1: 130, 0: 42})
+            test_probabilities = [0.03808594, 0.15625, 0.15917969, 0.64648438]
+            test_frequencies = Counter({11: 662, 10: 163, 1: 160, 0: 39})
     else:
         if nqubits == 1:
-            test_probabilities = [0.20117188, 0.79882812]
-            test_frequencies = Counter({"1": 818, "0": 206})
+            test_probabilities = [0.22851562, 0.77148438]
+            test_frequencies = Counter({"1": 790, "0": 234})
         else:
-            test_probabilities = [0.0390625, 0.16113281, 0.17382812, 0.62597656]
-            test_frequencies = Counter({"11": 641, "10": 178, "01": 165, "00": 40})
+            test_probabilities = [0.05078125, 0.18066406, 0.16503906, 0.60351562]
+            test_frequencies = Counter({"11": 618, "10": 169, "01": 185, "00": 52})
 
     test_probabilities = backend.cast(test_probabilities, dtype=float)
 
-    print(result.probabilities())
     backend.assert_allclose(
         backend.calculate_norm(result.probabilities() - test_probabilities)
         < PRECISION_TOL,


### PR DESCRIPTION
This PR fixes #1018 . There was an error in the way we were sampling the gates to apply when using the  `apply_channel()` method. This also affects the `PauliNoiseChannel` and the `UnitaryChannel`.
We did not notice earlier because the tests are also not implemented correctly. I will fix them as soon as possible.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
