### PR TITLE
Raise error when initial state shape is wrong

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -400,6 +400,16 @@ class NumpyBackend(Backend):
                 return self.execute_circuit(initial_state + circuit, None, nshots)
         elif initial_state is not None:
             initial_state = self.cast(initial_state)
+            if circuit.density_matrix:
+                valid_shape = 2 * (2**circuit.nqubits,)
+            else:
+                valid_shape = (2**circuit.nqubits,)
+            if tuple(initial_state.shape) != valid_shape:
+                raise_error(
+                    ValueError,
+                    f"Given initial state has shape {initial_state.shape} instead of "
+                    f"the expected {valid_shape}.",
+                )
 
         if circuit.repeated_execution:
             if circuit.measurements or circuit.has_collapse:

--- a/tests/test_models_circuit_execution.py
+++ b/tests/test_models_circuit_execution.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from qibo import Circuit, gates
+from qibo.quantum_info import random_density_matrix
 
 
 def test_eager_execute(backend, accelerators):
@@ -91,8 +92,6 @@ def test_final_state_property(backend):
 
 
 def test_density_matrix_circuit(backend):
-    from qibo.quantum_info import random_density_matrix
-
     initial_rho = random_density_matrix(2**3, backend=backend)
 
     c = Circuit(3, density_matrix=True)
@@ -146,3 +145,14 @@ def test_initial_state_error(backend):
 
     with pytest.raises(ValueError):
         backend.execute_circuit(c, c1)
+
+
+@pytest.mark.parametrize("density_matrix", [False, True])
+def test_initial_state_shape_error(backend, density_matrix):
+    nqubits = 2
+    c = Circuit(nqubits, density_matrix=density_matrix)
+    c.add(gates.X(i) for i in range(nqubits))
+
+    initial_state = random_density_matrix(2, backend=backend)
+    with pytest.raises(ValueError):
+        backend.execute_circuit(c, initial_state=initial_state)


### PR DESCRIPTION
Implements the fix described in https://github.com/qiboteam/qibo/issues/646#issuecomment-2160875608 and closes #646.

Note that without this, the qibojit-numba backend will proceed with execution and return wrong results, sometimes with a non-normalized final state or segmentation fault.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
