### PR TITLE
Unsupported native gates

### DIFF
--- a/src/qibo/transpiler/unroller.py
+++ b/src/qibo/transpiler/unroller.py
@@ -4,7 +4,7 @@ from operator import or_
 
 from qibo import gates
 from qibo.backends import _check_backend
-from qibo.config import raise_error
+from qibo.config import log, raise_error
 from qibo.models import Circuit
 from qibo.transpiler._exceptions import DecompositionError
 from qibo.transpiler.decompositions import (
@@ -22,7 +22,11 @@ class FlagMeta(EnumMeta):
 
     def __getitem__(cls, keys):
         if isinstance(keys, str):
-            return super().__getitem__(keys)
+            try:
+                return super().__getitem__(keys)
+            except KeyError:
+                log.info(f"Native gate {keys} is not supported by qibo.")
+                return super().__getitem__("NONE")
         return reduce(or_, [cls[key] for key in keys])  # pylint: disable=E1136
 
 
@@ -44,6 +48,7 @@ class NativeGates(Flag, metaclass=FlagMeta):
         - :class:`qibo.gates.gates.CNOT`
     """
 
+    NONE = 0
     I = auto()
     Z = auto()
     RZ = auto()

--- a/src/qibo/transpiler/unroller.py
+++ b/src/qibo/transpiler/unroller.py
@@ -25,7 +25,6 @@ class FlagMeta(EnumMeta):
             try:
                 return super().__getitem__(keys)
             except KeyError:
-                log.info(f"Native gate {keys} is not supported by qibo.")
                 return super().__getitem__("NONE")
         return reduce(or_, [cls[key] for key in keys])  # pylint: disable=E1136
 

--- a/tests/test_transpiler_unroller.py
+++ b/tests/test_transpiler_unroller.py
@@ -27,8 +27,8 @@ def test_native_gate_str_list():
     for gate in testlist:
         assert NativeGates[gate] in natives
 
-    with pytest.raises(KeyError):
-        NativeGates[["qi", "bo"]]  # Invalid gate names
+    natives = NativeGates[["qi", "bo"]]  # Invalid gate names
+    assert natives == NativeGates(0)
 
 
 def test_translate_gate_error_1q():


### PR DESCRIPTION
`Unroller` generates an error when initialized with unsupported gates.

https://github.com/qiboteam/qibolab/actions/runs/11569426877/job/32203123767?pr=1083#step:10:259

In this PR, when qibo receives native gates, unsupported gates will be ignored. Should we require backends to match qibo’s native gate set?

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.


https://github.com/qiboteam/qibolab/pull/1083
