### PR TITLE
Fix Shor example

### DIFF
--- a/examples/shor/functions.py
+++ b/examples/shor/functions.py
@@ -393,8 +393,9 @@ def quantum_order_finding_semiclassical(N, a):
         circuit.add(gates.U1(q_reg, -angle))
         circuit.add(gates.H(q_reg))
         results.append(circuit.add(gates.M(q_reg, collapse=True)))
+    circuit.add(gates.M(q_reg))
 
-    circuit()  # execute
+    circuit(nshots=1)  # execute
     s = sum(int(r.symbols[0].outcome()) * (2**i) for i, r in enumerate(results))
     print(f"The quantum circuit measures s = {s}.\n")
     return s


### PR DESCRIPTION
Fix Shor example, which is outdated since #1039, as reported in #1432.

The measurement in the end is needed because it is no longer possible to execute circuits that contain only collapse measurements using state vectors.

Specifying `nshots=1` is needed because a default `nshots=1000` was introduced in #1039 compared to the `None` being used before. This was also causing the performance issue reported in #1432, because during the repeated execution it was executing the circuit 1000 times instead of one that we need.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
