### PR TITLE
Move `GlobalBackend` check to `backends.__init__.py`

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -167,3 +167,10 @@ def set_threads(nthreads):
     if nthreads < 1:
         raise_error(ValueError, "Number of threads must be positive.")
     GlobalBackend().set_threads(nthreads)
+
+
+def _check_backend(backend):  # pragma: no cover
+    if backend is None:
+        return GlobalBackend()
+
+    return backend

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -169,7 +169,7 @@ def set_threads(nthreads):
     GlobalBackend().set_threads(nthreads)
 
 
-def _check_backend(backend):  # pragma: no cover
+def _check_backend(backend):
     if backend is None:
         return GlobalBackend()
 

--- a/src/qibo/backends/clifford.py
+++ b/src/qibo/backends/clifford.py
@@ -538,10 +538,9 @@ class CliffordBackend(NumpyBackend):
     def __init__(self, engine=None):
         super().__init__()
 
-        if engine is None:
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            engine = GlobalBackend()
+        engine = _check_backend(engine)
 
         if isinstance(engine, TensorflowBackend):
             raise_error(

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -4,7 +4,7 @@ from typing import List, Sequence, Tuple
 
 import sympy
 
-from qibo.backends import CliffordBackend, GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import raise_error
 
 REQUIRED_FIELDS = [
@@ -361,8 +361,7 @@ class Gate:
             ``Gate.matrix`` was defined as an atribute in ``qibo`` versions prior to  ``0.2.0``.
             From ``0.2.0`` on, it has been converted into a method and has replaced the ``asmatrix`` method.
         """
-        if backend is None:  # pragma: no cover
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         return backend.matrix(self)
 
@@ -481,7 +480,6 @@ class ParametrizedGate(Gate):
         self.parameters = tuple(params)
 
     def matrix(self, backend=None):
-        if backend is None:  # pragma: no cover
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         return backend.matrix_parametrized(self)

--- a/src/qibo/gates/channels.py
+++ b/src/qibo/gates/channels.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import PRECISION_TOL, raise_error
 from qibo.gates.abstract import Gate
 from qibo.gates.gates import I, Unitary, X, Y, Z
@@ -80,8 +80,7 @@ class Channel(Gate):
             vectorization,
         )
 
-        if backend is None:  # pragma: no cover
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         nqubits = 1 + max(self.target_qubits) if nqubits is None else nqubits
 
@@ -128,8 +127,7 @@ class Channel(Gate):
             choi_to_liouville,
         )
 
-        if backend is None:  # pragma: no cover
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         super_op = self.to_choi(nqubits=nqubits, order=order, backend=backend)
         super_op = choi_to_liouville(super_op, order=order, backend=backend)
@@ -166,8 +164,7 @@ class Channel(Gate):
 
         from qibo.quantum_info.basis import comp_basis_to_pauli  # pylint: disable=C0415
 
-        if backend is None:  # pragma: no cover
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         super_op = self.to_liouville(nqubits=nqubits, backend=backend)
 

--- a/src/qibo/gates/special.py
+++ b/src/qibo/gates/special.py
@@ -1,4 +1,4 @@
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.gates.abstract import SpecialGate
 from qibo.gates.measurements import M
 
@@ -104,8 +104,7 @@ class FusedGate(SpecialGate):
         Returns:
             ndarray: Matrix representation of special gate.
         """
-        if backend is None:  # pragma: no cover
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         return backend.matrix_fused(self)
 

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -24,14 +24,9 @@ class Hamiltonian(AbstractHamiltonian):
     """
 
     def __init__(self, nqubits, matrix=None, backend=None):
-        if backend is None:  # pragma: no cover
-            from qibo.backends import (  # pylint: disable=import-outside-toplevel
-                GlobalBackend,
-            )
+        from qibo.backends import _check_backend
 
-            self.backend = GlobalBackend()
-        else:
-            self.backend = backend
+        self.backend = _check_backend(backend)
 
         if not (
             isinstance(matrix, self.backend.tensor_types)
@@ -355,14 +350,11 @@ class SymbolicHamiltonian(AbstractHamiltonian):
         from qibo.symbols import Symbol  # pylint: disable=import-outside-toplevel
 
         self._qiboSymbol = Symbol  # also used in ``self._get_symbol_matrix``
-        if backend is None:  # pragma: no cover
-            from qibo.backends import (  # pylint: disable=import-outside-toplevel
-                GlobalBackend,
-            )
 
-            self.backend = GlobalBackend()
-        else:
-            self.backend = backend
+        from qibo.backends import _check_backend
+
+        self.backend = _check_backend(backend)
+
         if form is not None:
             self.form = form
         if nqubits is not None:

--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1000,14 +1000,13 @@ class Circuit:
     def unitary(self, backend=None):
         """Creates the unitary matrix corresponding to all circuit gates.
 
-        This is a ``(2 ** nqubits, 2 ** nqubits)`` matrix obtained by
-        multiplying all circuit gates.
+        This is a :math:`2^{n} \\times 2^{n}`` matrix obtained by
+        multiplying all circuit gates, where :math:`n` is ``nqubits``.
         """
 
-        if backend is None:
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         fgate = gates.FusedGate(*range(self.nqubits))
         for gate in self.queue:
@@ -1050,10 +1049,10 @@ class Circuit:
                     NotImplementedError,
                     "Circuit compilation is not available with callbacks.",
                 )
-        if backend is None:
-            from qibo.backends import GlobalBackend
 
-            backend = GlobalBackend()
+        from qibo.backends import _check_backend
+
+        backend = _check_backend(backend)
 
         from qibo.result import CircuitResult, QuantumState
 

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 from qibo import gates
-from qibo.backends import GlobalBackend
+from qibo.backends import GlobalBackend, _check_backend
 from qibo.config import raise_error
 
 
@@ -148,8 +148,8 @@ def ZNE(
         1. K. Temme, S. Bravyi et al, *Error mitigation for short-depth quantum circuits*.
            `arXiv:1612.02058 [quant-ph] <https://arxiv.org/abs/1612.02058>`_.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
+
     if readout is None:
         readout = {}
 
@@ -197,8 +197,7 @@ def sample_training_circuit_cdr(
     Returns:
         :class:`qibo.models.Circuit`: The sampled circuit.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if replacement_gates is None:
         replacement_gates = [(gates.RZ, {"theta": n * np.pi / 2}) for n in range(4)]
@@ -303,8 +302,8 @@ def CDR(
         1. P. Czarnik, A. Arrasmith et al, *Error mitigation with Clifford quantum-circuit data*.
            `arXiv:2005.10189 [quant-ph] <https://arxiv.org/abs/2005.10189>`_.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
+
     if readout is None:
         readout = {}
 
@@ -390,8 +389,8 @@ def vnCDR(
         1. A. Lowe, MH. Gordon et al, *Unified approach to data-driven quantum error mitigation*.
            `arXiv:2011.01157 [quant-ph] <https://arxiv.org/abs/2011.01157>`_.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
+
     if readout is None:
         readout = {}
 
@@ -495,8 +494,7 @@ def get_response_matrix(
     """
     from qibo import Circuit  # pylint: disable=import-outside-toplevel
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     response_matrix = np.zeros((2**nqubits, 2**nqubits))
 
@@ -599,8 +597,7 @@ def apply_randomized_readout_mitigation(
         random_pauli,
     )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     meas_qubits = circuit.measurements[0].qubits
     nshots_r = int(nshots / ncircuits)
@@ -672,8 +669,8 @@ def get_expectation_val_with_readout_mitigation(
     Returns:
         float: the mitigated expectation value of the observable.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
+
     if readout is None:  # pragma: no cover
         readout = {}
 
@@ -719,8 +716,7 @@ def sample_clifford_training_circuit(
         random_clifford,
     )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     non_clifford_gates_indices = [
         i
@@ -783,8 +779,7 @@ def error_sensitive_circuit(circuit, observable, backend=None):
         vectorization,
     )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     sampled_circuit = sample_clifford_training_circuit(circuit, backend=backend)
     unitary_matrix = sampled_circuit.unitary(backend=backend)
@@ -882,8 +877,8 @@ def ICS(
         1. Dayue Qin, Yanzhu Chen et al, *Error statistics and scalability of quantum error mitigation formulas*.
            `arXiv:2112.06255 [quant-ph] <https://arxiv.org/abs/2112.06255>`_.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
+
     if readout is None:
         readout = {}
 

--- a/src/qibo/models/grover.py
+++ b/src/qibo/models/grover.py
@@ -188,10 +188,9 @@ class Grover:
             measured (str): bitstring measured and checked as a valid solution.
             total_iterations (int): number of times the oracle has been called.
         """
-        if backend is None:  # pragma: no cover
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         k = 1
         lamda = lamda_value
@@ -225,10 +224,9 @@ class Grover:
             solution (str): bitstring (or list of bitstrings) measured as solution of the search.
             iterations (int): number of oracle calls done to reach a solution.
         """
-        if backend is None:  # pragma: no cover
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         if (self.num_sol or self.targ_a) and not self.iterative:
             if self.targ_a:

--- a/src/qibo/models/hep.py
+++ b/src/qibo/models/hep.py
@@ -41,12 +41,9 @@ class qPDF:
         self.circuit, self.rotation, self.nparams = ansatz_function(layers, nqubits)
 
         # load backend
-        if backend is None:  # pragma: no cover
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            self.backend = GlobalBackend()
-        else:
-            self.backend = backend
+        self.backend = _check_backend(backend)
 
         # load hamiltonian
         if multi_output:

--- a/src/qibo/models/iqae.py
+++ b/src/qibo/models/iqae.py
@@ -264,10 +264,10 @@ class IQAE:
         Returns:
             A :class:`qibo.models.iqae.IterativeAmplitudeEstimationResult` results object.
         """
-        if backend is None:
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
+
         # Initializing all parameters
         k = [0]
         # uppercase_k=4k+2

--- a/src/qibo/models/tsp.py
+++ b/src/qibo/models/tsp.py
@@ -135,12 +135,10 @@ class TSP:
     """
 
     def __init__(self, distance_matrix, backend=None):
-        if backend is None:  # pragma: no cover
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            self.backend = GlobalBackend()
-        else:
-            self.backend = backend
+        self.backend = _check_backend(backend)
+
         self.distance_matrix = distance_matrix
         self.num_cities = distance_matrix.shape[0]
         self.two_to_one = calculate_two_to_one(self.num_cities)

--- a/src/qibo/noise_model.py
+++ b/src/qibo/noise_model.py
@@ -341,10 +341,9 @@ class CompositeNoiseModel:
 
         from scipy.optimize import Bounds, direct
 
-        if backend == None:  # pragma: no cover
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
 
         nshots = target_result.nshots
         target_prob = freq_to_prob(target_result.frequencies())

--- a/src/qibo/optimizers.py
+++ b/src/qibo/optimizers.py
@@ -86,16 +86,16 @@ def optimize(
             )
         return cmaes(loss, initial_parameters, args, options)
     elif method == "sgd":
-        if backend is None:
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
+
         return sgd(loss, initial_parameters, args, options, compile, backend)
     else:
-        if backend is None:
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
+        backend = _check_backend(backend)
+
         return newtonian(
             loss,
             initial_parameters,

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 from joblib import Parallel, delayed
 
-from qibo.backends import GlobalBackend, set_threads
+from qibo.backends import _check_backend
 from qibo.config import raise_error
 
 
@@ -39,8 +39,7 @@ def parallel_execution(circuit, states, processes=None, backend=None):
     Returns:
         Circuit evaluation for input states.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if states is None or not isinstance(states, list):  # pragma: no cover
         raise_error(TypeError, "states must be a list.")
@@ -88,8 +87,7 @@ def parallel_circuits_execution(
     Returns:
         Circuit evaluation for input states.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if not isinstance(circuits, Iterable):  # pragma: no cover
         raise_error(TypeError, "circuits must be iterable.")
@@ -165,8 +163,7 @@ def parallel_parametrized_execution(
     Returns:
         Circuit evaluation for input parameters.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if not isinstance(parameters, list):  # pragma: no cover
         raise_error(TypeError, "parameters must be a list.")

--- a/src/qibo/quantum_info/basis.py
+++ b/src/qibo/quantum_info/basis.py
@@ -5,7 +5,7 @@ from typing import Optional
 import numpy as np
 
 from qibo import matrices
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import raise_error
 from qibo.quantum_info.superoperator_transformations import vectorization
 
@@ -89,8 +89,7 @@ def pauli_basis(
             "sparse representation is not implemented for unvectorized Pauli basis.",
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     pauli_labels = {"I": matrices.I, "X": matrices.X, "Y": matrices.Y, "Z": matrices.Z}
     basis_single = [pauli_labels[label] for label in pauli_order]
@@ -187,8 +186,7 @@ def comp_basis_to_pauli(
             array with their row-wise indexes.
 
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if sparse:
         elements, indexes = pauli_basis(
@@ -258,8 +256,7 @@ def pauli_to_comp_basis(
             tuple is composed of array of non-zero elements and an
             array with their row-wise indexes.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     unitary = pauli_basis(
         nqubits,

--- a/src/qibo/quantum_info/metrics.py
+++ b/src/qibo/quantum_info/metrics.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import numpy as np
 from scipy import sparse
 
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import PRECISION_TOL, raise_error
 
 
@@ -79,8 +79,7 @@ def concurrence(state, bipartition, check_purity: bool = True, backend=None):
     Returns:
         float: Concurrence of :math:`\\rho`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if (
         (len(state.shape) not in [1, 2])
@@ -157,8 +156,7 @@ def entanglement_of_formation(
     Returns:
         float: entanglement of formation of state :math:`\\rho`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     from qibo.quantum_info.utils import shannon_entropy  # pylint: disable=C0415
 
@@ -202,8 +200,7 @@ def entropy(
     Returns:
         float: The von-Neumann entropy :math:`S` of ``state`` :math:`\\rho`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if (
         (len(state.shape) >= 3)
@@ -289,8 +286,7 @@ def entanglement_entropy(
     Returns:
         float: Entanglement entropy :math:`S` of ``state`` :math:`\\rho`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if base <= 0.0:
         raise_error(ValueError, "log base must be non-negative.")
@@ -348,8 +344,7 @@ def trace_distance(state, target, check_hermitian: bool = False, backend=None):
     Returns:
         float: Trace distance between ``state`` :math:`\\rho` and ``target`` :math:`\\sigma`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if state.shape != target.shape:
         raise_error(
@@ -470,8 +465,7 @@ def fidelity(state, target, check_hermitian: bool = False, backend=None):
     Returns:
         float: Fidelity between ``state`` :math:`\\rho` and ``target`` :math:`\\sigma`.
     """
-    if backend is None:
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if state.shape != target.shape:
         raise_error(
@@ -666,8 +660,7 @@ def entanglement_fidelity(
     Returns:
         float: Entanglement fidelity :math:`F_{\\mathcal{E}}`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if isinstance(nqubits, int) is False:
         raise_error(
@@ -733,8 +726,7 @@ def process_fidelity(channel, target=None, check_unitary: bool = False, backend=
     Returns:
         float: Process fidelity between ``channel`` and ``target``.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if target is not None:
         if channel.shape != target.shape:
@@ -938,8 +930,8 @@ def diamond_norm(channel, target=None, backend=None, **kwargs):
 
     # `CVXPY` only works with `numpy`, so this function has to
     # convert any channel to the `numpy` backend by default
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
+
     channel = backend.to_numpy(channel)
 
     channel = np.transpose(channel)
@@ -1025,8 +1017,7 @@ def meyer_wallach_entanglement(circuit, backend=None):
         float: Meyer-Wallach entanglement.
     """
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     circuit.density_matrix = True
     nqubits = circuit.nqubits
@@ -1086,8 +1077,7 @@ def entangling_capability(circuit, samples: int, seed=None, backend=None):
             TypeError, "seed must be either type int or numpy.random.Generator."
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     local_state = (
         np.random.default_rng(seed) if seed is None or isinstance(seed, int) else seed
@@ -1151,8 +1141,7 @@ def expressibility(
         pqc_integral,
     )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     deviation = haar_integral(
         circuit.nqubits, power_t, samples=None, backend=backend
@@ -1214,8 +1203,7 @@ def frame_potential(
             TypeError, f"samples must be type int, but it is type {type(samples)}."
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     nqubits = circuit.nqubits
     dim = 2**nqubits
@@ -1259,8 +1247,7 @@ def _check_hermitian_or_not_gpu(matrix, backend=None):
         `backend` is not :class:`qibojit.backends.CupyBackend`
 
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     norm = backend.calculate_norm_density_matrix(
         np.transpose(np.conj(matrix)) - matrix, order=2

--- a/src/qibo/quantum_info/quantum_networks.py
+++ b/src/qibo/quantum_info/quantum_networks.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import raise_error
 
 
@@ -593,8 +593,7 @@ class QuantumNetwork:
 
     def _set_tensor_and_parameters(self):
         """Sets tensor based on inputs."""
-        if self._backend is None:
-            self._backend = GlobalBackend()
+        self._backend = _check_backend(self._backend)
 
         if isinstance(self.partition, list):
             self.partition = tuple(self.partition)

--- a/src/qibo/quantum_info/random_ensembles.py
+++ b/src/qibo/quantum_info/random_ensembles.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.stats import rv_continuous
 
 from qibo import Circuit, gates
-from qibo.backends import GlobalBackend, NumpyBackend
+from qibo.backends import NumpyBackend, _check_backend
 from qibo.config import MAX_ITERATIONS, PRECISION_TOL, raise_error
 from qibo.quantum_info.basis import comp_basis_to_pauli
 from qibo.quantum_info.superoperator_transformations import (
@@ -1201,8 +1201,7 @@ def _set_backend_and_local_state(seed, backend):
             TypeError, "seed must be either type int or numpy.random.Generator."
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if seed is None or isinstance(seed, int):
         if backend.__class__.__name__ in [

--- a/src/qibo/quantum_info/superoperator_transformations.py
+++ b/src/qibo/quantum_info/superoperator_transformations.py
@@ -6,7 +6,7 @@ from typing import Optional
 import numpy as np
 from scipy.optimize import minimize
 
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import PRECISION_TOL, raise_error
 from qibo.gates.abstract import Gate
 from qibo.gates.gates import Unitary
@@ -61,8 +61,7 @@ def vectorization(state, order: str = "row", backend=None):
                 f"order must be either 'row' or 'column' or 'system', but it is {order}.",
             )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if len(state.shape) == 1:
         state = np.outer(state, np.conj(state))
@@ -130,8 +129,7 @@ def unvectorization(state, order: str = "row", backend=None):
                 f"order must be either 'row' or 'column' or 'system', but it is {order}.",
             )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     dim = int(np.sqrt(len(state)))
 
@@ -449,8 +447,7 @@ def choi_to_kraus(
             f"validate_cp must be type bool, but it is type {type(validate_cp)}.",
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if validate_cp:
         norm = float(
@@ -652,8 +649,7 @@ def kraus_to_choi(kraus_ops, order: str = "row", backend=None):
     Returns:
         ndarray: Choi representation of the Kraus channel.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     gates, target_qubits = _set_gate_and_target_qubits(kraus_ops)
     nqubits = 1 + max(target_qubits)
@@ -782,8 +778,7 @@ def kraus_to_chi(
     """
     from qibo.quantum_info.basis import comp_basis_to_pauli
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     gates, target_qubits = _set_gate_and_target_qubits(kraus_ops)
     nqubits = 1 + max(target_qubits)
@@ -845,8 +840,7 @@ def kraus_to_stinespring(
     Returns:
         ndarray: Stinespring representation (restricted unitary) of the Kraus channel.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if initial_state_env is not None:
         if len(initial_state_env) != len(kraus_ops):
@@ -963,8 +957,7 @@ def liouville_to_pauli(
     """
     from qibo.quantum_info.basis import comp_basis_to_pauli
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     dim = int(np.sqrt(len(super_op)))
     nqubits = int(np.log2(dim))
@@ -1165,8 +1158,7 @@ def pauli_to_liouville(
     """
     from qibo.quantum_info.basis import pauli_to_comp_basis
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     dim = int(np.sqrt(len(pauli_op)))
     nqubits = int(np.log2(dim))
@@ -1873,8 +1865,7 @@ def stinespring_to_kraus(
     Returns:
         ndarray: Kraus operators.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if isinstance(dim_env, int) is False:
         raise_error(
@@ -2038,8 +2029,7 @@ def kraus_to_unitaries(
         if precision_tol < 0.0:
             raise_error(ValueError, "precision_tol must be non-negative.")
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     target_qubits = [q for q, _ in kraus_ops]
     nqubits = 1 + np.max(target_qubits)
@@ -2148,8 +2138,7 @@ def _reshuffling(super_op, order: str = "row", backend=None):
             NotImplementedError, "reshuffling not implemented for system vectorization."
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     dim = np.sqrt(super_op.shape[0])
 
@@ -2215,8 +2204,7 @@ def _individual_kraus_to_liouville(
     to be used in :func:`qibo.quantum_info.kraus_to_unitaries`. In principle,
     this should be not be accessible to users.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     gates, target_qubits = _set_gate_and_target_qubits(kraus_ops)
     nqubits = 1 + max(target_qubits)

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 import numpy as np
 
 from qibo import matrices
-from qibo.backends import GlobalBackend
+from qibo.backends import _check_backend
 from qibo.config import PRECISION_TOL, raise_error
 
 
@@ -134,8 +134,7 @@ def hadamard_transform(array, implementation: str = "fast", backend=None):
     Returns:
         ndarray: (Fast) Hadamard Transform of ``array``.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if (
         len(array.shape) not in [1, 2]
@@ -210,8 +209,7 @@ def shannon_entropy(probability_array, base: float = 2, backend=None):
     Returns:
         (float): The Shannon entropy :math:`H(\\mathcal{p})`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if isinstance(probability_array, list):
         probability_array = backend.cast(probability_array, dtype=np.float64)
@@ -281,8 +279,7 @@ def total_variation_distance(
     Returns:
         float: Total variation distance between :math:`\\mathbf{p}` and :math:`\\mathbf{q}`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if isinstance(prob_dist_p, list):
         prob_dist_p = backend.cast(prob_dist_p, dtype=np.float64)
@@ -341,8 +338,7 @@ def hellinger_distance(prob_dist_p, prob_dist_q, validate: bool = False, backend
     Returns:
         (float): Hellinger distance :math:`H(p, q)`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if isinstance(prob_dist_p, list):
         prob_dist_p = backend.cast(prob_dist_p, dtype=np.float64)
@@ -454,8 +450,7 @@ def haar_integral(
             TypeError, f"samples must be type int, but it is type {type(samples)}."
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     dim = 2**nqubits
 
@@ -529,8 +524,7 @@ def pqc_integral(circuit, power_t: int, samples: int, backend=None):
             TypeError, f"samples must be type int, but it is type {type(samples)}."
         )
 
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     circuit.density_matrix = True
     dim = 2**circuit.nqubits

--- a/src/qibo/result.py
+++ b/src/qibo/result.py
@@ -31,11 +31,9 @@ class QuantumState:
     """
 
     def __init__(self, state, backend=None):
-        if backend is None:  # pragma: no cover
-            from qibo.backends import GlobalBackend
+        from qibo.backends import _check_backend
 
-            backend = GlobalBackend()
-        self.backend = backend
+        self.backend = _check_backend(backend)
         self.density_matrix = len(state.shape) == 2
         self.nqubits = int(np.log2(state.shape[0]))
         self._state = state

--- a/src/qibo/transpiler/unitary_decompositions.py
+++ b/src/qibo/transpiler/unitary_decompositions.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from qibo import gates, matrices
-from qibo.backends import GlobalBackend, NumpyBackend
+from qibo.backends import NumpyBackend, _check_backend
 from qibo.config import raise_error
 
 magic_basis = np.array(
@@ -50,8 +50,7 @@ def calculate_psi(unitary, magic_basis=magic_basis, backend=None):
     Returns:
         (ndarray) Eigenvectors in the computational basis and eigenvalues of :math:`U^{T} U`.
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     if backend.__class__.__name__ in [
         "CupyBackend",
@@ -154,9 +153,8 @@ def calculate_diagonal(unitary, ua, ub, va, vb):
 
 
 def magic_decomposition(unitary, backend=None):
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
     """Decomposes an arbitrary unitary to (A1) from arXiv:quant-ph/0011050."""
+    backend = _check_backend(backend)
     psi, eigvals = calculate_psi(unitary, backend=backend)
     psi_tilde = np.conj(np.sqrt(eigvals)) * np.dot(unitary, psi)
     va, vb = calculate_single_qubit_unitaries(psi)
@@ -167,8 +165,7 @@ def magic_decomposition(unitary, backend=None):
 
 def to_bell_diagonal(ud, bell_basis=bell_basis, backend=None):
     """Transforms a matrix to the Bell basis and checks if it is diagonal."""
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     ud = backend.cast(ud)
     bell_basis = backend.cast(bell_basis, dtype=bell_basis.dtype)
@@ -248,8 +245,7 @@ def two_qubit_decomposition(q0, q1, unitary, backend=None):
     Returns:
         (list): gates implementing decomposition (24) from arXiv:quant-ph/0307177
     """
-    if backend is None:  # pragma: no cover
-        backend = GlobalBackend()
+    backend = _check_backend(backend)
 
     ud_diag = to_bell_diagonal(unitary, backend=backend)
     ud = None

--- a/tests/test_global_backend.py
+++ b/tests/test_global_backend.py
@@ -91,3 +91,20 @@ def test_gate_matrix():
     qibo.set_backend("numpy")
     gate = qibo.gates.H(0)
     matrix = gate.matrix
+
+
+def test_check_backend(backend):
+    # testing when backend is not None
+    test = qibo.backends._check_backend(backend)
+
+    assert test.name == backend.name
+    assert test.__class__ == backend.__class__
+
+    # testing when backend is None
+    test = None
+    test = qibo.backends._check_backend(test)
+
+    target = qibo.backends.GlobalBackend()
+
+    assert test.name == target.name
+    assert test.__class__ == target.__class__


### PR DESCRIPTION
This replaces all the repeated lines like:

```python3
if backend is None:  # pragma: no cover
    backend = GlobalBackend()
```
by a function in `backends.__init__.py`

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
