### PR TITLE
Fix value of the spectrum returned in the `quantum_info.entropies.von_neumann_entropy`

### DIFF
--- a/src/qibo/quantum_info/entropies.py
+++ b/src/qibo/quantum_info/entropies.py
@@ -1,4 +1,4 @@
-"""Submodule with entropy measures."""
+""Submodule with entropy measures."""
 
 from typing import Union
 
@@ -461,7 +461,7 @@ def von_neumann_entropy(
 
     if purity(state) == 1.0:
         if return_spectrum:
-            return 0.0, backend.cast([1.0], dtype=float)
+            return 0.0, backend.cast([0.0], dtype=float)
 
         return 0.0
 

--- a/src/qibo/quantum_info/entropies.py
+++ b/src/qibo/quantum_info/entropies.py
@@ -1,4 +1,4 @@
-""Submodule with entropy measures."""
+"""Submodule with entropy measures."""
 
 from typing import Union
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -97,7 +97,7 @@ def test_entropy_in_circuit(backend, density_matrix, base):
     values = [backend.to_numpy(x) for x in entropy]
     backend.assert_allclose(values, target, atol=PRECISION_TOL)
 
-    target_spectrum = [1.0] + list([0, 0, np.log(2), np.log(2)] / np.log(base))
+    target_spectrum = [0.0] + list([0, 0, np.log(2), np.log(2)] / np.log(base))
     entropy_spectrum = np.ravel(np.concatenate(entropy.spectrum)).tolist()
     backend.assert_allclose(entropy_spectrum, target_spectrum, atol=PRECISION_TOL)
 


### PR DESCRIPTION
The Von Neumann entropy function when return_spectrum=True returns -log(eigenvalues). However, if the state is pure, return_spectrum=True returned 1.0 which is the value of the eigenvalue, not the -log. The function is now changed to return 0.0 to be more consistent with the behavior of the function in the pure case.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
