### PR TITLE
Selfhosted GPU tests restricted to GPU backends only

### DIFF
--- a/selfhosted
+++ b/selfhosted
@@ -7,7 +7,7 @@ cp -r tests /tmp/
 cp pyproject.toml /tmp/
 cd /tmp/tests
 source /nfs/users/github/actions-runner/_work/qibo/qibo/testenv/bin/activate
-pytest
+pytest --gpu_only
 pytest_status=$?
 if [[ $pytest_status -ne 0 ]]
     then

--- a/selfhosted
+++ b/selfhosted
@@ -8,7 +8,7 @@ cp -r tests $tmpdir
 cp pyproject.toml $tmpdir
 cd $tmpdir/tests
 source /nfs/users/github/actions-runner/_work/qibo/qibo/testenv/bin/activate
-pytest --gpu_only
+pytest --gpu-only
 pytest_status=$?
 if [[ $pytest_status -ne 0 ]]
     then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def pytest_configure(config):
 
 @pytest.fixture
 def backend(backend_name, request):
-    if request.config.getoption("--gpu_only"):  # pragma: no cover
+    if request.config.getoption("--gpu-only"):  # pragma: no cover
         if backend_name not in ("cupy", "cuquantum"):
             pytest.skip("Skipping non-gpu backend.")
     yield get_backend(backend_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def backend(backend_name):
+def backend(backend_name, request):
     if request.config.getoption("--gpu_only"):  # pragma: no cover
         if backend_name not in ("cupy", "cuquantum"):
             pytest.skip("Skipping non-gpu backend.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from qibo.backends import _Global, construct_backend
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--gpu_only",
+        "--gpu-only",
         action="store_true",
         default=False,
         help="Run on GPU backends only.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,16 @@ import pytest
 
 from qibo.backends import _Global, construct_backend
 
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--gpu_only",
+        action="store_true",
+        default=False,
+        help="Run on GPU backends only.",
+    )
+
+
 # backends to be tested
 BACKENDS = [
     "numpy",
@@ -72,6 +82,9 @@ def pytest_configure(config):
 
 @pytest.fixture
 def backend(backend_name):
+    if request.config.getoption("--gpu_only"):  # pragma: no cover
+        if backend_name not in ("cupy", "cuquantum"):
+            pytest.skip("Skipping non-gpu backend.")
     yield get_backend(backend_name)
 
 


### PR DESCRIPTION
Same as qiboteam/qibojit#206. A ``--gpu-only`` option is added to pytest to run tests on GPU backends only.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
