### PR TITLE
``python 3.13.5`` in the CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.5"]
     uses: qiboteam/workflows/.github/workflows/deploy-pip-poetry.yml@v1
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.5"]
     uses: qiboteam/workflows/.github/workflows/rules-poetry.yml@v1
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
As pointed out in various other locations (eg #1670) there are some problems with ``numba`` and ``python3.13``.
Here https://github.com/numba/numba/issues/10101 they suggest the issue is related to list comprehensions and is lifted in ``python3.13.5``. Thus I am setting this as the version to be used in the CI here.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
