### PR TITLE
Change `gates.ECR` decomposition

### DIFF
--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -2051,9 +2051,18 @@ class ECR(Gate):
         self.unitary = True
 
     def decompose(self, *free, use_toffolis: bool = True) -> List[Gate]:
-        """"""
+        """Decomposition of :math:`\\textup{ECR}` gate up to global phase.
+
+        A global phase difference exists between the definitions of
+        :math:`\\textup{ECR}` and this decomposition. More precisely,
+
+        .. math::
+            \\textup{ECR} = e^{i 7 \\pi / 4} \\, S(q_{0}) \\, \\sqrt{X}(q_{1}) \\,
+                \\textup{CNOT}(q_{0}, q_{1}) \\, X(q_{0})
+        """
+
         q0, q1 = self.target_qubits
-        return [RZX(q0, q1, np.pi / 4), X(q0), RZX(q0, q1, -np.pi / 4)]
+        return [S(q0), SX(q1), CNOT(q0, q1), X(q0)]
 
 
 class TOFFOLI(Gate):

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -1074,7 +1074,14 @@ def test_ecr(backend):
 
     target_state = matrix @ initial_state
     backend.assert_allclose(final_state, target_state)
-    backend.assert_allclose(final_state_decompose, target_state)
+    # testing random expectation value due to global phase difference
+    observable = random_hermitian(2**nqubits, backend=backend)
+    backend.assert_allclose(
+        np.transpose(np.conj(final_state_decompose))
+        @ observable
+        @ final_state_decompose,
+        np.transpose(np.conj(target_state)) @ observable @ target_state,
+    )
 
     with pytest.raises(NotImplementedError):
         gates.ECR(0, 1).qasm_label


### PR DESCRIPTION
Replacing decomposition of ECR gate for one that is composed of only Clifford gates

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
