### PR TITLE
custom labels for plot_circuit drawing function - issue #1611

### DIFF
--- a/src/qibo/ui/mpldrawer.py
+++ b/src/qibo/ui/mpldrawer.py
@@ -415,7 +415,9 @@ def _draw_labels(ax, labels, inits, gate_grid, wire_grid, plot_params):
     nq = len(labels)
     xdata = (gate_grid[0] - scale, gate_grid[-1] + scale)
     if "wire_names" in plot_params:
-        labels = plot_params["wire_names"] if len(plot_params["wire_names"]) > 0 else labels
+        labels = (
+            plot_params["wire_names"] if len(plot_params["wire_names"]) > 0 else labels
+        )
     for i in range(nq):
         j = _get_flipped_index(labels[i], labels)
         _text(
@@ -726,7 +728,11 @@ def plot_circuit(circuit, scale=0.6, cluster_gates=True, style=None):
             all_gates.append(gate)
 
     gates_plot = _process_gates(all_gates, circuit.nqubits)
-    params['wire_names'] = circuit.init_kwargs['wire_names'] if circuit.init_kwargs['wire_names'] is not None else []
+    params["wire_names"] = (
+        circuit.init_kwargs["wire_names"]
+        if circuit.init_kwargs["wire_names"] is not None
+        else []
+    )
     if cluster_gates and len(gates_plot) > 0 and circuit.nqubits > 1:
         gates_cluster = _make_cluster_gates(gates_plot)
         ax = _plot_quantum_schedule(gates_cluster, inits, params, labels, scale=scale)

--- a/src/qibo/ui/mpldrawer.py
+++ b/src/qibo/ui/mpldrawer.py
@@ -414,6 +414,8 @@ def _draw_labels(ax, labels, inits, gate_grid, wire_grid, plot_params):
     fontsize = plot_params["fontsize"]
     nq = len(labels)
     xdata = (gate_grid[0] - scale, gate_grid[-1] + scale)
+    if "wire_names" in plot_params:
+        labels = plot_params["wire_names"] if len(plot_params["wire_names"]) > 0 else labels
     for i in range(nq):
         j = _get_flipped_index(labels[i], labels)
         _text(
@@ -724,7 +726,7 @@ def plot_circuit(circuit, scale=0.6, cluster_gates=True, style=None):
             all_gates.append(gate)
 
     gates_plot = _process_gates(all_gates, circuit.nqubits)
-
+    params['wire_names'] = circuit.init_kwargs['wire_names'] if circuit.init_kwargs['wire_names'] is not None else []
     if cluster_gates and len(gates_plot) > 0 and circuit.nqubits > 1:
         gates_cluster = _make_cluster_gates(gates_plot)
         ax = _plot_quantum_schedule(gates_cluster, inits, params, labels, scale=scale)


### PR DESCRIPTION
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.

Now by using the `wire_names` property from circuit it is possible to set the label to the mpl circuit:

```
circuit = Circuit(2)

circuit.add(gates.X(0))
circuit.add(gates.X(1))
circuit.add(gates.M(0, 1))

circuit.wire_names = ["w_1", "w_2"]

plot_circuit(circuit)
```
