### PR TITLE
Fix bug in `qasm` parser when `gates.U3` is present.

### DIFF
--- a/src/qibo/models/_openqasm.py
+++ b/src/qibo/models/_openqasm.py
@@ -109,6 +109,9 @@ def _qibo_gate_name(gate):
     if gate == "ccx":
         return "TOFFOLI"
 
+    if gate in ["u", "U"]:
+        return "U3"
+
     return gate.upper()
 
 

--- a/src/qibo/models/_openqasm.py
+++ b/src/qibo/models/_openqasm.py
@@ -110,6 +110,8 @@ def _qibo_gate_name(gate):
         return "TOFFOLI"
 
     if gate in ["u", "U"]:
+        # `u` for QASM 2.0
+        # `U` for QASM 3.0
         return "U3"
 
     return gate.upper()

--- a/tests/test_models_circuit_qasm.py
+++ b/tests/test_models_circuit_qasm.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from openqasm3 import parser
 
-import qibo
 from qibo import Circuit, __version__, gates
 
 
@@ -188,12 +187,25 @@ cry(0.3) q[2],q[1];"""
         target = c.to_qasm()
 
 
-@pytest.mark.parametrize(
-    "measurements",
-    [
-        [gates.M(0, 1)],
-    ],
-)
+@pytest.mark.parametrize("qasm_type", [2, 3])
+def test_u3_gate(qasm_type):
+    target = Circuit(1)
+    target.add(gates.U3(0, 1, 2, 3))
+    target = target.to_qasm()
+
+    # hardcoding the example to not create a `qiskit` dependency
+    string = (
+        ('OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nu(1.0,2.0,3.0) q[0];')
+        if qasm_type == 2
+        else 'OPENQASM 3.0;\ninclude "stdgates.inc";\nqubit[1] q;\nU(1.0, 2.0, 3.0) q[0];\n'
+    )
+    string = Circuit.from_qasm(string)
+    string = string.to_qasm()
+
+    assert_strings_equal(string, target)
+
+
+@pytest.mark.parametrize("measurements", [[gates.M(0, 1)]])
 def test_measurements(measurements):
     c = Circuit(2)
     c.add(gates.X(0))


### PR DESCRIPTION
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
