### PR TITLE
Remove circular dependency between `MeasurementResult` and `M` gate

### DIFF
--- a/src/qibo/gates/measurements.py
+++ b/src/qibo/gates/measurements.py
@@ -57,7 +57,7 @@ class M(Gate):
         self.target_qubits = tuple(q)
         self.register_name = register_name
         self.collapse = collapse
-        self.result = MeasurementResult(self)
+        self.result = MeasurementResult(self.target_qubits)
         # list of measurement pulses implementing the gate
         # relevant for experiments only
         self.pulses = None

--- a/src/qibo/measurements.py
+++ b/src/qibo/measurements.py
@@ -86,8 +86,8 @@ class MeasurementResult:
             to use for calculations.
     """
 
-    def __init__(self, gate):
-        self.measurement_gate = gate
+    def __init__(self, qubits):
+        self.target_qubits = qubits
         self.circuit = None
 
         self._samples = None
@@ -115,7 +115,7 @@ class MeasurementResult:
 
     def add_shot(self, probs, backend=None):
         backend = _check_backend(backend)
-        qubits = sorted(self.measurement_gate.target_qubits)
+        qubits = sorted(self.target_qubits)
         shot = backend.sample_shots(probs, 1)
         bshot = backend.samples_to_binary(shot, len(qubits))
         if self._samples:
@@ -153,7 +153,7 @@ class MeasurementResult:
         These symbols are useful for conditioning parametrized gates on measurement outcomes.
         """
         if self._symbols is None:
-            qubits = self.measurement_gate.target_qubits
+            qubits = self.target_qubits
             self._symbols = [MeasurementSymbol(i, self) for i in range(len(qubits))]
 
         return self._symbols
@@ -186,7 +186,7 @@ class MeasurementResult:
         if binary:
             return self._samples
 
-        qubits = self.measurement_gate.target_qubits
+        qubits = self.target_qubits
         return backend.samples_to_decimal(self._samples, len(qubits))
 
     def frequencies(self, binary=True, registers=False, backend=None):
@@ -213,7 +213,7 @@ class MeasurementResult:
                 self.samples(binary=False)
             )
         if binary:
-            qubits = self.measurement_gate.target_qubits
+            qubits = self.target_qubits
             return frequencies_to_binary(self._frequencies, len(qubits))
 
         return self._frequencies

--- a/src/qibo/measurements.py
+++ b/src/qibo/measurements.py
@@ -97,7 +97,7 @@ class MeasurementResult:
         self._symbols = None
 
     def __repr__(self):
-        qubits = self.measurement_gate.qubits
+        qubits = self.target_qubits
         nshots = self.nshots
         return f"MeasurementResult(qubits={qubits}, nshots={nshots})"
 

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -478,7 +478,7 @@ def test_measurementsymbol_pickling(backend):
 
 def test_measurementresult_nshots(backend):
     gate = gates.M(*range(3))
-    result = MeasurementResult(gate)
+    result = MeasurementResult(gate.qubits)
     # nshots starting from samples
     nshots = 10
     samples = backend.cast(
@@ -487,7 +487,7 @@ def test_measurementresult_nshots(backend):
     result.register_samples(samples)
     assert result.nshots == nshots
     # nshots starting from frequencies
-    result = MeasurementResult(gate)
+    result = MeasurementResult(gate.qubits)
     states, counts = np.unique(samples, axis=0, return_counts=True)
     to_str = lambda x: [str(item) for item in x]
     states = ["".join(to_str(s)) for s in states.tolist()]

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -13,7 +13,7 @@ def test_measurement_result_repr():
 
 
 def test_measurement_result_error():
-    result = MeasurementResult(gates.M(0))
+    result = MeasurementResult(gates.M(0).qubits)
     with pytest.raises(RuntimeError):
         samples = result.samples()
 

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -8,7 +8,7 @@ from qibo.symbols import I, Z
 
 
 def test_measurement_result_repr():
-    result = MeasurementResult(gates.M(0))
+    result = MeasurementResult(gates.M(0).target_qubits)
     assert str(result) == "MeasurementResult(qubits=(0,), nshots=None)"
 
 


### PR DESCRIPTION
This should close #1433

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
