### PR TITLE
review plot out of bounds qubit number - bug #1497

### DIFF
--- a/src/qibo/ui/mpldrawer.py
+++ b/src/qibo/ui/mpldrawer.py
@@ -577,12 +577,14 @@ def _process_gates(array_gates, nqubits):
         ]:
             for qbit in gate._target_qubits:
                 item = (init_label,)
-                item += ("q_" + str(qbit),)
+                qbit_item = qbit if qbit < nqubits else nqubits - 1
+                item += ("q_" + str(qbit_item),)
                 gates_plot.append(item)
         elif init_label == "ENTANGLEMENTENTROPY":
             for qbit in list(range(nqubits)):
                 item = (init_label,)
-                item += ("q_" + str(qbit),)
+                qbit_item = qbit if qbit < nqubits else nqubits - 1
+                item += ("q_" + str(qbit_item),)
                 gates_plot.append(item)
         else:
             item = ()
@@ -590,15 +592,19 @@ def _process_gates(array_gates, nqubits):
 
             for qbit in gate._target_qubits:
                 if type(qbit) is tuple:
-                    item += ("q_" + str(qbit[0]),)
+                    qbit_item = qbit[0] if qbit[0] < nqubits else nqubits - 1
+                    item += ("q_" + str(qbit_item),)
                 else:
-                    item += ("q_" + str(qbit),)
+                    qbit_item = qbit if qbit < nqubits else nqubits - 1
+                    item += ("q_" + str(qbit_item),)
 
             for qbit in gate._control_qubits:
                 if type(qbit) is tuple:
-                    item += ("q_" + str(qbit[0]),)
+                    qbit_item = qbit[0] if qbit[0] < nqubits else nqubits - 1
+                    item += ("q_" + str(qbit_item),)
                 else:
-                    item += ("q_" + str(qbit),)
+                    qbit_item = qbit if qbit < nqubits else nqubits - 1
+                    item += ("q_" + str(qbit_item),)
 
             gates_plot.append(item)
 
@@ -717,6 +723,7 @@ def plot_circuit(circuit, scale=0.6, cluster_gates=True, style=None):
             all_gates.append(gate)
 
     gates_plot = _process_gates(all_gates, circuit.nqubits)
+
     params["wire_names"] = (
         circuit.init_kwargs["wire_names"]
         if circuit.init_kwargs["wire_names"] is not None


### PR DESCRIPTION
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.

The circuit does not print with odd number of qubits, like 5, 7 and so on, because the circuit is using out of bounds number of qubits

```python
from qibo.ui import plot_circuit
from qibo.models.hep import qPDF

ansatz = 'Weighted'
multi_output = True
layers = 3
nqubits = 7

mypdf = qPDF(ansatz, layers, nqubits, multi_output=multi_output)
plot_circuit(mypdf.circuit, scale = 0.8, cluster_gates = True, style="quantumspain")
```