### PR TITLE
Fix doc warnings

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -473,7 +473,8 @@ factor results in the mitigated Pauli expectation value :math:`\langle O\rangle_
 .. math::
    \langle O\rangle_{ideal} = \frac{\langle O\rangle_{noisy}}{\lambda}
 
-.. autofunction:: qibo.models.error_mitigation.apply_randomized_readout_mitigation
+This process can be implemented with the aforementioned 
+:func:`qibo.models.error_mitigation.apply_randomized_readout_mitigation`.
 
 
 Zero Noise Extrapolation (ZNE)

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -193,7 +193,7 @@ class Backend(abc.ABC):
     def execute_circuits(
         self, circuits, initial_states=None, nshots=None
     ):  # pragma: no cover
-        """Execute multiple :class:`qibo.models.circuit.Circuit`s in parallel."""
+        """Execute multiple :class:`qibo.models.circuit.Circuit` in parallel."""
         raise_error(NotImplementedError)
 
     @abc.abstractmethod

--- a/src/qibo/backends/clifford.py
+++ b/src/qibo/backends/clifford.py
@@ -90,13 +90,13 @@ class CliffordBackend(NumpyBackend):
         return collections.Counter(dict(zip(res, counts)))
 
     def zero_state(self, nqubits: int):
-        """Construct the zero state |00...00>.
+        """Construct the zero state :math`\\ket{00...00}`.
 
         Args:
-            nqubits (int): Number of qubits.
+            nqubits (int): number of qubits.
 
         Returns:
-            (ndarray): Symplectic matrix for the zero state.
+            ndarray: Symplectic matrix for the zero state.
         """
         identity = self.np.eye(nqubits)
         symplectic_matrix = self.np.zeros(

--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -17,27 +17,26 @@ class M(Gate):
             If the qubits to measure are held in an iterable (eg. list) the ``*``
             operator can be used, for example ``gates.M(*[0, 1, 4])`` or
             ``gates.M(*range(5))``.
-        register_name (str): Optional name of the register to distinguish it
+        register_name (str, optional): Optional name of the register to distinguish it
             from other registers when used in circuits.
         collapse (bool): Collapse the state vector after the measurement is
             performed. Can be used only for single shot measurements.
             If ``True`` the collapsed state vector is returned. If ``False``
             the measurement result is returned.
-        basis (:class:`qibo.gates.Gate`, str, list): Basis to measure.
+        basis (:class:`qibo.gates.Gate` or str or list, optional): Basis to measure.
             Can be either:
             - a qibo gate
             - the string representing the gate
             - a callable that accepts a qubit, for example: ``lambda q: gates.RX(q, 0.2)``
-            - a list of the above, if a different basis will be used for each
-              measurement qubit.
-            Default is Z.
-        p0 (dict): Optional bitflip probability map. Can be:
+            - a list of the above, if a different basis will be used for each measurement qubit.
+            Defaults is to :class:`qibo.gates.Z`.
+        p0 (dict, optional): bitflip probability map. Can be:
             A dictionary that maps each measured qubit to the probability
             that it is flipped, a list or tuple that has the same length
             as the tuple of measured qubits or a single float number.
             If a single float is given the same probability will be used
             for all qubits.
-        p1 (dict): Optional bitflip probability map for asymmetric bitflips.
+        p1 (dict, optional): bitflip probability map for asymmetric bitflips.
             Same as ``p0`` but controls the 1->0 bitflip probability.
             If ``p1`` is ``None`` then ``p0`` will be used both for 0->1 and
             1->0 bitflips.

--- a/src/qibo/models/error_mitigation.py
+++ b/src/qibo/models/error_mitigation.py
@@ -658,8 +658,8 @@ def apply_randomized_readout_mitigation(
         nshots (int, optional): number of shots. Defaults to :math:`10000`.
         ncircuits (int, optional): number of randomized circuits. Each of them uses
             ``int(nshots / ncircuits)`` shots. Defaults to 10.
-        qubit_map (list, optional): the qubit map. If None, a list of range of circuit's qubits is used.
-            Defaults to ``None``.
+        qubit_map (list, optional): the qubit map. If ``None``, a list of range of circuit's 
+            qubits is used. Defaults to ``None``.
         seed (int or :class:`numpy.random.Generator`, optional): Either a generator of random
             numbers or a fixed seed to initialize a generator. If ``None``, initializes
             a generator with a random seed. Default: ``None``.
@@ -667,15 +667,15 @@ def apply_randomized_readout_mitigation(
             in the execution. If ``None``, it uses :class:`qibo.backends.GlobalBackend`.
             Defaults to ``None``.
 
-    Return:
+    Returns:
         :class:`qibo.measurements.CircuitResult`: the state of the input circuit with
             mitigated frequencies.
 
 
-    Reference:
+    References:
         1. Ewout van den Berg, Zlatko K. Minev et al,
         *Model-free readout-error mitigation for quantum expectation values*.
-           `arXiv:2012.09738 [quant-ph] <https://arxiv.org/abs/2012.09738>`_.
+        `arXiv:2012.09738 [quant-ph] <https://arxiv.org/abs/2012.09738>`_.
     """
     from qibo import Circuit  # pylint: disable=import-outside-toplevel
     from qibo.quantum_info import (  # pylint: disable=import-outside-toplevel

--- a/src/qibo/quantum_info/clifford.py
+++ b/src/qibo/quantum_info/clifford.py
@@ -297,16 +297,16 @@ class Clifford:
             of times each measured value/bitstring appears.
 
             If ``binary`` is ``True``
-                the keys of the `Counter` are in binary form, as strings of
-                :math:`0`s and :math`1`s.
+                the keys of the :class:`collections.Counter` are in binary form, 
+                as strings of :math:`0` and :math`1`.
             If ``binary`` is ``False``
-                the keys of the ``Counter`` are integers.
+                the keys of the :class:`collections.Counter` are integers.
             If ``registers`` is ``True``
-                a `dict` of `Counter` s is returned where keys are the name of
-                each register.
+                a `dict` of :class:`collections.Counter` is returned where keys are
+                the name of each register.
             If ``registers`` is ``False``
-                a single ``Counter`` is returned which contains samples from all
-                the measured qubits, independently of their registers.
+                a single :class:`collections.Counter` is returned which contains samples 
+                from all the measured qubits, independently of their registers.
         """
         measured_qubits = self.measurement_gate.target_qubits
         freq = self._backend.calculate_frequencies(self.samples(False))

