### PR TITLE
Serialization of measurements

### DIFF
--- a/src/qibo/backends/clifford.py
+++ b/src/qibo/backends/clifford.py
@@ -259,7 +259,7 @@ class CliffordBackend(NumpyBackend):
         samples = self.np.vstack(samples)
 
         for meas in circuit.measurements:
-            meas.result.register_samples(samples[:, meas.target_qubits], self)
+            meas.result.register_samples(samples[:, meas.target_qubits])
 
         result = Clifford(
             self.zero_state(circuit.nqubits),

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -119,7 +119,7 @@ class Gate:
 
         gate = cls(*raw["init_args"], **raw["init_kwargs"])
         if raw["_class"] == "M" and raw["samples"] is not None:
-            gate.result.register_samples(self.backend.cast(raw["samples"], int))
+            gate.result.register_samples(raw["samples"])
         try:
             return gate.controlled_by(*raw["_control_qubits"])
         except RuntimeError as e:

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -14,7 +14,18 @@ REQUIRED_FIELDS = [
     "_target_qubits",
     "_control_qubits",
 ]
-REQUIRED_FIELDS_INIT_KWARGS = ["theta", "phi", "lam", "phi0", "phi1"]
+REQUIRED_FIELDS_INIT_KWARGS = [
+    "theta",
+    "phi",
+    "lam",
+    "phi0",
+    "phi1",
+    "register_name",
+    "collapse",
+    "basis",
+    "p0",
+    "p1",
+]
 
 
 class Gate:
@@ -107,6 +118,8 @@ class Gate:
             raise ValueError(f"Unknown gate {raw['_class']}")
 
         gate = cls(*raw["init_args"], **raw["init_kwargs"])
+        if raw["_class"] == "M" and raw["samples"] is not None:
+            gate.result.register_samples(self.backend.cast(raw["samples"], int))
         try:
             return gate.controlled_by(*raw["_control_qubits"])
         except RuntimeError as e:

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -119,7 +119,7 @@ class Gate:
 
         gate = cls(*raw["init_args"], **raw["init_kwargs"])
         if raw["_class"] == "M" and raw["samples"] is not None:
-            gate.result.register_samples(raw["samples"])
+            gate.result.register_samples(raw["measurement_result"]["samples"])
         try:
             return gate.controlled_by(*raw["_control_qubits"])
         except RuntimeError as e:

--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -118,7 +118,7 @@ class Gate:
             raise ValueError(f"Unknown gate {raw['_class']}")
 
         gate = cls(*raw["init_args"], **raw["init_kwargs"])
-        if raw["_class"] == "M" and raw["samples"] is not None:
+        if raw["_class"] == "M" and raw["measurement_result"]["samples"] is not None:
             gate.result.register_samples(raw["measurement_result"]["samples"])
         try:
             return gate.controlled_by(*raw["_control_qubits"])

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -115,7 +115,7 @@ class M(Gate):
         gate.
         """
         encoded_simple = super().raw
-        encoded_simple.update(self.result.raw)
+        encoded_simple.update({"measurement_result": self.result.raw})
         return encoded_simple
 
     @staticmethod

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -194,7 +194,7 @@ class M(Gate):
         qubits = sorted(self.target_qubits)
         # measure and get result
         probs = backend.calculate_probabilities(state, qubits, nqubits)
-        shot = self.result.add_shot(probs)
+        shot = self.result.add_shot(probs, backend=backend)
         # collapse state
         return backend.collapse_state(state, qubits, shot, nqubits)
 
@@ -206,7 +206,7 @@ class M(Gate):
         qubits = sorted(self.target_qubits)
         # measure and get result
         probs = backend.calculate_probabilities_density_matrix(state, qubits, nqubits)
-        shot = self.result.add_shot(probs)
+        shot = self.result.add_shot(probs, backend=backend)
         # collapse state
         return backend.collapse_density_matrix(state, qubits, shot, nqubits)
 

--- a/src/qibo/measurements.py
+++ b/src/qibo/measurements.py
@@ -96,6 +96,11 @@ class MeasurementResult:
         nshots = self.nshots
         return f"MeasurementResult(qubits={qubits}, nshots={nshots})"
 
+    @property
+    def raw(self) -> dict:
+        samples = self._samples.tolist() if self.has_samples() else self._samples
+        return {"samples": samples}
+
     def add_shot(self, probs):
         qubits = sorted(self.measurement_gate.target_qubits)
         shot = self.backend.sample_shots(probs, 1)
@@ -117,12 +122,12 @@ class MeasurementResult:
     def has_samples(self):
         return self._samples is not None
 
-    def register_samples(self, samples, backend=None):
+    def register_samples(self, samples):
         """Register samples array to the ``MeasurementResult`` object."""
         self._samples = samples
         self.nshots = len(samples)
 
-    def register_frequencies(self, frequencies, backend=None):
+    def register_frequencies(self, frequencies):
         """Register frequencies to the ``MeasurementResult`` object."""
         self._frequencies = frequencies
         self.nshots = sum(frequencies.values())

--- a/src/qibo/measurements.py
+++ b/src/qibo/measurements.py
@@ -124,7 +124,7 @@ class MeasurementResult:
 
     def register_samples(self, samples):
         """Register samples array to the ``MeasurementResult`` object."""
-        self._samples = samples
+        self._samples = self.backend.cast(samples, int)
         self.nshots = len(samples)
 
     def register_frequencies(self, frequencies):

--- a/src/qibo/measurements.py
+++ b/src/qibo/measurements.py
@@ -80,8 +80,10 @@ class MeasurementResult:
     """
 
     def __init__(self, gate, nshots=0, backend=None):
+        from qibo.backends import _check_backend
+
         self.measurement_gate = gate
-        self.backend = backend
+        self.backend = _check_backend(backend)
         self.nshots = nshots
         self.circuit = None
 
@@ -124,7 +126,7 @@ class MeasurementResult:
 
     def register_samples(self, samples):
         """Register samples array to the ``MeasurementResult`` object."""
-        self._samples = self.backend.cast(samples, int)
+        self._samples = self.backend.cast(samples, self.backend.np.int64)
         self.nshots = len(samples)
 
     def register_frequencies(self, frequencies):

--- a/src/qibo/quantum_info/clifford.py
+++ b/src/qibo/quantum_info/clifford.py
@@ -269,7 +269,7 @@ class Clifford:
             self._samples = self._backend.cast(samples, dtype="int32")
             for gate in self.measurements:
                 rqubits = tuple(qubit_map.get(q) for q in gate.target_qubits)
-                gate.result.register_samples(self._samples[:, rqubits], self._backend)
+                gate.result.register_samples(self._samples[:, rqubits])
 
         if registers:
             return {

--- a/src/qibo/result.py
+++ b/src/qibo/result.py
@@ -244,7 +244,7 @@ class MeasurementOutcomes:
                             if int(bitstring[qubit_map.get(q)]):
                                 idx += 2 ** (len(rqubits) - i - 1)
                         rfreqs[idx] += freq
-                    gate.result.register_frequencies(rfreqs, self.backend)
+                    gate.result.register_frequencies(rfreqs)
             else:
                 self._frequencies = self.backend.calculate_frequencies(
                     self.samples(binary=False)
@@ -356,9 +356,7 @@ class MeasurementOutcomes:
                 self._samples = samples
                 for gate in self.measurements:
                     rqubits = tuple(qubit_map.get(q) for q in gate.target_qubits)
-                    gate.result.register_samples(
-                        self._samples[:, rqubits], self.backend
-                    )
+                    gate.result.register_samples(self._samples[:, rqubits])
 
         if registers:
             return {

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from qibo import gates, models
+from qibo.measurements import MeasurementResult
 
 
 def assert_result(
@@ -473,3 +474,23 @@ def test_measurementsymbol_pickling(backend):
         assert symbol.index == new_symbol.index
         assert symbol.name == new_symbol.name
         backend.assert_allclose(symbol.result.samples(), new_symbol.result.samples())
+
+
+def test_measurementresult_nshots(backend):
+    gate = gates.M(*range(3))
+    result = MeasurementResult(gate)
+    # nshots starting from samples
+    nshots = 10
+    samples = backend.cast(
+        [[i % 2, i % 2, i % 2] for i in range(nshots)], backend.np.int64
+    )
+    result.register_samples(samples)
+    assert result.nshots == nshots
+    # nshots starting from frequencies
+    result = MeasurementResult(gate)
+    states, counts = np.unique(samples, axis=0, return_counts=True)
+    to_str = lambda x: [str(item) for item in x]
+    states = ["".join(to_str(s)) for s in states.tolist()]
+    freq = dict(zip(states, counts.tolist()))
+    result.register_frequencies(freq)
+    assert result.nshots == nshots

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -8,12 +8,12 @@ from qibo.symbols import I, Z
 
 
 def test_measurement_result_repr():
-    result = MeasurementResult(gates.M(0), nshots=10)
-    assert str(result) == "MeasurementResult(qubits=(0,), nshots=10)"
+    result = MeasurementResult(gates.M(0))
+    assert str(result) == "MeasurementResult(qubits=(0,), nshots=None)"
 
 
 def test_measurement_result_error():
-    result = MeasurementResult(gates.M(0), nshots=10)
+    result = MeasurementResult(gates.M(0))
     with pytest.raises(RuntimeError):
         samples = result.samples()
 


### PR DESCRIPTION
This addresses the bug #1426 by implementing a proper serialization of measurement gates and their result.
Furthermore, the possibility to specify the `basis` of measurement gates with strings (for instance `"Z"` or `["X", "Z", "Y"]`) has been added.
I also made some minor modifications to `MeasurementResult`, and I would also like to remove the `circuit` attribute from it. At the moment it is only used to generate the samples when they are not available. However, as I see it, the `MeasurementResult` should always be associated with the samples.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
