### PR TITLE
Added circuit composition via __matmul__ to qibo.Circuit 

### DIFF
--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -274,6 +274,18 @@ class Circuit:
 
         return newcircuit
 
+    def __matmul__(self, circuit):
+        """Compose circuits.
+        In qibo this is the same as add circuits
+
+        Args:
+            circuit: Circuit to be composed with the current one.
+
+        Returns:
+            The circuit resulting from the composition.
+        """
+        return self + circuit
+
     @property
     def wire_names(self):
         return self._wire_names

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -93,6 +93,7 @@ def test_circuit_add():
     assert c.ngates == 3
     assert list(c.queue) == [g1, g2, g3]
 
+
 def test_circuit_matmul():
     c = Circuit(2)
     g1, g2, g3 = gates.H(0), gates.H(1), gates.CNOT(0, 1)
@@ -102,7 +103,9 @@ def test_circuit_matmul():
     c1 = c + c
     c2 = c @ c
     import numpy as np
-    assert np.linalg.norm( c1.unitary() - c2.unitary() ) < 1e-10
+
+    assert np.linalg.norm(c1.unitary() - c2.unitary()) < 1e-10
+
 
 def test_circuit_add_errors():
     c = Circuit(2)

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -93,6 +93,16 @@ def test_circuit_add():
     assert c.ngates == 3
     assert list(c.queue) == [g1, g2, g3]
 
+def test_circuit_matmul():
+    c = Circuit(2)
+    g1, g2, g3 = gates.H(0), gates.H(1), gates.CNOT(0, 1)
+    c.add(g1)
+    c.add(g2)
+    c.add(g3)
+    c1 = c + c
+    c2 = c @ c
+    import numpy as np
+    assert np.linalg.norm( c1.unitary() - c2.unitary() ) < 1e-10
 
 def test_circuit_add_errors():
     c = Circuit(2)


### PR DESCRIPTION
… because circuits are representations of  unitaries so it's also natural to multiply them. 

For example one can imagine a class which has a mode of running things in numpy or more symbolically on qibo.Circuit, with the @ symbol the same code will run irrespective of what is the underlying object.

```
class something:
    def __init__(self, data):
        self.data = data
        
    def __matmul__(self, thing):
        return __class__(self.data @ thing.data)

# @ will operate on Circuit c1
s1 = something(c1)
# @ will operate on the matrix
s2 = something(c1.unitary())

print( (s1 @ s1).data.unitary() - (s2 @ s2).data)
```

This arises from needing to wrap around myself conditioned on the type so for the numpy mode use @ and for Circuit use + 

The PR includes:
- implementation of __matmul__ by wrapping __add__
- test function checking norm equality after some compositions

Some more test code
```
from test_models_circuit import *
test_circuit_matmul()
c = Circuit(2)
c.add(gates.CNOT(0,1))
c1 = c+c
c2 = c @ c
import numpy as np
np.linalg.norm( c1.unitary() - c2.unitary())

print(c1.draw())
print(c2.draw())
print(c1.fuse().draw())
print(c2.fuse().draw())
c1.add(gates.H(1))
c3 = c1 @ c2 @ c1
print(c3.draw())
```







Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