--- a/src/qibo/result.py
+++ b/src/qibo/result.py
@@ -191,25 +191,27 @@ class MeasurementOutcomes:
         """Returns the frequencies of measured samples.
 
         Args:
-            binary (bool, optional): Return frequency keys in binary or decimal form.
+            binary (bool, optional): If ``True``, returns frequency keys in binary form.
+                If ``False``, returns them in decimal form. Defaults to ``True``.
             registers (bool, optional): Group frequencies according to registers.
+                Defaults to ``False``.
 
         Returns:
-            A `collections.Counter` where the keys are the observed values
+            A :class:`collections.Counter` where the keys are the observed values
             and the values the corresponding frequencies, that is the number
             of times each measured value/bitstring appears.
 
             If ``binary`` is ``True``
-                the keys of the `Counter` are in binary form, as strings of
-                :math:`0`s and :math`1`s.
+                the keys of the :class:`collections.Counter` are in binary form, 
+                as strings of :math:`0` and :math`1`.
             If ``binary`` is ``False``
-                the keys of the ``Counter`` are integers.
+                the keys of the :class:`collections.Counter` are integers.
             If ``registers`` is ``True``
-                a `dict` of `Counter` s is returned where keys are the name of
-                each register.
+                a `dict` of :class:`collections.Counter` is returned where keys are
+                the name of each register.
             If ``registers`` is ``False``
-                a single ``Counter`` is returned which contains samples from all
-                the measured qubits, independently of their registers.
+                a single :class:`collections.Counter` is returned which contains samples 
+                from all the measured qubits, independently of their registers.
         """
         qubits = self.measurement_gate.qubits
 

--- a/src/qibo/ui/mpldrawer.py
+++ b/src/qibo/ui/mpldrawer.py
@@ -601,7 +601,7 @@ def _process_gates(array_gates):
                 item += ("q_" + str(qbit),)
                 gates_plot.append(item)
         elif init_label == "ENTANGLEMENTENTROPY":
-            for qbit in list(range(circuit.nqubits)):
+            for qbit in list(range(circuit.nqubits)):  # pylint: disable=E0602
                 item = (init_label,)
                 item += ("q_" + str(qbit),)
                 gates_plot.append(item)


### PR DESCRIPTION
This closes almost all warnings in the docs that are not already being closed by #1441.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
