### PR TITLE
Adding code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+# Qibo Code of Conduct
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and our
+community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+*   Using welcoming and inclusive language.
+*   Being respectful of differing viewpoints and experiences.
+*   Gracefully accepting constructive criticism.
+*   Focusing on what is best for the community.
+*   Showing empathy towards other community members.
+
+Examples of unacceptable behavior by participants include:
+
+*   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances.
+*   Trolling, insulting/derogatory comments, and personal or political attacks.
+*   Public or private harassment.
+*   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission.
+*   Conduct which could reasonably be considered inappropriate for the forum in
+    which it occurs.
+
+All Qibo forums and spaces are meant for professional interactions, and any
+behavior which could reasonably be considered inappropriate in a professional
+setting is unacceptable.
+
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+
+## Scope
+
+This Code of Conduct applies to all content on https://qibo.science, Qibo's
+GitHub organization, or any other official Qibo web presence allowing for
+community interactions, as well as at all official Qibo events, whether offline
+or online.
+
+The Code of Conduct also applies within project spaces and in public spaces
+whenever an individual is representing Qibo or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+or de facto representative at an online or offline event.
+
+
+## Conflict Resolution
+
+Conflicts in an open source project can take many forms, from someone having a
+bad day and using harsh and hurtful language in the issue queue, to more serious
+instances such as sexist/racist statements or threats of violence, and
+everything in between.
+
+If the behavior is threatening or harassing, or for other reasons requires
+immediate escalation, please see below.
+
+However, for the vast majority of issues, we aim to empower individuals to first
+resolve conflicts themselves, asking for help when needed, and only after that
+fails to escalate further. This approach gives people more control over the
+outcome of their dispute.
+
+If you are experiencing or witnessing conflict, we ask you to use the following
+escalation strategy to address the conflict:
+
+1.  Address the perceived conflict directly with those involved, preferably in a
+    real-time medium.
+2.  If this fails, get a third party (e.g. a mutual friend, and/or someone with
+    background on the issue, but not involved in the conflict) to intercede.
+3.  If you are still unable to resolve the conflict, and you believe it rises to
+    harassment or another code of conduct violation, report it.
+
+## Reporting Violations
+
+Violations of the Code of Conduct can be reported to Qibo's Project Coordinator,
+Stefano Carrazza (stefano.carrazza@unimi.it). The Project Coordinator will
+determine whether the Code of Conduct was violated, and will issue an
+appropriate sanction, possibly including a written warning or expulsion from the
+project, project sponsored spaces, or project forums. We ask that you make a
+good-faith effort to resolve your conflict via the conflict resolution policy
+before submitting a report.
+
+Violations of the Code of Conduct can occur in any setting, even those unrelated
+to the project. We will only consider complaints about conduct that has occurred
+within one year of the report.
+
+
+## Enforcement
+
+If the Project Coordinator receive a report alleging a violation of the Code of
+Conduct, the Project Coordinator will notify the accused of the report, and
+provide them an opportunity to discuss the report before a sanction is issued.
+The Project Coordinator will do his utmost to keep the reporter anonymous. If
+the act is ongoing (such as someone engaging in harassment), or involves a
+threat to anyone's safety (e.g. threats of violence), the Project Coordinator
+may issue sanctions without notice.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+available at https://contributor-covenant.org/version/1/4.


### PR DESCRIPTION
Including a code of conduct before elaborating the contributing guidelines.