### PR TITLE
Fix bug in `quantum_info.random_clifford`

### DIFF
--- a/src/qibo/quantum_info/random_ensembles.py
+++ b/src/qibo/quantum_info/random_ensembles.py
@@ -1159,11 +1159,13 @@ def _sample_from_quantum_mallows_distribution(nqubits: int, local_state):
     """
     mute_index = list(range(nqubits))
 
-    exponents = np.arange(nqubits, 0, -1, dtype=int)
+    exponents = np.arange(nqubits, 0, -1, dtype=np.int64)
+    powers = 4**exponents
+    powers[powers == 0] = np.iinfo(np.int64).max
 
     r = local_state.uniform(0, 1, size=nqubits)
 
-    indexes = -1 * (np.ceil(np.log2(r + (1 - r) / 4**exponents)))
+    indexes = -1 * (np.ceil(np.log2(r + (1 - r) / powers)))
 
     hadamards = 1 * (indexes < exponents)
 


### PR DESCRIPTION
The `quantum_info.random_clifford` function was breaking for `nqubits >= 30` due to trying to create numbers bigger than the `max` of `np.int64`. This fixes it.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
