### PR TITLE
Improving docstrings in final qubit mapping, w/ `{logical: physical}`

### DIFF
--- a/src/qibo/transpiler/abstract.py
+++ b/src/qibo/transpiler/abstract.py
@@ -47,7 +47,7 @@ class Router(ABC):
             circuit (:class:`qibo.models.circuit.Circuit`): Circuit to be routed.
 
         Returns:
-            (:class:`qibo.models.circuit.Circuit`, dict): Routed circuit and final logical-physical qubit mapping.
+            (:class:`qibo.models.circuit.Circuit`, dict): Routed circuit and final {logical: physical} qubit mapping.
         """
 
 

--- a/src/qibo/transpiler/asserts.py
+++ b/src/qibo/transpiler/asserts.py
@@ -32,7 +32,7 @@ def assert_transpiling(
         original_circuit (:class:`qibo.models.circuit.Circuit`): Circuit before transpiling.
         transpiled_circuit (:class:`qibo.models.circuit.Circuit`): Circuit after transpiling.
         connectivity (:class:`networkx.Graph`): Hardware connectivity.
-        final_layout (dict): Final logical-physical qubit mapping.
+        final_layout (dict): Final {logical: physical} qubit mapping.
         native_gates (:class:`qibo.transpiler.unroller.NativeGates`, optional): Native gates supported by the hardware.
             Defaults to :class:`qibo.transpiler.unroller.NativeGates.default()`.
         check_circuit_equivalence (bool, optional): Check if the transpiled circuit is equivalent to the original one.
@@ -68,7 +68,7 @@ def assert_circuit_equivalence(
     Args:
         original_circuit (:class:`qibo.models.circuit.Circuit`): Circuit before transpiling.
         transpiled_circuit (:class:`qibo.models.circuit.Circuit`): Circuit after transpiling.
-        final_layout (dict): Final logical-physical qubit mapping.
+        final_layout (dict): Final {logical: physical} qubit mapping.
         test_states (list, optional): List of states to test the equivalence.
             If ``None``, ``ntests`` random states will be tested. Defauts to ``None``.
         ntests (int, optional): Number of random states to test the equivalence. Defaults to :math: `3`.

--- a/src/qibo/transpiler/pipeline.py
+++ b/src/qibo/transpiler/pipeline.py
@@ -77,7 +77,7 @@ class Passes:
             circuit (:class:`qibo.models.circuit.Circuit`): Circuit to be transpiled.
 
         Returns:
-            (:class:`qibo.models.circuit.Circuit`, dict): Transpiled circuit and final logical-physical qubit mapping.
+            (:class:`qibo.models.circuit.Circuit`, dict): Transpiled circuit and final {logical: physical} qubit mapping.
         """
 
         final_layout = None

--- a/src/qibo/transpiler/router.py
+++ b/src/qibo/transpiler/router.py
@@ -245,7 +245,7 @@ class CircuitMap:
         return self._routed_blocks.circuit(circuit_kwargs=circuit_kwargs)
 
     def final_layout(self):
-        """Returns the final physical-logical qubits mapping."""
+        """Returns the final {logical: physical} qubits mapping."""
 
         return {self.wire_names[i]: self._l2p[i] for i in range(self.nqubits)}
 
@@ -338,7 +338,7 @@ class ShortestPaths(Router):
             circuit (:class:`qibo.models.circuit.Circuit`): Circuit to be matched to hardware connectivity.
 
         Returns:
-            (:class:`qibo.models.circuit.Circuit`, dict): Routed circuit and final logical-physical qubit mapping.
+            (:class:`qibo.models.circuit.Circuit`, dict): Routed circuit and final {logical: physical} qubit mapping.
         """
         assert_placement(circuit, self.connectivity)
         self._preprocessing(circuit=circuit)
@@ -519,7 +519,7 @@ class ShortestPaths(Router):
 
     def _preprocessing(self, circuit: Circuit):
         """The following objects will be initialised:
-            - circuit: class to represent circuit and to perform logical-physical qubit mapping.
+            - circuit: class to represent circuit and to perform {logical: physical} qubit mapping.
             - _final_measurements: measurement gates at the end of the circuit.
             - _front_layer: list containing the blocks to be executed.
 
@@ -629,7 +629,7 @@ class Sabre(Router):
             circuit (:class:`qibo.models.circuit.Circuit`): Circuit to be routed.
 
         Returns:
-            (:class:`qibo.models.circuit.Circuit`, dict): Routed circuit and final logical-physical qubit mapping.
+            (:class:`qibo.models.circuit.Circuit`, dict): Routed circuit and final {logical: physical} qubit mapping.
         """
         assert_placement(circuit, self.connectivity)
         self._preprocessing(circuit=circuit)
@@ -669,7 +669,7 @@ class Sabre(Router):
 
     def _preprocessing(self, circuit: Circuit):
         """The following objects will be initialised:
-            - circuit: class to represent circuit and to perform logical-physical qubit mapping.
+            - circuit: class to represent circuit and to perform {logical: physical} qubit mapping.
             - _final_measurements: measurement gates at the end of the circuit.
             - _dist_matrix: matrix reporting the shortest path lengh between all node pairs.
             - _dag: direct acyclic graph of the circuit based on commutativity.


### PR DESCRIPTION
## PR addressing Issue: https://github.com/qiboteam/qibo/issues/1562
- [x] Changes incorrect `CircuitMap.final_layout()` docstring from `physical-logical` to `logical-physical`
- [x] Changes all `logical-physical` by `{logical: physical}`, for showing more explicitly which are the keys/values

## Extra for reviewers:
- [ ] Please check the first change from above is correct, since I didn't went too deeply to check it. Instead I assumed it has to be that way based on the contradiction there was, and checking the next method names it calls 👍 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
