### PR TITLE
Temporary fix for `q{i}` mapping

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -152,7 +152,9 @@ class _Global:
             edges = [
                 (node_mapping[e[0]], node_mapping[e[1]]) for e in connectivity_edges
             ]
-            connectivity = nx.Graph(edges)
+            connectivity = nx.Graph()
+            connectivity.add_nodes_from(list(node_mapping.values()))
+            connectivity.add_edges_from(edges)
 
             return Passes(
                 connectivity=connectivity,


### PR DESCRIPTION
The name of the `i`th hardware qubit is stored at index `i` in `QibolabBackend.qubits`. When passed to current qibo implementation, this is then converted to `q{i}` and stored in `initial_layout`. 

This PR ensures that the keys in `initial_layout` (the hardware qubit names) are sorted during default transpilation, so `i` in `gate.qubits` in transpiled circuit consistently refers to the `i`th hardware qubit.

Will be deprecated after #1500.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
