### PR TITLE
``expectation_from_samples`` fix

### DIFF
--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -129,6 +129,8 @@ class Hamiltonian(AbstractHamiltonian):
                 "Observable is not diagonal. Expectation of non diagonal observables starting from samples is currently supported for `qibo.hamiltonians.hamiltonians.SymbolicHamiltonian` only.",
             )
         diag = self.backend.np.reshape(diag, self.nqubits * (2,))
+        if qubit_map is None:
+            qubit_map = range(self.nqubits)
         diag = self.backend.np.transpose(diag, axes=qubit_map).ravel()
         # select only the elements with non-zero counts
         diag = diag[[int(state, 2) for state in freq.keys()]]

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -130,6 +130,8 @@ class Hamiltonian(AbstractHamiltonian):
             )
         diag = self.backend.np.reshape(diag, self.nqubits * (2,))
         diag = self.backend.np.transpose(diag, axes=qubit_map).ravel()
+        # select only the elements with non-zero counts
+        diag = diag[[int(state, 2) for state in freq.keys()]]
         counts = self.backend.cast(list(freq.values()), dtype=diag.dtype) / sum(
             freq.values()
         )

--- a/tests/test_hamiltonians.py
+++ b/tests/test_hamiltonians.py
@@ -300,7 +300,6 @@ def test_hamiltonian_expectation_from_samples_with_some_zero_counts(backend, qma
         freq["01"] / 100 * observable.matrix[indices[0], indices[0]]
         + freq["11"] / 100 * observable.matrix[indices[1], indices[1]]
     )
-    # breakpoint()
     backend.assert_allclose(observable.expectation_from_samples(freq, qmap), true_val)
 
 

--- a/tests/test_hamiltonians.py
+++ b/tests/test_hamiltonians.py
@@ -285,6 +285,25 @@ def test_hamiltonian_expectation_from_samples(backend):
     backend.assert_allclose(exp, exp_from_samples, atol=1e-2)
 
 
+@pytest.mark.parametrize("qmap", (None, [1, 0]))
+def test_hamiltonian_expectation_from_samples_with_some_zero_counts(backend, qmap):
+    """Test Hamiltonian expectation value calculation."""
+    backend.set_seed(12)
+
+    freq = {"01": 48, "11": 52}
+    observable = SymbolicHamiltonian(
+        2 * Z(0) * (1 - Z(1)) ** 2 + Z(0) * Z(1), nqubits=2, backend=backend
+    ).dense
+    # switch the matrix indices if qmap is inverted
+    indices = [1, 3] if qmap is None else [2, 3]
+    true_val = (
+        freq["01"] / 100 * observable.matrix[indices[0], indices[0]]
+        + freq["11"] / 100 * observable.matrix[indices[1], indices[1]]
+    )
+    # breakpoint()
+    backend.assert_allclose(observable.expectation_from_samples(freq, qmap), true_val)
+
+
 def test_hamiltonian_expectation_from_circuit(backend):
     """Test Hamiltonian expectation value calculation."""
     backend.set_seed(12)


### PR DESCRIPTION
Small fix to ``expectation_from_samples`` that selects only the elements of the diagonal that correspond to non-zero counts.
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
