### PR TITLE
 Remove non-native backends

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -12,7 +12,6 @@ from qibo.backends.tensorflow import TensorflowBackend
 from qibo.config import log, raise_error
 
 QIBO_NATIVE_BACKENDS = ("numpy", "tensorflow", "pytorch")
-QIBO_NON_NATIVE_BACKENDS = ("qibojit", "qibolab", "qibo-cloud-backends", "qibotn")
 
 
 class MetaBackend:
@@ -206,19 +205,20 @@ def list_available_backends() -> dict:
 
 def construct_backend(backend, **kwargs) -> Backend:
     """Construct a generic native or non-native qibo backend.
+
     Args:
         backend (str): Name of the backend to load.
         kwargs (dict): Additional arguments for constructing the backend.
     Returns:
         qibo.backends.abstract.Backend: The loaded backend.
-
     """
     if backend in QIBO_NATIVE_BACKENDS + ("clifford",):
         return MetaBackend.load(backend, **kwargs)
-    elif backend in QIBO_NON_NATIVE_BACKENDS:
+
+    try:
         module = import_module(backend.replace("-", "_"))
         return getattr(module, "MetaBackend").load(**kwargs)
-    else:
+    except ImportError:
         raise_error(
             ValueError,
             f"Backend {backend} is not available. To check which backends are installed use `qibo.list_available_backends()`.",


### PR DESCRIPTION
This just escaped a previous review.

The idea of the `MetaBackend` was to avoid any need for an explicit registration in `qibo`, so let's make it complete removing all mentions of `"qibojit"` & friends.