### PR TITLE
Fix to data-based mitigation methods

### DIFF
--- a/src/qibo/backends/npmatrices.py
+++ b/src/qibo/backends/npmatrices.py
@@ -75,13 +75,13 @@ class NumpyMatrices:
         raise_error(NotImplementedError)
 
     def RX(self, theta):
-        cos = self.np.cos(theta / 2.0) + 0j
-        isin = -1j * self.np.sin(theta / 2.0)
+        cos = self.np.cos(theta / 2.0)  # + 0j
+        isin = -1 * self.np.sin(theta / 2.0)
         return self._cast([[cos, isin], [isin, cos]], dtype=self.dtype)
 
     def RY(self, theta):
-        cos = self.np.cos(theta / 2.0) + 0j
-        sin = self.np.sin(theta / 2.0) + 0j
+        cos = self.np.cos(theta / 2.0)  # + 0j
+        sin = self.np.sin(theta / 2.0)  # + 0j
         return self._cast([[cos, -sin], [sin, cos]], dtype=self.dtype)
 
     def RZ(self, theta):

--- a/src/qibo/backends/npmatrices.py
+++ b/src/qibo/backends/npmatrices.py
@@ -75,13 +75,13 @@ class NumpyMatrices:
         raise_error(NotImplementedError)
 
     def RX(self, theta):
-        cos = self.np.cos(theta / 2.0)  # + 0j
-        isin = -1 * self.np.sin(theta / 2.0)
+        cos = self.np.cos(theta / 2.0) + 0j
+        isin = -1j * self.np.sin(theta / 2.0)
         return self._cast([[cos, isin], [isin, cos]], dtype=self.dtype)
 
     def RY(self, theta):
-        cos = self.np.cos(theta / 2.0)  # + 0j
-        sin = self.np.sin(theta / 2.0)  # + 0j
+        cos = self.np.cos(theta / 2.0) + 0j
+        sin = self.np.sin(theta / 2.0) + 0j
         return self._cast([[cos, -sin], [sin, cos]], dtype=self.dtype)
 
     def RZ(self, theta):

--- a/src/qibo/hamiltonians/hamiltonians.py
+++ b/src/qibo/hamiltonians/hamiltonians.py
@@ -568,7 +568,7 @@ class SymbolicHamiltonian(AbstractHamiltonian):
 
         keys = list(freq.keys())
         counts = list(freq.values())
-        counts = self.backend.cast(counts, dtype=type(counts[0])) / sum(counts)
+        counts = self.backend.cast(counts, dtype=self.backend.np.float64) / sum(counts)
         expvals = []
         for term in self.terms:
             qubits = {


### PR DESCRIPTION
As per title, this introduces the use of a simulation backend (numpy for now) to get the noise free values for data-based mitigation methods, such as CDR.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
