### PR TITLE
Adding ``wire_names`` to ``circuit.raw`` and ``from_dict``

### DIFF
--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -1115,6 +1115,7 @@ class Circuit:
             "queue": [gate.raw for gate in self.queue],
             "nqubits": self.nqubits,
             "density_matrix": self.density_matrix,
+            "wire_names": self.wire_names,
             "qibo_version": qibo.__version__,
         }
 
@@ -1124,7 +1125,11 @@ class Circuit:
 
         Essentially the counter-part of :meth:`raw`.
         """
-        circ = cls(raw["nqubits"], density_matrix=raw["density_matrix"])
+        circ = cls(
+            raw["nqubits"],
+            density_matrix=raw["density_matrix"],
+            wire_names=raw.get("wire_names"),
+        )
 
         for gate in raw["queue"]:
             circ.add(Gate.from_dict(gate))

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -375,6 +375,14 @@ def test_circuit_serialization():
     assert Circuit.from_dict(raw).raw == raw
 
 
+def test_circuit_serialization_with_wire_names():
+    c = Circuit(2, wire_names=["a", "b"])
+    raw = c.raw
+    assert "wire_names" in raw
+    new_c = Circuit.from_dict(raw)
+    assert new_c.wire_names == c.wire_names
+
+
 def test_circuit_light_cone():
     from qibo import __version__
 

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -387,13 +387,7 @@ def test_circuit_serialization_with_wire_names():
     new_c = Circuit.from_dict(raw)
     assert new_c.wire_names == c.wire_names
 
-    get_backend()  # this has to be called before get_transpiler
-    # otherwise it crashes
-    transpiler = get_transpiler()
-    g = Graph()
-    g.add_edge(*wire_names)
-    transpiler.connectivity = g
-    transpiler.passes = [Sabre()]
+    transpiler = Passes(passes=[Sabre()], connectivity=Graph([wire_names]))
 
     c, _ = transpiler(c)
     new_c, _ = transpiler(new_c)

--- a/tests/test_models_circuit.py
+++ b/tests/test_models_circuit.py
@@ -6,10 +6,10 @@ import numpy as np
 import pytest
 from networkx import Graph
 
-from qibo import Circuit, gates, get_backend, get_transpiler
+from qibo import Circuit, gates
 from qibo.models.circuit import _resolve_qubits
 from qibo.models.utils import initialize
-from qibo.transpiler import Sabre
+from qibo.transpiler import Passes, Sabre
 from qibo.transpiler._exceptions import PlacementError
 
 


### PR DESCRIPTION
As per title this fixes the serialization of circuit by including the ``wire_names``, should fix the problems encountered in qiboteam/qibo-client#99.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
