### PR TITLE
Making Fused gate matrix backend dependent

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -156,7 +156,7 @@ class NumpyBackend(Backend):
             # transfer gate matrix to numpy as it is more efficient for
             # small tensor calculations
             # explicit to_numpy see https://github.com/qiboteam/qibo/issues/928
-            gmatrix = self.to_numpy(gate.matrix(self))
+            # gmatrix = self.to_numpy(gate.matrix(self))
             # add controls if controls were instantiated using
             # the ``Gate.controlled_by`` method
             num_controls = len(gate.control_qubits)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -157,6 +157,7 @@ class NumpyBackend(Backend):
             # small tensor calculations
             # explicit to_numpy see https://github.com/qiboteam/qibo/issues/928
             # gmatrix = self.to_numpy(gate.matrix(self))
+            gmatrix = gate.matrix(self)
             # add controls if controls were instantiated using
             # the ``Gate.controlled_by`` method
             num_controls = len(gate.control_qubits)


### PR DESCRIPTION
This just makes the fused gate to be constructed through the backend and avoid converting to numpy. The reason for this is that in some cases conversion to numpy can be tricky: with gpu backends you have to copy data to cpu, whereas for ml backends conversion to numpy is not always possible and will fail (e.g. pytorch with gradients attached, symbolic tensorflow or traced jax arrays).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
