### PR TITLE
Matrix representation of `gates.GeneralizedRBS` independent of qubit order

### DIFF
--- a/src/qibo/backends/npmatrices.py
+++ b/src/qibo/backends/npmatrices.py
@@ -491,21 +491,17 @@ class NumpyMatrices:
         )
 
     def GeneralizedRBS(self, qubits_in, qubits_out, theta, phi):
-        bitstring_length = len(qubits_in) + len(qubits_out)
-        integer_in = "".join(
-            ["1" if k in qubits_in else "0" for k in range(bitstring_length)]
-        )
-        integer_in = int(integer_in, 2)
-        integer_out = "".join(
-            ["1" if k in qubits_out else "0" for k in range(bitstring_length)]
-        )
-        integer_out = int(integer_out, 2)
+        num_qubits_in, num_qubits_out = len(qubits_in), len(qubits_out)
+        bitstring_length = num_qubits_in + num_qubits_out
 
         matrix = [
             [1 + 0j if l == k else 0j for l in range(2**bitstring_length)]
             for k in range(2**bitstring_length)
         ]
         exp, sin, cos = self.np.exp(1j * phi), self.np.sin(theta), self.np.cos(theta)
+
+        integer_in = int("1" * num_qubits_in + "0" * num_qubits_out, base=2)
+        integer_out = int("0" * num_qubits_in + "1" * num_qubits_out, base=2)
         matrix[integer_in][integer_in] = exp * cos
         matrix[integer_in][integer_out] = -exp * sin
         matrix[integer_out][integer_in] = self.np.conj(exp) * sin

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -2535,13 +2535,10 @@ class GeneralizedRBS(ParametrizedGate):
         super().__init__(trainable)
         self.name = "grbs"
         self.draw_label = "gRBS"
+        self.target_qubits = tuple(qubits_in) + tuple(qubits_out)
         self.unitary = True
 
-        target_qubits = list(qubits_in) + list(qubits_out)
-        target_qubits.sort()
-        self.target_qubits = tuple(target_qubits)
-
-        self.parameter_names = "theta"
+        self.parameter_names = ["theta", "phi"]
         self.parameters = theta, phi
         self.nparams = 2
 

--- a/tests/test_gates_gates.py
+++ b/tests/test_gates_gates.py
@@ -1322,7 +1322,7 @@ def test_deutsch(backend):
 
 def test_generalized_rbs(backend):
     theta, phi = 0.1234, 0.4321
-    qubits_in, qubits_out = [0, 1], [2, 3]
+    qubits_in, qubits_out = [0, 3], [1, 2]
     nqubits = len(qubits_in + qubits_out)
     integer_in = "".join(["1" if k in qubits_in else "0" for k in range(nqubits)])
     integer_out = "".join(["1" if k in qubits_out else "0" for k in range(nqubits)])


### PR DESCRIPTION
The  `gates.GeneralizedRBS` gate must be Hamming weight preserving when the number of input and output qubits is the same, but here we can see that it is not: 

```Python
from qibo import gates
from qibo.backends import NumpyBackend

backend = NumpyBackend()

gate = gates.GeneralizedRBS([1,2],[3,4],theta=0.123)

print(gate.matrix(backend))
```
It is mixing states $|0001\rangle$ and $|0110\rangle$ .

This PR address this issue. I construct the RBS gate without considering the order of the qubits passed as input. This is the same approach we follow for other multi-qubit gates. 

This simplifies the code and makes the cheat introduced in PR #1594 unnecessary.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
