### PR TITLE
Apply channel for Clifford circuits with `cupy`

### DIFF
--- a/src/qibo/backends/clifford.py
+++ b/src/qibo/backends/clifford.py
@@ -147,6 +147,7 @@ class CliffordBackend(NumpyBackend):
         index = self.np.random.choice(
             range(len(probabilities)), size=1, p=probabilities
         )[0]
+        index = int(index)
         if index != len(channel.gates):
             gate = channel.gates[index]
             state = gate.apply_clifford(self, state, nqubits)


### PR DESCRIPTION
This PR fixes a `TypeError` when using noise channels in Clifford circuits and running them with the `CliffordBackend` on GPU. It can be reproduced with the following code extracted from  [test_backends_clifford.py](https://github.com/qiboteam/qibo/blob/master/tests/test_backends_clifford.py):

```Python
import numpy as np
from qibo import gates
from qibo.backends import CliffordBackend
from qibo.quantum_info import random_clifford
from qibo.noise import NoiseModel, PauliError

backend = CliffordBackend('cupy')

nqubits = 3

c = random_clifford(nqubits, density_matrix=True, backend=backend)

noise = NoiseModel()
noisy_gates = np.random.choice(c.queue, size=1, replace=False)
noise.add(PauliError([("X", 0.3)]), noisy_gates[0].__class__)

c.add(gates.M(*range(nqubits)))

c = noise.apply(c)

result = backend.execute_circuit(c)
```
