### PR TITLE
Add energy fluctuation in VQE

### DIFF
--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -124,7 +124,7 @@ class VQE:
         Evaluate energy fluctuation
 
         .. math::
-            \\Xi_{k}(\\mu) = \\sqrt{\\langle\\mu|\\hat{H}_{k}^2|\\mu\\rangle - \\langle\\mu|\\hat{H}_{k}|\\mu\\rangle^2} \\,
+            \\Xi_{k}(\\mu) = \\sqrt{\\langle\\mu|\\hat{H}^2|\\mu\\rangle - \\langle\\mu|\\hat{H}|\\mu\\rangle^2} \\,
 
         for a given state :math:`|\\mu\\rangle`.
         """

--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -128,6 +128,9 @@ class VQE:
             \\Xi_{k}(\\mu) = \\sqrt{\\langle\\mu|\\hat{H}^2|\\mu\\rangle - \\langle\\mu|\\hat{H}|\\mu\\rangle^2} \\,
 
         for a given state :math:`|\\mu\\rangle`.
+
+        Args:
+            state (np.ndarray): quantum state to be used to compute the energy fluctuation with H.
         """
         energy = self.hamiltonian.expectation(state)
         h = self.hamiltonian.matrix

--- a/src/qibo/models/variational.py
+++ b/src/qibo/models/variational.py
@@ -1,5 +1,7 @@
+import numpy as np
 from qibo.config import raise_error
 from qibo.models.evolution import StateEvolution
+from qibo.hamiltonians import Hamiltonian
 
 
 class VQE:
@@ -33,6 +35,7 @@ class VQE:
         """Initialize circuit ansatz and hamiltonian."""
         self.circuit = circuit
         self.hamiltonian = hamiltonian
+        self.backend = hamiltonian.backend
 
     def minimize(
         self,
@@ -115,6 +118,21 @@ class VQE:
         )
         self.circuit.set_parameters(parameters)
         return result, parameters, extra
+    
+    def energy_fluctuation(self, state):
+        """
+        Evaluate energy fluctuation
+
+        .. math::
+            \\Xi_{k}(\\mu) = \\sqrt{\\langle\\mu|\\hat{H}_{k}^2|\\mu\\rangle - \\langle\\mu|\\hat{H}_{k}|\\mu\\rangle^2} \\,
+
+        for a given state :math:`|\\mu\\rangle`.
+        """
+        energy = self.hamiltonian.expectation(state)
+        h = self.hamiltonian.matrix
+        h2 = Hamiltonian(nqubits=self.hamiltonian.nqubits, matrix=h @ h, backend=self.backend)
+        average_h2 = self.backend.calculate_expectation_state(h2, state, normalize=True)
+        return np.sqrt(average_h2 - energy**2)
 
 
 class AAVQE:

--- a/tests/test_models_variational.py
+++ b/tests/test_models_variational.py
@@ -133,9 +133,9 @@ def test_vqe(backend, method, options, compile, filename):
         assert_regression_fixture(backend, params, filename)
 
     # test energy fluctuation
-    state = v.hamiltonian.ground_state.state()
+    state = np.ones(2**nqubits) / np.sqrt(2**nqubits)
     energy_fluctuation = v.energy_fluctuation(state)
-    assert energy_fluctuation != 0
+    assert energy_fluctuation >= 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models_variational.py
+++ b/tests/test_models_variational.py
@@ -133,7 +133,7 @@ def test_vqe(backend, method, options, compile, filename):
         assert_regression_fixture(backend, params, filename)
 
     # test energy fluctuation
-    state = v.hamiltonian.ground_state
+    state = v.hamiltonian.ground_state.state()
     energy_fluctuation = v.energy_fluctuation(state)
     assert energy_fluctuation != 0 
 

--- a/tests/test_models_variational.py
+++ b/tests/test_models_variational.py
@@ -132,6 +132,11 @@ def test_vqe(backend, method, options, compile, filename):
     if filename is not None:
         assert_regression_fixture(backend, params, filename)
 
+    # test energy fluctuation
+    state = v.hamiltonian.ground_state
+    energy_fluctuation = v.energy_fluctuation(state)
+    assert energy_fluctuation != 0 
+
 
 @pytest.mark.parametrize(
     "solver,dense",


### PR DESCRIPTION
New feature in VQE. The energy fluctuation given the VQE hamiltonian $\hat{H}$ and a state $|\mu\rangle$:

$$\Xi_{k}(\mu) = \sqrt{\langle\mu|\hat{H}^2|\mu\rangle - \langle\mu|\hat{H}|\mu\rangle^2}.$$

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
