### PR TITLE
Skipping controlled `try/except` for `M` gate in `from_dict`

### DIFF
--- a/src/qibo/gates/abstract.py
+++ b/src/qibo/gates/abstract.py
@@ -118,8 +118,10 @@ class Gate:
             raise ValueError(f"Unknown gate {raw['_class']}")
 
         gate = cls(*raw["init_args"], **raw["init_kwargs"])
-        if raw["_class"] == "M" and raw["measurement_result"]["samples"] is not None:
-            gate.result.register_samples(raw["measurement_result"]["samples"])
+        if raw["_class"] == "M":
+            if raw["measurement_result"]["samples"] is not None:
+                gate.result.register_samples(raw["measurement_result"]["samples"])
+            return gate
         try:
             return gate.controlled_by(*raw["_control_qubits"])
         except RuntimeError as e:


### PR DESCRIPTION
This avoids the `try/except` for controlled gates in `from_dict` when the gate is a measurement. Should close #1482. 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
