### PR TITLE
Casting parameters as `float64` silencing `tf` warnings

### DIFF
--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -716,7 +716,7 @@ function.
 
     # Define circuit ansatz
     params = tf.Variable(
-        tf.random.uniform((2,), dtype=tf.float64).astype(tf.complex128)
+        tf.random.uniform((2,), dtype=tf.float64)
     )
     c = models.Circuit(2)
     c.add(gates.RX(0, params[0]))
@@ -729,7 +729,6 @@ function.
             fidelity = tf.math.abs(tf.reduce_sum(tf.math.conj(target_state) * final_state))
             loss = 1 - fidelity
         grads = tape.gradient(loss, params)
-        grads = tf.math.real(grads)
         optimizer.apply_gradients(zip([grads], [params]))
 
 
@@ -763,7 +762,6 @@ For example:
             fidelity = tf.math.abs(tf.reduce_sum(tf.math.conj(target_state) * final_state))
             loss = 1 - fidelity
         grads = tape.gradient(loss, params)
-        grads = tf.math.real(grads)
         optimizer.apply_gradients(zip([grads], [params]))
 
     for _ in range(nepochs):

--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -702,6 +702,9 @@ the following script optimizes the parameters of two rotations so that the circu
 output matches a target state using the fidelity as the corresponding loss
 function.
 
+Note that, as in the following example, the rotation angles have to assume real values
+to ensure the rotational gates are representing unitary operators.
+
 .. code-block:: python
 
     import qibo

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -32,8 +32,12 @@ class TensorflowBackend(NumpyBackend):
         super().__init__()
         self.name = "tensorflow"
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = str(TF_LOG_LEVEL)
+
         import tensorflow as tf  # pylint: disable=import-error
         import tensorflow.experimental.numpy as tnp  # pylint: disable=import-error
+
+        if TF_LOG_LEVEL >= 2:
+            tf.get_logger().setLevel("ERROR")
 
         tnp.experimental_enable_numpy_behavior()
         self.tf = tf

--- a/tests/test_models_circuit_backpropagation.py
+++ b/tests/test_models_circuit_backpropagation.py
@@ -22,7 +22,7 @@ def test_variable_backpropagation():
     backend = construct_tensorflow_backend()
     import tensorflow as tf
 
-    theta = tf.Variable(0.1234, dtype=tf.complex128)
+    theta = tf.Variable(0.1234, dtype=tf.float64)
     # TODO: Fix parametrized gates so that `Circuit` can be defined outside
     # of the gradient tape
     with tf.GradientTape() as tape:
@@ -45,7 +45,7 @@ def test_two_variables_backpropagation():
     backend = construct_tensorflow_backend()
     import tensorflow as tf
 
-    theta = tf.Variable([0.1234, 0.4321], dtype=tf.complex128)
+    theta = tf.Variable([0.1234, 0.4321], dtype=tf.float64)
     # TODO: Fix parametrized gates so that `Circuit` can be defined outside
     # of the gradient tape
     with tf.GradientTape() as tape:

--- a/tests/test_models_circuit_parametrized.py
+++ b/tests/test_models_circuit_parametrized.py
@@ -227,8 +227,8 @@ def test_variable_theta():
 
     import tensorflow as tf  # pylint: disable=import-error
 
-    theta1 = tf.Variable(0.1234, dtype=tf.complex128)
-    theta2 = tf.Variable(0.4321, dtype=tf.complex128)
+    theta1 = tf.Variable(0.1234, dtype=tf.float64)
+    theta2 = tf.Variable(0.4321, dtype=tf.float64)
     cvar = Circuit(2)
     cvar.add(gates.RX(0, theta1))
     cvar.add(gates.RY(1, theta2))


### PR DESCRIPTION
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
