### PR TITLE
Router sabre

### DIFF
--- a/src/qibo/transpiler/blocks.py
+++ b/src/qibo/transpiler/blocks.py
@@ -168,6 +168,18 @@ class CircuitBlocks:
                 BlockingError,
                 "The block you are trying to remove is not present in the circuit blocks.",
             )
+    
+    def return_last_block(self):
+        """Return the last block in the circuit blocks."""
+        if len(self.block_list) == 0:
+            raise_error(
+                BlockingError,
+                "No blocks found in the circuit blocks.",
+            )
+        return self.block_list[-1]
+        
+    
+
 
 
 def block_decomposition(circuit: Circuit, fuse: bool = True):

--- a/src/qibo/transpiler/router.py
+++ b/src/qibo/transpiler/router.py
@@ -659,8 +659,9 @@ class Sabre(Router):
         self.circuit = None
         self._memory_map = None
         self._final_measurements = None
-        self._temporary_added_swaps = 0
-        self._saved_circuit = None
+        # self._temporary_added_swaps = 0
+        # self._saved_circuit = None
+        self._temp_added_swaps = []
         random.seed(seed)
 
     def __call__(self, circuit: Circuit, initial_layout: dict):
@@ -689,7 +690,11 @@ class Sabre(Router):
             if (
                 self._temporary_added_swaps > self.swap_threshold * longest_path
             ):  # threshold is arbitrary
-                self.circuit = deepcopy(self._saved_circuit)
+                # self.circuit = deepcopy(self._saved_circuit)
+                while self._temp_added_swaps:
+                    swap = self._temp_added_swaps.pop()
+                    self.circuit.update(swap) # -1
+                self._temp_added_swaps = []
                 self._shortest_path_routing()
 
         circuit_kwargs = circuit.init_kwargs
@@ -799,8 +804,10 @@ class Sabre(Router):
 
         for qubit in self.circuit.logical_to_physical(best_candidate, index=True):
             self._delta_register[qubit] += self.delta
-        self.circuit.update(best_candidate)
-        self._temporary_added_swaps += 1
+        # self.circuit.update(best_candidate)
+        # self._temporary_added_swaps += 1
+        self._temp_added_swaps.append(best_candidate)
+
 
     def _compute_cost(self, candidate: int):
         """Compute the cost associated to a possible SWAP candidate."""
@@ -897,8 +904,9 @@ class Sabre(Router):
         self._update_front_layer()
         self._memory_map = []
         self._delta_register = [1.0 for _ in self._delta_register]
-        self._temporary_added_swaps = 0
-        self._saved_circuit = deepcopy(self.circuit)
+        # self._temporary_added_swaps = 0
+        # self._saved_circuit = deepcopy(self.circuit)
+        self._temp_added_swaps = []
 
     def _shortest_path_routing(self):
         """Route a gate in the front layer using the shortest path. This method is executed when the standard SABRE fails to find an optimized solution.

--- a/src/qibo/transpiler/router.py
+++ b/src/qibo/transpiler/router.py
@@ -250,10 +250,11 @@ class CircuitMap:
         physical_swap = self.logical_to_physical(swap, index=True)
         if undo:
             last_swap_block = self._routed_blocks.return_last_block()
-            if last_swap_block.gates[0].__class__ != gates.SWAP:
+            if last_swap_block.gates[0].__class__ != gates.SWAP or \
+                last_swap_block.qubits != physical_swap:
                 raise_error(
                     TranspilerPipelineError,
-                    "Last block is not a SWAP gate. Cannot undo SWAP.",
+                    "The last block does not match the current swap.",
                 )
             self._routed_blocks.remove_block(last_swap_block)
             self._swaps -= 1
@@ -703,7 +704,7 @@ class Sabre(Router):
                 # self.circuit = deepcopy(self._saved_circuit)
                 while self._temp_added_swaps:
                     swap = self._temp_added_swaps.pop()
-                    self.circuit.update(swap) # -1
+                    self.circuit.update(swap, undo=True)
                 self._temp_added_swaps = []
                 self._shortest_path_routing()
 


### PR DESCRIPTION
This PR is an addition to #1398.

Since `deepcopy()` makes the compiler slower, it needs to be changed.

[code](https://github.com/qiboteam/qibo/blob/9db9b666f67563122a5ab716ae689bfe579d333f/src/qibo/transpiler/router.py#L901)

Line 901 takes over 30% of the routing time.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
