### PR TITLE
Support `Align` gate in `QASM`

### DIFF
--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -529,6 +529,10 @@ class Align(ParametrizedGate):
         self._parameters = (delay,)
         self.nparams = 1
 
+    @property
+    def qasm_label(self):
+        return "align"
+
 
 def _is_clifford_given_angle(angle):
     """Helper function to update Clifford boolean condition according to the given angle ``angle``."""

--- a/src/qibo/models/_openqasm.py
+++ b/src/qibo/models/_openqasm.py
@@ -109,6 +109,9 @@ def _qibo_gate_name(gate):
     if gate == "ccx":
         return "TOFFOLI"
 
+    if gate == "align":
+        return "Align"
+
     return gate.upper()
 
 


### PR DESCRIPTION
This adds support for the `Align` gate to the qasm parser and should close #1478. However, this implementation is not compatible with `qiskit` which begs for defining the `delay` gate (their equivalent to our align) as a special operation:
``` python
OPENQASM 2.0;
include "qelib1.inc";
opaque delay(param0) q0;
qreg q[1];
delay(1.0) q[0];
``` 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
