### PR TITLE
Fixing DBI tests

### DIFF
--- a/src/qibo/models/dbi/double_bracket.py
+++ b/src/qibo/models/dbi/double_bracket.py
@@ -5,7 +5,6 @@ from functools import partial
 import hyperopt
 import numpy as np
 
-from qibo.config import raise_error
 from qibo.hamiltonians import Hamiltonian
 
 
@@ -74,7 +73,7 @@ class DoubleBracketIteration:
             )
         elif mode is DoubleBracketGeneratorType.group_commutator:
             if d is None:
-                raise_error(ValueError, f"Cannot use group_commutator with matrix {d}")
+                d = self.diagonal_h_matrix
             operator = (
                 self.h.exp(-step)
                 @ self.backend.calculate_matrix_exp(-step, d)


### PR DESCRIPTION
This PR fixes tests after the discussion in #1154.
I decided to have the same behavior for `group_commutator` and `single_commutator`, i.e. when `d` is not provided the diagonal part of `h` will be used.
I've also fixed coverage.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
