### PR TITLE
Changed the directory to selfhosted tests to ``$(mktemp -d)``

### DIFF
--- a/selfhosted
+++ b/selfhosted
@@ -3,8 +3,7 @@
 # Script for running the selfhosted tests on QPUs directly from GitHub
 # Tests need to be copied to /tmp/ because coverage does not work with NFS
 
-tmpdir=/tmp/$(date +%s)
-mkdir $tmpdir
+tmpdir=$(mktemp -d)
 cp -r tests $tmpdir
 cp pyproject.toml $tmpdir
 cd $tmpdir/tests

--- a/selfhosted
+++ b/selfhosted
@@ -3,7 +3,8 @@
 # Script for running the selfhosted tests on QPUs directly from GitHub
 # Tests need to be copied to /tmp/ because coverage does not work with NFS
 
-tmpdir=/tmp/$(date +%s)/
+tmpdir=/tmp/$(date +%s)
+mkdir $tmpdir
 cp -r tests $tmpdir
 cp pyproject.toml $tmpdir
 cd $tmpdir/tests

--- a/selfhosted
+++ b/selfhosted
@@ -3,9 +3,10 @@
 # Script for running the selfhosted tests on QPUs directly from GitHub
 # Tests need to be copied to /tmp/ because coverage does not work with NFS
 
-cp -r tests /tmp/qibo
-cp pyproject.toml /tmp/qibo
-cd /tmp/qibo/tests
+tmpdir=/tmp/$(date +%s)/
+cp -r tests $tmpdir
+cp pyproject.toml $tmpdir
+cd $tmpdir/tests
 source /nfs/users/github/actions-runner/_work/qibo/qibo/testenv/bin/activate
 pytest
 pytest_status=$?
@@ -14,6 +15,6 @@ if [[ $pytest_status -ne 0 ]]
         exit $pytest_status
 fi
 cd -
-mv /tmp/qibo/tests/coverage.xml .
-mv /tmp/qibo/tests/htmlcov .
-rm -r /tmp/qibo/tests
+mv $tmpdir/tests/coverage.xml .
+mv $tmpdir/tests/htmlcov .
+rm -r $tmpdir

--- a/selfhosted
+++ b/selfhosted
@@ -3,9 +3,9 @@
 # Script for running the selfhosted tests on QPUs directly from GitHub
 # Tests need to be copied to /tmp/ because coverage does not work with NFS
 
-cp -r tests /tmp/
-cp pyproject.toml /tmp/
-cd /tmp/tests
+cp -r tests /tmp/qibo
+cp pyproject.toml /tmp/qibo
+cd /tmp/qibo/tests
 source /nfs/users/github/actions-runner/_work/qibo/qibo/testenv/bin/activate
 pytest
 pytest_status=$?
@@ -14,6 +14,6 @@ if [[ $pytest_status -ne 0 ]]
         exit $pytest_status
 fi
 cd -
-mv /tmp/tests/coverage.xml .
-mv /tmp/tests/htmlcov .
-rm -r /tmp/tests
+mv /tmp/qibo/tests/coverage.xml .
+mv /tmp/qibo/tests/htmlcov .
+rm -r /tmp/qibo/tests

--- a/selfhosted
+++ b/selfhosted
@@ -3,7 +3,7 @@
 # Script for running the selfhosted tests on QPUs directly from GitHub
 # Tests need to be copied to /tmp/ because coverage does not work with NFS
 
-tmpdir=$(mktemp -d)
+tmpdir=$(mktemp -d selfhosted.qibo.XXXXXXX)
 cp -r tests $tmpdir
 cp pyproject.toml $tmpdir
 cd $tmpdir/tests


### PR DESCRIPTION
This is done in order to avoid possible problems with ``qibojit`` selfhosted tests that were writing to the same ``/tmp/tests`` directory.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
