### PR TITLE
Disable macos tests for pytorch circuit repetition

### DIFF
--- a/tests/test_models_circuit_features.py
+++ b/tests/test_models_circuit_features.py
@@ -1,5 +1,5 @@
 """Test how features defined in :class:`qibo.models.circuit.Circuit` work during circuit execution."""
-
+import sys
 from collections import Counter
 
 import numpy as np
@@ -306,7 +306,7 @@ def test_repeated_execute_with_pauli_noise(backend):
         == "Attempting to perform noisy simulation with `density_matrix=False` and no Measurement gate in the Circuit. If you wish to retrieve the statistics of the outcomes please include measurements in the circuit, otherwise set `density_matrix=True` to recover the final state."
     )
 
-
+@pytest.mark.skipif(sys.platform == "darwin", reason="Mac tests")
 @pytest.mark.parametrize("nqubits", [1, 2])
 def test_repeated_execute_probs_and_freqs(backend, nqubits):
     circuit = Circuit(nqubits)


### PR DESCRIPTION
Closes #1313, following the approach discussed during the qibo meeting.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
