### PR TITLE
Avoid logging for missing backends

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -329,8 +329,7 @@ def construct_backend(backend, **kwargs) -> Backend:  # pylint: disable=R1710
         # pylint: disable=unsupported-membership-test
         if provider not in e.msg:
             raise e
-        raise_error(
-            MissingBackend,
+        raise MissingBackend(
             f"The '{backend}' backends' provider is not available. Check that a Python "
             + f"package named '{provider}' is installed, and it is exposing valid Qibo "
             + "backends.",


### PR DESCRIPTION
Restore 95c71fa3b413e30f6d7577c64655626a1ba5b3f1 after removal in 2fdbf852c3ce9f1d734e9b81bc6bd93284bd73fb as part of https://github.com/qiboteam/qibo/pull/1479.

I'm still not introducing any test, since I'd need an environment without `qibojit` installed. I already have an attempt of doing it, cf. #1495, but it's on hold because working locally, but not in the CI (just on macOS).