### PR TITLE
random_clifford casting qubits to python int

### DIFF
--- a/src/qibo/quantum_info/random_ensembles.py
+++ b/src/qibo/quantum_info/random_ensembles.py
@@ -1104,17 +1104,17 @@ def _sample_from_quantum_mallows_distribution(nqubits: int, local_state):
 
 @cache
 def _create_S(q):
-    return gates.S(q)
+    return gates.S(int(q))
 
 
 @cache
 def _create_CZ(cq, tq):
-    return gates.CZ(cq, tq)
+    return gates.CZ(int(cq), int(tq))
 
 
 @cache
 def _create_CNOT(cq, tq):
-    return gates.CNOT(cq, tq)
+    return gates.CNOT(int(cq), int(tq))
 
 
 def _operator_from_hadamard_free_group(


### PR DESCRIPTION
Related to the bug observed in https://github.com/qiboteam/qibo-client/issues/39. It looks like the qubit numbers are stored as numpy.int64 instead of python int, therefore serialization with json does not work from the qibo-client side. Could you please confirm this patch is acceptable?

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
