### PR TITLE
Graph not built if no edges are provided

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -138,11 +138,8 @@ class _Global:
         qubits = cls._backend.qubits
         natives = cls._backend.natives
         connectivity_edges = cls._backend.connectivity
-        if (
-            qubits is not None
-            and natives is not None
-        ):
-            if   len(connectivity_edges) == 0:
+        if qubits is not None and natives is not None:
+            if len(connectivity_edges) == 0:
                 connectivity = nx.Graph()
                 qubits = cls._backend.platform.qubits.keys()
                 connectivity.add_nodes_from(qubits)

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -139,7 +139,11 @@ class _Global:
         natives = cls._backend.natives
         connectivity_edges = cls._backend.connectivity
         if qubits is not None and natives is not None:
-            connectivity = nx.Graph(connectivity_edges) if connectivity_edges is not None else nx.Graph()
+            connectivity = (
+                nx.Graph(connectivity_edges)
+                if connectivity_edges is not None
+                else nx.Graph()
+            )
             connectivity.add_nodes_from(qubits)
 
             return Passes(

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -139,12 +139,8 @@ class _Global:
         natives = cls._backend.natives
         connectivity_edges = cls._backend.connectivity
         if qubits is not None and natives is not None:
-            if len(connectivity_edges) == 0:
-                connectivity = nx.Graph()
-                qubits = cls._backend.platform.qubits.keys()
-                connectivity.add_nodes_from(qubits)
-            else:
-                connectivity = nx.Graph(connectivity_edges)
+            connectivity = nx.Graph(connectivity_edges) if connectivity_edges is not None else nx.Graph()
+            connectivity.add_nodes_from(qubits)
 
             return Passes(
                 connectivity=connectivity,

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -141,9 +141,14 @@ class _Global:
         if (
             qubits is not None
             and natives is not None
-            and connectivity_edges is not None
         ):
-            connectivity = nx.Graph(connectivity_edges)
+            if   len(connectivity_edges) == 0:
+                connectivity = nx.Graph()
+                qubits = cls._backend.platform.qubits.keys()
+                connectivity.add_nodes_from(qubits)
+            else:
+                connectivity = nx.Graph(connectivity_edges)
+
             return Passes(
                 connectivity=connectivity,
                 passes=[
@@ -152,7 +157,6 @@ class _Global:
                     Unroller(NativeGates[natives]),
                 ],
             )
-
         return Passes(passes=[])
 
 

--- a/tests/test_backends_global.py
+++ b/tests/test_backends_global.py
@@ -148,11 +148,13 @@ def test_default_transpiler_sim():
         and backend.qubits is None
     )
 
+
 CONNECTIVITY = [
     [("A1", "A2"), ("A2", "A3"), ("A3", "A4"), ("A4", "A5")],
     [("A1", "A2")],
     [],
-]  
+]
+
 
 @pytest.mark.parametrize("connectivity", CONNECTIVITY)
 def test_default_transpiler_hw(connectivity):
@@ -183,5 +185,3 @@ def test_default_transpiler_hw(connectivity):
         NativeGates.CZ in transpiler.native_gates
         and NativeGates.GPI2 in transpiler.native_gates
     )
-
-

--- a/tests/test_backends_global.py
+++ b/tests/test_backends_global.py
@@ -148,8 +148,14 @@ def test_default_transpiler_sim():
         and backend.qubits is None
     )
 
+CONNECTIVITY = [
+    [("A1", "A2"), ("A2", "A3"), ("A3", "A4"), ("A4", "A5")],
+    [("A1", "A2")],
+    [],
+]  
 
-def test_default_transpiler_hw():
+@pytest.mark.parametrize("connectivity", CONNECTIVITY)
+def test_default_transpiler_hw(connectivity):
     class TempBackend(NumpyBackend):
         def __init__(self):
             super().__init__()
@@ -161,7 +167,7 @@ def test_default_transpiler_hw():
 
         @property
         def connectivity(self):
-            return [("A1", "A2"), ("A2", "A3"), ("A3", "A4"), ("A4", "A5")]
+            return connectivity
 
         @property
         def natives(self):
@@ -172,13 +178,10 @@ def test_default_transpiler_hw():
     transpiler = _Global.transpiler()
 
     assert list(transpiler.connectivity.nodes) == ["A1", "A2", "A3", "A4", "A5"]
-    assert list(transpiler.connectivity.edges) == [
-        ("A1", "A2"),
-        ("A2", "A3"),
-        ("A3", "A4"),
-        ("A4", "A5"),
-    ]
+    assert list(transpiler.connectivity.edges) == connectivity
     assert (
         NativeGates.CZ in transpiler.native_gates
         and NativeGates.GPI2 in transpiler.native_gates
     )
+
+


### PR DESCRIPTION
I was trying to execute the following snippet:
```py
from qibo import set_backend
from qibo import gates, Circuit

set_backend("qibolab", platform="qw5q_platinum")

c = Circuit(3, wire_names = [1, 3, 2])
c.add(gates.GPI2(0,0))
c.add(gates.GPI2(1,0))
c.add(gates.GPI2(2,0))
c.add(gates.M(0,1,2))
r = c()
print(r.frequencies())

```
With the following error:

```
2024-12-11 14:48:38,615 - qm - INFO     - Starting session: 649d66cf-f564-4ac9-bd72-086b8ef0b602
[Qibo 0.2.15|INFO|2024-12-11 14:48:38]: Loading platform qw5q_platinum
[Qibo 0.2.15|INFO|2024-12-11 14:48:38]: Using qibolab (qw5q_platinum) backend on /CPU:0
[Qibo 0.2.15|ERROR|2024-12-11 14:48:38]: The circuit qubits are not in the connectivity graph.
Traceback (most recent call last):
  File "/nfs/users/edoardo.pedicillo/circuit.py", line 13, in <module>
    r = c()
  File "/nfs/users/edoardo.pedicillo/qibo/src/qibo/models/circuit.py", line 1102, in __call__
    return self.execute(initial_state=initial_state, nshots=nshots)
  File "/nfs/users/edoardo.pedicillo/qibo/src/qibo/models/circuit.py", line 1092, in execute
    transpiled_circuit, _ = transpiler(self)  # pylint: disable=E1102
  File "/nfs/users/edoardo.pedicillo/qibo/src/qibo/transpiler/pipeline.py", line 84, in __call__
    circuit = transpiler_pass(circuit)
  File "/nfs/users/edoardo.pedicillo/qibo/src/qibo/transpiler/optimizer.py", line 23, in __call__
    raise_error(
  File "/nfs/users/edoardo.pedicillo/qibo/src/qibo/config.py", line 46, in raise_error
    raise exception(message)
ValueError: The circuit qubits are not in the connectivity graph.
```
Versions:
- `qibolab`: branch related to qiboteam/qibolab#1083
-  `qibolab_platform_qrc`: commit 5c78e45763705bdd6ab9d9d8129b36a9f9d781d1

After some investigations, the error is due to how the connectivity graph is built in the case no edges (i.e., qubit pairs) are provided.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
