### PR TITLE
Speed up `circuit.unitary()` using sparse matrices

### DIFF
--- a/src/qibo/optimizers.py
+++ b/src/qibo/optimizers.py
@@ -133,10 +133,20 @@ def cmaes(loss, initial_parameters, args=(), callback=None, options=None):
     """
     import cma
 
-    r = cma.fmin2(
-        loss, initial_parameters, 1.7, options=options, args=args, callback=callback
-    )
-    return r[1].result.fbest, r[1].result.xbest, r
+    es = cma.CMAEvolutionStrategy(initial_parameters, sigma0=1.7, inopts=options)
+
+    if callback is not None:
+        while not es.stop():
+            solutions = es.ask()
+            objective_values = [loss(x, *args) for x in solutions]
+            for solution in solutions:
+                callback(solution)
+            es.tell(solutions, objective_values)
+            es.logger.add()
+    else:
+        es.optimize(loss, args=args)
+
+    return es.result.fbest, es.result.xbest, es.result
 
 
 def newtonian(

--- a/tests/test_models_variational.py
+++ b/tests/test_models_variational.py
@@ -92,7 +92,7 @@ test_values = [
     ("BFGS", {"maxiter": 1}, False, "vqe_bfgs.out"),
     ("parallel_L-BFGS-B", {"maxiter": 1}, True, None),
     ("parallel_L-BFGS-B", {"maxiter": 1}, False, None),
-    ("cma", {"maxfevals": 2}, False, None),
+    ("cma", {"maxiter": 1}, False, None),
     ("sgd", {"nepochs": 5}, False, None),
     ("sgd", {"nepochs": 5}, True, None),
 ]
@@ -132,10 +132,6 @@ def test_vqe(backend, method, options, compile, filename):
     loss_values = []
 
     def callback(parameters, loss_values=loss_values, vqe=v):
-        # cma callback takes as input a CMAEvolutionStrategy class
-        # which keeps track of the best current solution into its .best.x
-        if method == "cma":
-            parameters = parameters.best.x
         vqe.circuit.set_parameters(parameters)
         loss_values.append(vqe.hamiltonian.expectation(vqe.circuit().state()))
 
@@ -153,7 +149,6 @@ def test_vqe(backend, method, options, compile, filename):
         shutil.rmtree("outcmaes")
     if filename is not None:
         assert_regression_fixture(backend, params, filename)
-
     assert best == min(loss_values)
 
     # test energy fluctuation
@@ -316,7 +311,7 @@ def test_falqon_optimization_callback(backend):
 test_names = "method,options,compile,filename"
 test_values = [
     ("BFGS", {"maxiter": 1}, False, "aavqe_bfgs.out"),
-    ("cma", {"maxfevals": 2}, False, None),
+    ("cma", {"maxiter": 1}, False, None),
     ("parallel_L-BFGS-B", {"maxiter": 1}, False, None),
 ]
 


### PR DESCRIPTION
This PR proposes to speed up `circuit.unitary()` which returns the unitary corresponding to the circuit by performing the multiplication of all matrices gates using sparse matrices instead. I think that it makes sense given that most of times we are dealing with single and two qubit gates, which could be seen as sparse operators for large number of qubits.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
