### PR TITLE
Modify `models.encodings.hamming_weight_encoder` to upload data in the lexicographical order

### DIFF
--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -373,12 +373,6 @@ def hamming_weight_encoder(
 
     # sort data such that the encoding is performed in lexicographical order
     lex_order = [int(string, 2) for string in bitstrings]
-    # bitstrings_lexicographical = list(
-    #     zip(bitstrings_lexicographical, range(len(bitstrings_lexicographical)))
-    # )
-    # bitstrings_lexicographical.sort()
-    # bitstrings_lexicographical = np.asarray(bitstrings_lexicographical)
-    # lexicographical_order = list(bitstrings_lexicographical[:, 1].astype(int))
     lex_order_sorted = np.sort(np.copy(lex_order))
     lex_order = [np.where(lex_order_sorted == num)[0][0] for num in lex_order]
     data = data[lex_order]

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -371,6 +371,15 @@ def hamming_weight_encoder(
     initial_string = np.array([1] * weight + [0] * (nqubits - weight))
     bitstrings, targets_and_controls = _ehrlich_algorithm(initial_string)
 
+    # sort data such that the encoding is performed in lexicographical order
+    bitstrings_lexicographical = list(zip(bitstrings, range(len(bitstrings))))
+    bitstrings_lexicographical.sort()
+    bitstrings_lexicographical = np.asarray(bitstrings_lexicographical)
+    lexicographical_order = list(bitstrings_lexicographical[:, 1].astype(int))
+    bitstrings_lexicographical = list(bitstrings_lexicographical[:, 0])
+    data = data[lexicographical_order]
+    del bitstrings_lexicographical
+
     # Calculate all gate phases necessary to encode the amplitudes.
     _data = np.abs(data) if complex_data else data
     thetas = _generate_rbs_angles(_data, nqubits, architecture="diagonal")

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -372,13 +372,17 @@ def hamming_weight_encoder(
     bitstrings, targets_and_controls = _ehrlich_algorithm(initial_string)
 
     # sort data such that the encoding is performed in lexicographical order
-    bitstrings_lexicographical = list(zip(bitstrings, range(len(bitstrings))))
-    bitstrings_lexicographical.sort()
-    bitstrings_lexicographical = np.asarray(bitstrings_lexicographical)
-    lexicographical_order = list(bitstrings_lexicographical[:, 1].astype(int))
-    bitstrings_lexicographical = list(bitstrings_lexicographical[:, 0])
-    data = data[lexicographical_order]
-    del bitstrings_lexicographical
+    lex_order = [int(string, 2) for string in bitstrings]
+    # bitstrings_lexicographical = list(
+    #     zip(bitstrings_lexicographical, range(len(bitstrings_lexicographical)))
+    # )
+    # bitstrings_lexicographical.sort()
+    # bitstrings_lexicographical = np.asarray(bitstrings_lexicographical)
+    # lexicographical_order = list(bitstrings_lexicographical[:, 1].astype(int))
+    lex_order_sorted = np.sort(np.copy(lex_order))
+    lex_order = [np.where(lex_order_sorted == num)[0][0] for num in lex_order]
+    data = data[lex_order]
+    del lex_order, lex_order_sorted
 
     # Calculate all gate phases necessary to encode the amplitudes.
     _data = np.abs(data) if complex_data else data

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -217,6 +217,7 @@ def test_unary_encoder_random_gaussian(backend, nqubits, seed):
     backend.assert_allclose(stddev, theoretical_norm, atol=1e-1)
 
 
+@pytest.mark.parametrize("seed", [10])
 @pytest.mark.parametrize("optimize_controls", [False, True])
 @pytest.mark.parametrize("complex_data", [False, True])
 @pytest.mark.parametrize("full_hwp", [False, True])
@@ -229,6 +230,7 @@ def test_hamming_weight_encoder(
     full_hwp,
     complex_data,
     optimize_controls,
+    seed,
 ):
     n_choose_k = int(binom(nqubits, weight))
     dims = 2**nqubits
@@ -237,15 +239,17 @@ def test_hamming_weight_encoder(
     initial_string = np.array([1] * weight + [0] * (nqubits - weight))
     indices = _ehrlich_algorithm(initial_string, False)
     indices = [int(string, 2) for string in indices]
+    indices_lex = list(np.copy(indices))
+    indices_lex.sort()
 
-    rng = np.random.default_rng(10)
+    rng = np.random.default_rng(seed)
     data = rng.random(n_choose_k)
     if complex_data:
         data = data.astype(complex) + 1j * rng.random(n_choose_k)
     data /= np.linalg.norm(data)
 
     target = np.zeros(dims, dtype=dtype)
-    target[indices] = data
+    target[indices_lex] = data
     target = backend.cast(target, dtype=target.dtype)
 
     circuit = hamming_weight_encoder(

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -239,8 +239,7 @@ def test_hamming_weight_encoder(
     initial_string = np.array([1] * weight + [0] * (nqubits - weight))
     indices = _ehrlich_algorithm(initial_string, False)
     indices = [int(string, 2) for string in indices]
-    indices_lex = list(np.copy(indices))
-    indices_lex.sort()
+    indices_lex = np.sort(np.copy(indices))
 
     rng = np.random.default_rng(seed)
     data = rng.random(n_choose_k)


### PR DESCRIPTION
Data is amplitude-encoded in the lexicographical order instead of the order of the original Gray code.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
