### PR TITLE
Reset Transpiler When Setting Backends

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -115,6 +115,7 @@ class _Global:
     @classmethod
     def set_backend(cls, backend, **kwargs):
         cls._backend = construct_backend(backend, **kwargs)
+        cls._transpiler = None
         log.info(f"Using {cls._backend} backend on {cls._backend.device}")
 
     @classmethod


### PR DESCRIPTION
Changing the backend does not reset the transpiler, which can cause potential errors.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
