### PR TITLE
Handling dependent parameters in circuits

### DIFF
--- a/src/qibo/models/circuit.py
+++ b/src/qibo/models/circuit.py
@@ -688,9 +688,15 @@ class Circuit:
                         ):
                             self._independent_parameters_map[idx].add(self.ngates)
                             independent = False
-                if independent:
-                    self._independent_parameters_map[self.ngates] = {
-                        self.ngates,
+                    if independent:
+                        self._independent_parameters_map[self.ngates] = {
+                            self.ngates,
+                        }
+                else:
+                    self._independent_parameters_map = {
+                        self.ngates: {
+                            self.ngates,
+                        }
                     }
 
             self.queue.append(gate)
@@ -747,14 +753,16 @@ class Circuit:
 
     @independent_parameters_map.setter
     def independent_parameters_map(self, par_map: dict[int, set[int]]):
-        for val in par_map.values():
+        for key, val in par_map.items():
             for idx in val:
                 try:
-                    if not isinstance(self.queue[idx], ParametrizedGate):
+                    gate = self.queue[idx]
+                    if not isinstance(gate, ParametrizedGate):
                         raise_error(
                             RuntimeError,
-                            f"Passed a parameter map containing the index ``{idx}``, corresponding to the non-parametrized gate ``{self.queue[idx]}``.",
+                            f"Passed a parameter map containing the index ``{idx}``, corresponding to the non-parametrized gate ``{gate}``.",
                         )
+                    self.queue[idx].parameters = self.queue[key].parameters
                 except IndexError as e:
                     raise e
         self._independent_parameters_map = par_map

--- a/tests/test_models_circuit_features.py
+++ b/tests/test_models_circuit_features.py
@@ -5,6 +5,7 @@ from collections import Counter
 
 import numpy as np
 import pytest
+import torch
 
 from qibo import Circuit, gates, matrices
 from qibo.config import PRECISION_TOL
@@ -372,3 +373,48 @@ def test_repeated_execute_probs_and_freqs(backend, nqubits):
         )
     for key in dict(test_frequencies).keys():
         backend.assert_allclose(result.frequencies()[key], test_frequencies[key])
+
+
+def test_circuit_independent_parameters_map():
+    # all parameters independent
+    c = Circuit(2)
+    parameters = np.array([1, 2, 3, 4])
+    c.add(gates.RZ(0, parameters[0]))
+    c.add(gates.U2(1, *parameters[1:3]))
+    c.add(gates.RX(0, parameters[3]))
+    assert c.independent_parameters_map == {0: {0}, 1: {1}, 2: {2}}
+    # some dependent parameters
+
+    c = Circuit(2)
+    parameters = torch.tensor([1, 2, 3, 4])
+    c.add(gates.RZ(0, parameters[0]))
+    c.add(gates.U2(1, *parameters[1:3]))
+    c.add(gates.U2(0, *parameters[1:3]))
+    c.add(gates.RX(1, parameters[0]))
+    c.add(gates.RY(0, parameters[3]))
+    # multiple parameters gate are always considered independent for now
+    assert c.independent_parameters_map == {
+        0: {0, 3},
+        1: {
+            1,
+        },
+        2: {
+            2,
+        },
+        4: {
+            4,
+        },
+    }
+    # testing the setter
+    c.independent_parameters_map = {
+        0: {0, 3, 4},
+        1: {
+            1,
+        },
+        2: {
+            2,
+        },
+    }
+    assert (
+        c.queue[0].parameters[0] is c.queue[3].parameters[0] is c.queue[4].parameters[0]
+    )


### PR DESCRIPTION
This provides the ``Circuit`` object with a ``._independent_parameters_map`` object which is useful for handling the parameters of the gates that are supposed to change together and are thus dependent. This is particularly useful for the implementation of QML equivariant models qiboteam/qiboml#112, qiboteam/qiboml#108, qiboteam/qiboml#99.
The new attribute maps an index of a gate (in the circuit queue) to all the indices of the gates that are supposed to share its parameters. For instance:
``` python
{0: {0,2,3}, 1: {1,4}}
```
will indicate that the 0-th gate parameters are shared among the 0, 2 and 3-rd gates, whereas the 1-st gate parameters are shared among the 1-st and 4-th gates.
If no parameter is shared than the dictionary looks simply as:
```python
{0: {0}, 2: {2}, 3: {3}, 1: {1,4}}
```
Additionally, this implies that the ``set_parameters`` now takes as input a collection of parameters with length equal to the circuit's ``_independent_parameters_map``.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
