### PR TITLE
Remove `TrotterCircuit` cache

### DIFF
--- a/tests/test_hamiltonians_trotter.py
+++ b/tests/test_hamiltonians_trotter.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from qibo import hamiltonians
+from qibo import hamiltonians, symbols
 from qibo.backends import NumpyBackend
 from qibo.quantum_info import random_hermitian, random_statevector
 
@@ -141,6 +141,14 @@ def test_trotter_hamiltonian_three_qubit_term(backend):
     target_state = np.dot(u[1], np.dot(u[0], initial_state))
     target_state = np.dot(u[0], np.dot(u[1], target_state))
     backend.assert_allclose(final_state, target_state)
+
+
+def test_symbolic_hamiltonian_circuit_different_dts(backend):
+    """Issue: https://github.com/qiboteam/qibo/issues/1357."""
+    ham = hamiltonians.SymbolicHamiltonian(symbols.Z(0))
+    a = ham.circuit(0.1)
+    b = ham.circuit(0.1)
+    assert np.linalg.norm(ham.circuit(0.2).unitary() - (a + b).unitary()) == 0
 
 
 def test_old_trotter_hamiltonian_errors():

--- a/tests/test_hamiltonians_trotter.py
+++ b/tests/test_hamiltonians_trotter.py
@@ -148,7 +148,9 @@ def test_symbolic_hamiltonian_circuit_different_dts(backend):
     ham = hamiltonians.SymbolicHamiltonian(symbols.Z(0))
     a = ham.circuit(0.1)
     b = ham.circuit(0.1)
-    assert np.linalg.norm(ham.circuit(0.2).unitary() - (a + b).unitary()) == 0
+    matrix1 = ham.circuit(0.2).unitary(backend)
+    matrix2 = (a + b).unitary(backend)
+    np.testing.assert_allclose(matrix1, matrix2)
 
 
 def test_old_trotter_hamiltonian_errors():


### PR DESCRIPTION
Fixes #1357. 

I believe the `TrotterCircuit` class is implementing a cache of the circuit implementing the Trotter decomposition returned by `hamiltonian.circuit(dt)` , to avoid recreating it if the users decides to use a different `dt`. However, this creates a ("secret") link between the circuits returned by `hamiltonian.circuit` that can confuse users, such as in #1357, and also complicates the code.

If allocating a circuit is not considered very costly, this cache probably does not provide much in terms of performance, therefore I decided to remove it to have cleaner code (and behavior).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
