### PR TITLE
Fix clustering bug when plotting single-qubit circuits

### DIFF
--- a/src/qibo/ui/mpldrawer.py
+++ b/src/qibo/ui/mpldrawer.py
@@ -702,7 +702,7 @@ def plot_circuit(circuit, scale=0.6, cluster_gates=True, style=None):
 
             fgates = None
 
-            if cluster_gates:
+            if cluster_gates and circuit.nqubits > 1:
                 fgates = _make_cluster_gates(
                     _process_gates(gate.gates, circuit.nqubits)
                 )
@@ -725,7 +725,7 @@ def plot_circuit(circuit, scale=0.6, cluster_gates=True, style=None):
 
     gates_plot = _process_gates(all_gates, circuit.nqubits)
 
-    if cluster_gates and len(gates_plot) > 0:
+    if cluster_gates and len(gates_plot) > 0 and circuit.nqubits > 1:
         gates_cluster = _make_cluster_gates(gates_plot)
         ax = _plot_quantum_schedule(gates_cluster, inits, params, labels, scale=scale)
         return ax, ax.figure


### PR DESCRIPTION
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.

The clustering action for the circuit is useful on more than 2-qubits, this review skip the clustering for 1-qubit circuits