### PR TITLE
Fix definition of `fidelity` in `quantum_info.metrics`

### DIFF
--- a/src/qibo/quantum_info/metrics.py
+++ b/src/qibo/quantum_info/metrics.py
@@ -272,7 +272,7 @@ def fidelity(state, target, check_hermitian: bool = False, backend=None):
                     fid = fid + matrix
                     del matrix
 
-            fid = backend.np.real(backend.np.trace(fid)) ** 2
+            fid = backend.np.real(backend.np.trace(fid))
 
             return fid
 

--- a/tests/test_quantum_info_metrics.py
+++ b/tests/test_quantum_info_metrics.py
@@ -255,14 +255,6 @@ def test_fidelity_and_infidelity_and_bures(backend, check_hermitian):
         atol=PRECISION_TOL,
     )
 
-    state = random_unitary(4, backend=backend)
-    target = random_unitary(4, backend=backend)
-    if backend.__class__.__name__ in ["CupyBackend", "CuQuantumBackend"]:
-        with pytest.raises(NotImplementedError):
-            test = fidelity(state, target, check_hermitian=True, backend=backend)
-    else:
-        test = fidelity(state, target, check_hermitian=True, backend=backend)
-
 
 @pytest.mark.parametrize("seed", [10])
 def test_process_fidelity_and_infidelity(backend, seed):


### PR DESCRIPTION
Two different definitions of fidelity were being mixed, one with $\text{Tr}$ and another with $\text{Tr}^{2}$. This PR fixes it.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
