### PR TITLE
Add link to source code in the documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
+    "sphinx.ext.viewcode",
     "recommonmark",
     "nbsphinx",
 ]


### PR DESCRIPTION
I've added the sphinx extension [viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) which allows to visualize the source code directly from the documentation.

After a quick discussion with @BrunoLiegiBastonLiegi we think that it would be useful to improve the quality of the documentation. 

If we like this approach I can propagate it to the other repos.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
