### PR TITLE
Fix root cause of bug reported in PR #1412

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -645,9 +645,7 @@ class NumpyBackend(Backend):
         return self.cast(shots, dtype=shots[0].dtype)
 
     def samples_to_binary(self, samples, nqubits):
-        ### This is faster just staying @ NumPy.
         qrange = np.arange(nqubits - 1, -1, -1, dtype=np.int32)
-        samples = self.to_numpy(samples)
         return np.mod(np.right_shift(samples[:, None], qrange), 2)
 
     def samples_to_decimal(self, samples, nqubits):

--- a/src/qibo/measurements.py
+++ b/src/qibo/measurements.py
@@ -167,11 +167,12 @@ class MeasurementResult:
             # calculate samples for the whole circuit so that
             # individual register samples are registered here
             self.circuit.final_state.samples()
+
         if binary:
             return self._samples
-        else:
-            qubits = self.measurement_gate.target_qubits
-            return self.backend.samples_to_decimal(self._samples, len(qubits))
+
+        qubits = self.measurement_gate.target_qubits
+        return self.backend.samples_to_decimal(self._samples, len(qubits))
 
     def frequencies(self, binary=True, registers=False):
         """Returns the frequencies of measured samples.
@@ -198,8 +199,8 @@ class MeasurementResult:
         if binary:
             qubits = self.measurement_gate.target_qubits
             return frequencies_to_binary(self._frequencies, len(qubits))
-        else:
-            return self._frequencies
+
+        return self._frequencies
 
     def apply_bitflips(self, p0, p1=None):  # pragma: no cover
         return apply_bitflips(self, p0, p1)

--- a/src/qibo/result.py
+++ b/src/qibo/result.py
@@ -325,12 +325,7 @@ class MeasurementOutcomes:
         if self._samples is None:
             if self.measurements[0].result.has_samples():
                 self._samples = self.backend.np.concatenate(
-                    [
-                        self.backend.cast(
-                            gate.result.samples(), dtype=self.backend.np.int32
-                        )
-                        for gate in self.measurements
-                    ],
+                    [gate.result.samples() for gate in self.measurements],
                     axis=1,
                 )
             else:


### PR DESCRIPTION
The root cause of the issue raised in #1412 was a `cast` to `numpy` inside `NumpyBackend.samples_to_binary`. That is what was turning the subsequent `cast` into a requirement for `torch`. Without the former, the latter could be removed.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
