### PR TITLE
Repeated execution and density matrices

### DIFF
--- a/tests/test_models_circuit_execution.py
+++ b/tests/test_models_circuit_execution.py
@@ -64,7 +64,7 @@ def test_repeated_execute(backend, accelerators):
     c.add((gates.RY(i, t) for i, t in enumerate(thetas)))
     target_state = backend.execute_circuit(c).state(numpy=True)
     target_state = np.array(20 * [target_state])
-    c.repeated_execution = True
+    c.has_collapse = True
     final_state = backend.execute_circuit(c, nshots=20)
     final_state = [backend.to_numpy(x) for x in final_state]
     backend.assert_allclose(final_state, target_state)


### PR DESCRIPTION
While doing some tests for #1022 I realized that `circuit.repeated_execution` was not updated properly when the `circuit.density_matrix` flag is switched after the gates are added. For example:
```py
circuit = Circuit(2)
circuit.add(gates.UnitaryChannel(...)) # circuit.repeated_execution is now switched to True because a channel is added
circuit.density_matrix = True # does not disable repeated execution
```
so in the end the circuit will be executed repeatedly even though we are using density matrices.

Here I changed `circuit.repeated_execution` to a property that is evaluated right before the circuit is executed and is `True` when the circuit contains collapse measurements or channels and density matrices are disabled.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
