### PR TITLE
Permutation synthesis and Li's sparse encoder

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -419,7 +419,7 @@ Graph state
 .. autofunction:: qibo.models.encodings.graph_state
 
 Permutation synthesis
-"""""""""""
+"""""""""""""""""""""
 
 .. autofunction:: qibo.models.encodings.permutation_synthesis
 
@@ -2500,7 +2500,7 @@ Parameterized quantum circuit integral
 .. autofunction:: qibo.quantum_info.pqc_integral
 
 Decompose permutation into the fewest pairwise transpositions
-""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 .. autofunction:: qibo.quantum_info.decompose_permutation
 

--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -418,6 +418,11 @@ Graph state
 
 .. autofunction:: qibo.models.encodings.graph_state
 
+Permutation synthesis
+"""""""""""
+
+.. autofunction:: qibo.models.encodings.permutation_synthesis
+
 .. _error-mitigation:
 
 Error Mitigation
@@ -2493,6 +2498,11 @@ Parameterized quantum circuit integral
 """"""""""""""""""""""""""""""""""""""
 
 .. autofunction:: qibo.quantum_info.pqc_integral
+
+Decompose permutation into the fewest pairwise transpositions
+""""""""""""""""""""""""""""""""""""""
+
+.. autofunction:: qibo.quantum_info.decompose_permutation
 
 
 .. _GST:

--- a/src/qibo/models/__init__.py
+++ b/src/qibo/models/__init__.py
@@ -8,6 +8,7 @@ from qibo.models.encodings import (
     ghz_state,
     graph_state,
     hamming_weight_encoder,
+    permutation_synthesis,
     phase_encoder,
     sparse_encoder,
     unary_encoder,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -278,7 +278,7 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
     )
 
     dim = len(data_sorted)
-    sigma = [i for i in range(2**nqubits)]
+    sigma = np.arange(2**nqubits)
 
     flag = backend.np.zeros(dim, dtype=backend.np.int8)
     indexes = list(
@@ -298,6 +298,8 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
                     break
         else:
             data_binary.append((bi_int, xi))
+
+    sigma = list(sigma)
 
     # binary enconder on \sum_i = xi |sigma^{-1}(b_i)>
     circuit_binary = sparse_encoder(

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2136,7 +2136,7 @@ def permutation_synthesis(
         Return a circuit synthesis of sigma.
 
     Args:
-        sigma (list[int]): permutation description on {0,...,d-1}.
+        sigma (list[int] or tuple[int]): permutation description on {0,...,d-1}.
         m (int): power‑of‑two budget m (Default:2)
 
     Returns:
@@ -2148,6 +2148,9 @@ def permutation_synthesis(
         `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
     """
     backend = _check_backend(backend)
+
+    if isinstance(sigma, tuple):
+        sigma = list(sigma)
 
     if not isinstance(sigma, list):
         raise_error(TypeError, f"Permutation ``sigma`` must be a ``list`` of ``int``.")

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -173,7 +173,7 @@ def sparse_encoder(
         :class:`qibo.models.circuit.Circuit`: Circuit that loads sparse :math:`\\mathbf{x}`.
 
     References:
-        1. L. Li, J. Luo,
+        1. L. Li, and J. Luo,
         *Nearly Optimal Circuit Size for Sparse Quantum State Preparation*
         `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
         2. R. M. S. Farias, T. O. Maciel, G. Camilo, R. Lin, S. Ramos-Calderer, and L. Aolita,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -203,10 +203,6 @@ def sparse_encoder(
     if isinstance(data[0][0], str) and nqubits is None:
         nqubits = len(data[0][0])
 
-    _data_test = data[0][1]
-    _data_test = (
-        _data_test.dtype if "array" in str(type(_data_test)) else type(_data_test)
-    )
 
     if method not in ("li", "farias"):
         raise_error(

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2118,7 +2118,7 @@ def permutation_synthesis(
     backend=None,
 ):
     """Return circuit that implements a given permutation.
-    
+
     Given permutation ``sigma`` on :math:`{0, \\, 1, \\, \\dots, \\, d-1}`
     and a power‑of‑two budget :math:`m`, this function factors ``sigma``
     into the fewest layers :math:`\\sigma_{1}, \\, \\sigma_{2}, \\, \\cdots, \\, \\sigma_{t}`

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2153,7 +2153,9 @@ def permutation_synthesis(
 
     n = int(backend.np.ceil(backend.np.log2(len(sigma))))
     if sum([abs(s - i) for s, i in zip(sorted(sigma), range(2**n))]) != 0:
-        raise_error(ValueError, "Permutation sigma must contain all indices {0,...,n-1}")
+        raise_error(
+            ValueError, "Permutation sigma must contain all indices {0,...,n-1}"
+        )
 
     if m > 0 and (m & (m - 1)) != 0:
         raise_error(ValueError, f"budget m must be a power‑of‑two")

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2118,7 +2118,7 @@ def _perm_pair_flip_ops(n: int, m: int, backend=None):
 
 
 def permutation_synthesis(
-    sigma: Union[List[int], Tuple[int, ...]],
+    sigma: Union[List[int], tuple[int, ...]],
     m: int = 2,
     backend=None,
 ):

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -308,10 +308,10 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
     # binary enconder on \sum_i = xi |sigma^{-1}(b_i)>
     circuit = binary_encoder(data_sorted, backend=backend, **kwargs)
     circuit.queue = circuit.queue[: (dim - 1)]
-    circuit_binary = Circuit(nqubits)
+    circuit_binary = Circuit(nqubits, **kwargs)
     circuit_binary.add(circuit.on_qubits(*range(nqubits - circuit.nqubits, nqubits)))
 
-    circuit_permutation = permutation_synthesis(sigma. **kwargs)
+    circuit_permutation = permutation_synthesis(sigma, **kwargs)
 
     return circuit_binary + circuit_permutation
 

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2150,7 +2150,10 @@ def permutation_synthesis(
         sigma = list(sigma)
 
     if not isinstance(sigma, (list, tuple)):
-        raise_error(TypeError, f"Permutation ``sigma`` must be either a ``list`` or a ``tuple`` of ``int``s.")
+        raise_error(
+            TypeError,
+            f"Permutation ``sigma`` must be either a ``list`` or a ``tuple`` of ``int``s.",
+        )
 
     n = int(backend.np.ceil(backend.np.log2(len(sigma))))
     if sum([abs(s - i) for s, i in zip(sorted(sigma), range(2**n))]) != 0:

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2126,7 +2126,7 @@ def permutation_synthesis(
         Return a circuit synthesis of sigma.
 
     Args:
-        sigma (list[int] or tuple[int]): permutation description on {0,...,d-1}.
+        sigma (list or tuple): permutation description on {0,...,d-1}.
         m (int): power‑of‑two budget m (Default:2)
 
     Returns:

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -232,7 +232,7 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
         \\mathbf{y} = \\left\\{ (b_{1}, x_{1}), \\, \\dots, \\, (b_{s}, x_{s}) \\right\\} \\, ,
 
 
-    where :math:`\\{x_{j}\\}_{j\\in[s]}` is the non-zero components of :math:`\\mathbf{x}`
+    where :math:`\\{x_{j}\\}_{j\\in[s]}` are the non-zero components of :math:`\\mathbf{x}`
     and :math:`\\{b_{j}\\}_{j\\in[s]}` is the set of addresses associated with these values.
     Then, this function generates a quantum circuit  :math:`s\\text{-}\\mathrm{Load}` that encodes
     :math:`\\mathbf{x}` in the amplitudes of an :math:`n`-qubit quantum state as
@@ -311,7 +311,7 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
     circuit_binary = Circuit(nqubits)
     circuit_binary.add(circuit.on_qubits(*range(nqubits - circuit.nqubits, nqubits)))
 
-    circuit_permutation = permutation_synthesis(sigma)
+    circuit_permutation = permutation_synthesis(sigma. **kwargs)
 
     return circuit_binary + circuit_permutation
 
@@ -329,7 +329,7 @@ def _sparse_encoder_farias(data, nqubits: int, backend=None, **kwargs):
         \\mathbf{y} = \\left\\{ (b_{1}, x_{1}), \\, \\dots, \\, (b_{s}, x_{s}) \\right\\} \\, ,
 
 
-    where :math:`\\{x_{j}\\}_{j\\in[s]}` is the non-zero components of :math:`\\mathbf{x}`
+    where :math:`\\{x_{j}\\}_{j\\in[s]}` are the non-zero components of :math:`\\mathbf{x}`
     and :math:`\\{b_{j}\\}_{j\\in[s]}` is the set of addresses associated with these values.
     Then, this function generates a quantum circuit  :math:`s\\text{-}\\mathrm{Load}` that encodes
     :math:`\\mathbf{x}` in the amplitudes of an :math:`n`-qubit quantum state as
@@ -2122,11 +2122,12 @@ def permutation_synthesis(
     sigma: Union[List[int], tuple[int, ...]],
     m: int = 2,
     backend=None,
+    **kwargs
 ):
     """Return circuit that implements a given permutation.
 
-    Given permutation ``sigma`` on :math:`{0, \\, 1, \\, \\dots, \\, d-1}`
-    and a power‑of‑two budget :math:`m`, this function factors ``sigma``
+    Given permutation ``sigma`` on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`
+    and a power‑of‑two budget ``m``, this function factors ``sigma``
     into the fewest layers :math:`\\sigma_{1}, \\, \\sigma_{2}, \\, \\cdots, \\, \\sigma_{t}`
     such that:
         - each layer has at most :math:`m` disjoint transpositions;

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2133,7 +2133,7 @@ def permutation_synthesis(
         :class:`qibo.models.circuit.Circuit`: Circuit that implements the permutation sigma.
 
     References:
-        1. L. Li, J. Luo,
+        1. L. Li, and J. Luo,
         *Nearly Optimal Circuit Size for Sparse Quantum State Preparation*
         `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
     """

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2074,18 +2074,14 @@ def _perm_row_ops(A, ell: int, m: int, n: int, backend=None):
             if A[j, k] != 0:
                 # Element b_{j},{k} != 0, {k} > {log2m-1}"
                 for kprime in range(ell):
-                    if k == kprime:
-                        continue
                     # There is a typo in the paper
                     # b_{j},{kprime} should be different from Ã_{j},{kprime} not Ã_{j},{k}
-                    if A[j, kprime] == atilde[j, kprime]:
-                        continue
-
-                    qgates.append(gates.CNOT(n - k - 1, n - kprime - 1))
-                    # check whether the gate is applied on other rows
-                    for l in range(nrows):
-                        if A[l, k] == 1:
-                            A[l, kprime] = (A[l, kprime] + 1) % 2
+                    if kprime != k and A[j, kprime] != atilde[j, kprime]:
+                        qgates.append(gates.CNOT(n - k - 1, n - kprime - 1))
+                        # check whether the gate is applied on other rows
+                        for l in range(nrows):
+                            if A[l, k] == 1:
+                                A[l, kprime] = (A[l, kprime] + 1) % 2
 
                 # Let us clean the element b_{j},{k}
 
@@ -2121,18 +2117,23 @@ def permutation_synthesis(
     m: int = 2,
     backend=None,
 ):
-    """Given permutation sigma on {0,...,d-1} and a power‑of‑two budget m,
-    factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that
-        - each layer has at most m disjoint transpositions
+    """Return circuit that implements a given permutation.
+    
+    Given permutation ``sigma`` on :math:`{0, \\, 1, \\, \\dots, \\, d-1}`
+    and a power‑of‑two budget :math:`m`, this function factors ``sigma``
+    into the fewest layers :math:`\\sigma_{1}, \\, \\sigma_{2}, \\, \\cdots, \\, \\sigma_{t}`
+    such that:
+        - each layer has at most :math:`m` disjoint transpositions;
         - each layer moves a power‑of‑two number of indices.
-        Return a circuit synthesis of sigma.
+
+    The function returns a circuit synthesis of ``sigma``.
 
     Args:
-        sigma (list or tuple): permutation description on {0,...,d-1}.
-        m (int): power‑of‑two budget m (Default:2)
+        sigma (list or tuple): permutation description on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`.
+        m (int): power‑of‑two budget. Defauls to :math:`2`.
 
     Returns:
-        :class:`qibo.models.circuit.Circuit`: Circuit that implements the permutation sigma.
+        :class:`qibo.models.circuit.Circuit`: Circuit that implements the permutation ``sigma``.
 
     References:
         1. L. Li, and J. Luo,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -264,7 +264,7 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
         :class:`qibo.models.circuit.Circuit`: Circuit that loads sparse :math:`\\mathbf{x}`.
 
     References:
-        1. L. Li, J. Luo,
+        1. L. Li, and J. Luo,
         *Nearly Optimal Circuit Size for Sparse Quantum State Preparation*
         `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
 

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2005,7 +2005,7 @@ def _perm_column_ops(
         if any(elem != 0 for elem in A[:, idxj]):
             ell += 1
             flag[idxj] = 1
-    
+
             # look for columns that are equal to A[:,idxj]
             for idxk in range(idxj + 1, ncols):
                 if backend.np.array_equal(A[:, idxj], A[:, idxk]):
@@ -2109,9 +2109,7 @@ def _perm_pair_flip_ops(n: int, m: int, backend=None):
     prefix = int(backend.np.ceil(backend.np.log2(2 * m)))
     x_qubits, controls = range(prefix, n), range(n - prefix)
     qgates = [gates.X(n - q - 1) for q in x_qubits]
-    qgates.append(
-        gates.X(n - 1).controlled_by(*controls)
-    )  # flip qubit 0
+    qgates.append(gates.X(n - 1).controlled_by(*controls))  # flip qubit 0
     qgates.extend(gates.X(n - q - 1) for q in x_qubits)
 
     return qgates

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -296,16 +296,10 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
 
     sigma = list(sigma)
 
-    rem = int(2 ** backend.np.ceil(backend.np.log2(dim))) - dim
-    data_sorted = backend.np.pad(
-        data_sorted, (0, rem), "constant", constant_values=(0.0)
-    )
     # binary enconder on \sum_i = xi |sigma^{-1}(b_i)>
-    circuit = binary_encoder(data_sorted, backend=backend, **kwargs)
-    circuit.queue = circuit.queue[: (dim - 1)]
-    circuit_binary = Circuit(nqubits, **kwargs)
-    circuit_binary.add(circuit.on_qubits(*range(nqubits - circuit.nqubits, nqubits)))
-
+    circuit_binary = sparse_encoder(
+        data_binary, method="farias", nqubits=nqubits, backend=backend, **kwargs
+    )
     circuit_permutation = permutation_synthesis(sigma, **kwargs)
 
     return circuit_binary + circuit_permutation

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -1993,7 +1993,7 @@ def _perm_column_ops(
         for k in range(n):
             bits.append((x >> k) & 1)
         A.append(bits)
-    A = backend.np.array(A, dtype=int)
+    A = backend.cast(A, dtype=backend.np.int8)
     ncols = A.shape[1]
     # initialize the list of gates
     qgates = []
@@ -2060,11 +2060,11 @@ def _perm_row_ops(A, ell: int, m: int, n: int, backend=None):
                 flag = True
                 break
 
-        if flag == False:
+        if not flag:
             # There is no element b_{j},k != 0 for k > {log2m-1}"
-            ctrls = [n - l - 1 for l in range(ncols) if A[j][l] != 0]
+            ctrls = [n - l - 1 for l in range(ncols) if A[j, l] != 0]
             qgates.append(gates.X(n - log2m - 1).controlled_by(*ctrls))
-            ctrls = [l for l in range(ncols) if A[j][l] == 1]
+            ctrls = [l for l in range(ncols) if A[j, l] == 1]
 
             # check whether the gate is applied on other rows
             for l in range(j, nrows):
@@ -2152,8 +2152,8 @@ def permutation_synthesis(
     if isinstance(sigma, tuple):
         sigma = list(sigma)
 
-    if not isinstance(sigma, list):
-        raise_error(TypeError, f"Permutation ``sigma`` must be a ``list`` of ``int``.")
+    if not isinstance(sigma, (list, tuple)):
+        raise_error(TypeError, f"Permutation ``sigma`` must be either a ``list`` or a ``tuple`` of ``int``s.")
 
     n = int(backend.np.ceil(backend.np.log2(len(sigma))))
     if sum([abs(s - i) for s, i in zip(sorted(sigma), range(2**n))]) != 0:

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2157,8 +2157,8 @@ def permutation_synthesis(
             f"Permutation ``sigma`` must be either a ``list`` or a ``tuple`` of ``int``s.",
         )
 
-    n = int(backend.np.ceil(backend.np.log2(len(sigma))))
-    if sum([abs(s - i) for s, i in zip(sorted(sigma), range(2**n))]) != 0:
+    nqubits = int(backend.np.ceil(backend.np.log2(len(sigma))))
+    if sum([abs(s - i) for s, i in zip(sorted(sigma), range(2**nqubits))]) != 0:
         raise_error(
             ValueError, "Permutation sigma must contain all indices {0,...,n-1}"
         )
@@ -2175,13 +2175,13 @@ def permutation_synthesis(
     # each layer moves a power‑of‑two number of indices
     layers = decompose_permutation(sigma, m)
 
-    circuit = Circuit(n)
+    circuit = Circuit(nqubits)
     # in case we have more than one permutation to do, do it in layers
     for layer in layers:
         m = len(layer)
-        ell, col_gates, A = _perm_column_ops(layer, n, backend)
-        row_gates = _perm_row_ops(A, ell, m, n, backend)
-        flip_gates = _perm_pair_flip_ops(n, m, backend)
+        ell, col_gates, A = _perm_column_ops(layer, nqubits, backend)
+        row_gates = _perm_row_ops(A, ell, m, nqubits, backend)
+        flip_gates = _perm_pair_flip_ops(nqubits, m, backend)
         col_row = col_gates + row_gates
         circuit.add(col_row)
         circuit.add(flip_gates)

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -289,8 +289,8 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
     data_binary = []
     for bi_int, xi in zip(bitstrings_sorted, data_sorted):
         bi_int = int(bi_int)
-        if bi_int >= d:
-            for k in range(d):
+        if bi_int >= dim:
+            for k in range(dim):
                 if flag[k] == 0:
                     flag[k] = 1
                     sigma[bi_int] = k

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -293,8 +293,7 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
             for k in range(dim):
                 if flag[k] == 0:
                     flag[k] = 1
-                    sigma[bi_int] = k
-                    sigma[k] = bi_int
+                    sigma[[bi_int, k]] = [k, bi_int]
                     data_binary.append((k, xi))
                     break
         else:

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -203,7 +203,6 @@ def sparse_encoder(
     if isinstance(data[0][0], str) and nqubits is None:
         nqubits = len(data[0][0])
 
-
     if method not in ("li", "farias"):
         raise_error(
             ValueError,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -215,7 +215,7 @@ def sparse_encoder(
         )
 
     func = _sparse_encoder_farias if method == "farias" else _sparse_encoder_li
-     
+
     return func(data, nqubits, backend, **kwargs)
 
 
@@ -272,13 +272,18 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
     """
     backend = _check_backend(backend)
     data_sorted, bitstrings_sorted = _sort_data_sparse(data, nqubits, backend)
-    bitstrings_sorted = backend.cast([int("".join(map(str, string)), 2) for string in bitstrings_sorted], dtype=backend.np.int8)
+    bitstrings_sorted = backend.cast(
+        [int("".join(map(str, string)), 2) for string in bitstrings_sorted],
+        dtype=backend.np.int8,
+    )
 
     dim = len(data_sorted)
     sigma = [i for i in range(2**nqubits)]
 
     flag = backend.np.zeros(dim, dtype=backend.np.int8)
-    indexes = list(backend.to_numpy(bitstrings_sorted[bitstrings_sorted < dim]).astype(int))
+    indexes = list(
+        backend.to_numpy(bitstrings_sorted[bitstrings_sorted < dim]).astype(int)
+    )
     flag[indexes] = 1
 
     data_binary = []

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2002,19 +2002,16 @@ def _perm_column_ops(
     ell = 0
     flag = backend.np.zeros(n, dtype=int)
     for idxj in range(ncols):
-        if backend.np.array_equal(A[:, idxj], backend.np.zeros_like(A[:, idxj])):
-            continue
-        # else, we count the number of non-zeros columns
-        # and flag these columns
-        ell += 1
-        flag[idxj] = 1
-
-        # look for columns that are equal to A[:,idxj]
-        for idxk in range(idxj + 1, ncols):
-            if backend.np.array_equal(A[:, idxj], A[:, idxk]):
-                qgates.append(gates.CNOT(n - idxj - 1, n - idxk - 1))
-                # this should transform the k-th column into an all-zero column
-                A[:, idxk] = backend.np.zeros_like(A[:, idxk])
+        if any(elem != 0 for elem in A[:, idxj]):
+            ell += 1
+            flag[idxj] = 1
+    
+            # look for columns that are equal to A[:,idxj]
+            for idxk in range(idxj + 1, ncols):
+                if backend.np.array_equal(A[:, idxj], A[:, idxk]):
+                    qgates.append(gates.CNOT(n - idxj - 1, n - idxk - 1))
+                    # this should transform the k-th column into an all-zero column
+                    A[:, idxk] = 0
 
     # Now, we need to swap the ell non-zero columns to the first ell columns
     for idxk in range(ell, ncols):

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -301,14 +301,15 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
 
     sigma = list(sigma)
 
-
-    rem  = int(2**backend.np.ceil(backend.np.log2(dim))) - dim
-    data_sorted = backend.np.pad(data_sorted,(0, rem),'constant', constant_values=(0.))
+    rem = int(2 ** backend.np.ceil(backend.np.log2(dim))) - dim
+    data_sorted = backend.np.pad(
+        data_sorted, (0, rem), "constant", constant_values=(0.0)
+    )
     # binary enconder on \sum_i = xi |sigma^{-1}(b_i)>
     circuit = binary_encoder(data_sorted, backend=backend, **kwargs)
-    circuit.queue = circuit.queue[:(dim-1)]
+    circuit.queue = circuit.queue[: (dim - 1)]
     circuit_binary = Circuit(nqubits)
-    circuit_binary.add(circuit.on_qubits(*range(nqubits-circuit.nqubits,nqubits)))
+    circuit_binary.add(circuit.on_qubits(*range(nqubits - circuit.nqubits, nqubits)))
 
     circuit_permutation = permutation_synthesis(sigma)
 

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -301,10 +301,15 @@ def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
 
     sigma = list(sigma)
 
+
+    rem  = int(2**backend.np.ceil(backend.np.log2(dim))) - dim
+    data_sorted = backend.np.pad(data_sorted,(0, rem),'constant', constant_values=(0.))
     # binary enconder on \sum_i = xi |sigma^{-1}(b_i)>
-    circuit_binary = sparse_encoder(
-        data_binary, method="farias", nqubits=nqubits, backend=backend, **kwargs
-    )
+    circuit = binary_encoder(data_sorted, backend=backend, **kwargs)
+    circuit.queue = circuit.queue[:(dim-1)]
+    circuit_binary = Circuit(nqubits)
+    circuit_binary.add(circuit.on_qubits(*range(nqubits-circuit.nqubits,nqubits)))
+
     circuit_permutation = permutation_synthesis(sigma)
 
     return circuit_binary + circuit_permutation

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2119,10 +2119,7 @@ def _perm_pair_flip_ops(n: int, m: int, backend=None):
 
 
 def permutation_synthesis(
-    sigma: Union[List[int], tuple[int, ...]],
-    m: int = 2,
-    backend=None,
-    **kwargs
+    sigma: Union[List[int], tuple[int, ...]], m: int = 2, backend=None, **kwargs
 ):
     """Return circuit that implements a given permutation.
 

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -2153,10 +2153,10 @@ def permutation_synthesis(
 
     n = int(backend.np.ceil(backend.np.log2(len(sigma))))
     if sum([abs(s - i) for s, i in zip(sorted(sigma), range(2**n))]) != 0:
-        raise_error(TypeError, "Permutation sigma must contain all indices {0,...,n-1}")
+        raise_error(ValueError, "Permutation sigma must contain all indices {0,...,n-1}")
 
     if m > 0 and (m & (m - 1)) != 0:
-        raise_error(TypeError, f"budget m must be a power‑of‑two")
+        raise_error(ValueError, f"budget m must be a power‑of‑two")
 
     from qibo.quantum_info.utils import (  # pylint: disable=import-outside-toplevel
         decompose_permutation,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -123,7 +123,7 @@ def phase_encoder(data, rotation: str = "RY", backend=None, **kwargs):
     return circuit
 
 
-def sparse_encoder(data, nqubits: int = None, backend=None, **kwargs):
+def sparse_encoder(data, method:str = "li", nqubits: int = None, backend=None, **kwargs):
     """Create circuit that encodes :math:`1`-dimensional data in a subset of amplitudes
     of the computational basis.
 
@@ -143,9 +143,192 @@ def sparse_encoder(data, nqubits: int = None, backend=None, **kwargs):
 
     .. math::
         s\\text{-}\\mathrm{Load}(\\mathbf{y}) \\, \\ket{0}^{\\otimes \\, n} = \\sum_{j\\in[s]} \\,
-            \\frac{x_{j}}{\\|\\mathbf{x}\\|_{F}} \\, \\ket{b_{j}} \\, ,
+            \\frac{x_{j}}{\\|\\mathbf{x}\\|_{2}} \\, \\ket{b_{j}} \\, ,
 
-    where :math:`\\|\\cdot\\|_{F}` is the Frobenius norm.
+    where :math:`\\|\\cdot\\|_{2}` is the l2-norm.
+
+    Resulting circuit parametrizes ``data`` in hyperspherical coordinates
+    in the :math:`(2^{n} - 1)`-unit sphere.
+
+
+    Args:
+        data (ndarray or list or zip): sequence of tuples of the form :math:`(b_{j}, x_{j})`.
+            The addresses :math:`b_{j}` can be either integers or in bitstring
+            format of size :math:`n`.
+        method (str, optional): method to be used, either ``li`` or ``farias``. They refer to 
+            methods in references [1] and [2], respectively.
+            Defaults to ``li`` 
+        nqubits (int, optional): total number of qubits in the system.
+            To be used when :math:`b_j` are integers. If :math:`b_j` are strings and
+            ``nqubits`` is ``None``, defaults to the length of the strings :math:`b_{j}`.
+            Defaults to ``None``.
+        backend (:class:`qibo.backends.abstract.Backend`, optional): backend to be used
+            in the execution. If ``None``, it uses the current backend. Defaults to ``None``.
+        kwargs (dict, optional): Additional arguments used to initialize a Circuit object.
+            For details, see the documentation of :class:`qibo.models.circuit.Circuit`.
+
+    Returns:
+        :class:`qibo.models.circuit.Circuit`: Circuit that loads sparse :math:`\\mathbf{x}`.
+
+    References:
+        1. L. Li, J. Luo,
+        *Nearly Optimal Circuit Size for Sparse Quantum State Preparation*
+        `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
+        2. R. M. S. Farias, T. O. Maciel, G. Camilo, R. Lin, S. Ramos-Calderer, and L. Aolita,
+        *Quantum encoder for fixed-Hamming-weight subspaces*,
+        `Phys. Rev. Applied 23, 044014 (2025) <https://doi.org/10.1103/PhysRevApplied.23.044014>`_.
+
+        3. `Hyperpherical coordinates <https://en.wikipedia.org/wiki/N-sphere>`_.
+    """
+    backend = _check_backend(backend)
+
+    if isinstance(data, zip):
+        data = list(data)
+
+    # TODO: Fix this mess with qibo native dtypes
+    try:
+        type_test = bool("int" in str(data[0][0].dtype))
+    except AttributeError:
+        type_test = bool("int" in str(type(data[0][0])))
+
+    if type_test and nqubits is None:
+        raise_error(
+            ValueError,
+            "``nqubits`` must be specified when computational basis states are "
+            + "indidated by integers.",
+        )
+
+    if isinstance(data[0][0], str) and nqubits is None:
+        nqubits = len(data[0][0])
+
+    _data_test = data[0][1]
+    _data_test = (
+        _data_test.dtype if "array" in str(type(_data_test)) else type(_data_test)
+    )
+
+    match method:
+        case "li":
+            circuit = _sparse_encoder_li(data, nqubits, backend, **kwargs)
+        case "farias":
+            circuit = _sparse_encoder_farias(data, nqubits, backend, **kwargs)
+        case _:
+            raise_error(
+                ValueError,
+                "``method`` should be either ``li`` or ``farias``",
+            )
+
+    return circuit
+
+def _sparse_encoder_li(data, nqubits: int, backend=None, **kwargs):
+    """Create circuit that encodes :math:`1`-dimensional data in a subset of amplitudes
+    of the computational basis.
+
+    Consider a sparse-access model, where for a data vector
+    :math:`\\mathbf{x} \\in \\mathbb{C}^{d}`, with :math:`d = 2^{n}` and
+    :math:`s` non-zero amplitudes, one has access to the data vector
+    :math:`\\mathbf{y}` of the form
+
+    .. math::
+        \\mathbf{y} = \\left\\{ (b_{1}, x_{1}), \\, \\dots, \\, (b_{s}, x_{s}) \\right\\} \\, ,
+
+
+    where :math:`\\{x_{j}\\}_{j\\in[s]}` is the non-zero components of :math:`\\mathbf{x}`
+    and :math:`\\{b_{j}\\}_{j\\in[s]}` is the set of addresses associated with these values.
+    Then, this function generates a quantum circuit  :math:`s\\text{-}\\mathrm{Load}` that encodes
+    :math:`\\mathbf{x}` in the amplitudes of an :math:`n`-qubit quantum state as
+
+    .. math::
+        s\\text{-}\\mathrm{Load}(\\mathbf{y}) \\, \\ket{0}^{\\otimes \\, n} = \\sum_{j\\in[s]} \\,
+            \\frac{x_{j}}{\\|\\mathbf{x}\\|_{2}} \\, \\ket{b_{j}} \\, ,
+
+    where :math:`\\|\\cdot\\|_{2}` is the l2-norm.
+
+    Resulting circuit parametrizes ``data`` in hyperspherical coordinates
+    in the :math:`(2^{n} - 1)`-unit sphere.
+
+
+    Args:
+        data (ndarray or list or zip): sequence of tuples of the form :math:`(b_{j}, x_{j})`.
+            The addresses :math:`b_{j}` can be either integers or in bitstring
+            format of size :math:`n`.
+        nqubits (int, optional): total number of qubits in the system.
+            To be used when :math:`b_j` are integers. If :math:`b_j` are strings and
+            ``nqubits`` is ``None``, defaults to the length of the strings :math:`b_{j}`.
+            Defaults to ``None``.
+        backend (:class:`qibo.backends.abstract.Backend`, optional): backend to be used
+            in the execution. If ``None``, it uses the current backend. Defaults to ``None``.
+        kwargs (dict, optional): Additional arguments used to initialize a Circuit object.
+            For details, see the documentation of :class:`qibo.models.circuit.Circuit`.
+
+    Returns:
+        :class:`qibo.models.circuit.Circuit`: Circuit that loads sparse :math:`\\mathbf{x}`.
+
+    References:
+        1. L. Li, J. Luo,
+        *Nearly Optimal Circuit Size for Sparse Quantum State Preparation*
+        `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
+
+        2. `Hyperpherical coordinates <https://en.wikipedia.org/wiki/N-sphere>`_.
+    """
+    backend = _check_backend(backend)
+    data_sorted, bitstrings_sorted = _sort_data_sparse(data, nqubits, backend)
+    d = len(data_sorted)
+    sigma = [i for i in range(2**nqubits)]
+
+    flag = backend.np.zeros(d, dtype=backend.np.int8)
+    for bi in bitstrings_sorted:
+        bi_int =  int(''.join(map(str, bi)), 2)
+        if bi_int < d:
+            flag[bi_int]=1
+
+    data_binary=[]
+    for bi,xi in zip(bitstrings_sorted,data_sorted):
+        bi_int =  int(''.join(map(str, bi)), 2)
+        if bi_int >= d:
+            for k in range(d):
+                if flag[k]==0:
+                    flag[k]=1
+                    sigma[bi_int]=k
+                    sigma[k]=bi_int
+                    data_binary.append((k,xi))
+                    break
+        else:
+            data_binary.append((bi_int,xi))
+
+    # binary enconder on \sum_i = xi |sigma^{-1}(b_i)>
+    circuit_binary      = sparse_encoder(data_binary, method='farias', nqubits=nqubits, backend=backend, **kwargs)
+    circuit_permutation = permutation_synthesis(sigma)
+    circuit = Circuit(nqubits)
+    circuit.add([gate for gate in circuit_binary.queue])
+    circuit.add([gate for gate in circuit_permutation.queue])
+
+    return circuit
+
+
+
+def _sparse_encoder_farias(data, nqubits: int, backend=None, **kwargs):
+    """Create circuit that encodes :math:`1`-dimensional data in a subset of amplitudes
+    of the computational basis.
+
+    Consider a sparse-access model, where for a data vector
+    :math:`\\mathbf{x} \\in \\mathbb{C}^{d}`, with :math:`d = 2^{n}` and
+    :math:`s` non-zero amplitudes, one has access to the data vector
+    :math:`\\mathbf{y}` of the form
+
+    .. math::
+        \\mathbf{y} = \\left\\{ (b_{1}, x_{1}), \\, \\dots, \\, (b_{s}, x_{s}) \\right\\} \\, ,
+
+
+    where :math:`\\{x_{j}\\}_{j\\in[s]}` is the non-zero components of :math:`\\mathbf{x}`
+    and :math:`\\{b_{j}\\}_{j\\in[s]}` is the set of addresses associated with these values.
+    Then, this function generates a quantum circuit  :math:`s\\text{-}\\mathrm{Load}` that encodes
+    :math:`\\mathbf{x}` in the amplitudes of an :math:`n`-qubit quantum state as
+
+    .. math::
+        s\\text{-}\\mathrm{Load}(\\mathbf{y}) \\, \\ket{0}^{\\otimes \\, n} = \\sum_{j\\in[s]} \\,
+            \\frac{x_{j}}{\\|\\mathbf{x}\\|_{2}} \\, \\ket{b_{j}} \\, ,
+
+    where :math:`\\|\\cdot\\|_{2}` is the l2-norm.
 
     Resulting circuit parametrizes ``data`` in hyperspherical coordinates
     in the :math:`(2^{n} - 1)`-unit sphere.
@@ -1787,3 +1970,213 @@ def _add_wbd_gate(
                 )
             )
         circuit.add(gates.CNOT(second_register[control - dif], first_register[0]))
+
+def _perm_column_ops(
+        indices: list[int], 
+        n:int,
+        backend = None,
+        ):
+    """Return (ell, gate_list) performing duplicate‑col removal + compaction."""
+    backend =_check_backend(backend)
+    # flatten the (x_0, x_1),...(x_{2m-2}, x_{2m-1})
+    # We construct a matrix composed of
+    # xj to track the changes in xj where xj,k represents the k-th bit and the 
+    # bits are arranged from the least significant bit to the most significant bit
+    indices = list(sum(indices, ()))
+    A=[]
+    for x in indices:
+        bits=[]
+        for k in range(n):
+            bits.append((x>>k)&1)
+        A.append(bits)
+    A = backend.np.array(A, dtype=int)
+    ncols = A.shape[1]
+    # initialize the list of gates
+    qgates = []
+    
+    # number of non-zero columns
+    ell = 0
+    flag = backend.np.zeros(n,dtype=int)
+    for idxj in range(ncols):
+        if backend.np.array_equal(A[:,idxj],backend.np.zeros_like(A[:,idxj])):
+            continue
+        # else, we count the number of non-zeros columns
+        # and flag these columns
+        ell+=1
+        flag[idxj] = 1
+
+        # look for columns that are equal to A[:,idxj]
+        for idxk in range(idxj+1,ncols):
+            if backend.np.array_equal(A[:,idxj],A[:,idxk]):
+                qgates.append(gates.CNOT(n-idxj-1,n-idxk-1))
+                # this should transform the k-th column into an all-zero column
+                A[:,idxk] = backend.np.zeros_like(A[:,idxk])
+
+    # Now, we need to swap the ell non-zero columns to the first ell columns
+    for idxk in range(ell,ncols):
+        if not backend.np.array_equal(A[:,idxk],backend.np.zeros_like(A[:,idxk])):
+            for k in range(len(flag)):
+                if flag[k]==0:
+                    flag[k]=1
+                    flag[idxk]=0
+
+                    qgates.append(gates.SWAP(n-idxk-1,n-k-1))
+
+                    bits = A[:,idxk].copy()
+                    A[:,idxk] = A[:,k]
+                    A[:,k] = bits
+                    break
+
+    return ell, qgates, A
+
+def _perm_row_ops(
+        A, 
+        ell: int, 
+        m: int, 
+        n: int, 
+        backend = None
+        ):
+    """Return gates that reduce all rows after row0 to target form."""
+    backend =_check_backend(backend)
+    
+    log2m = int(backend.np.log2(2*m))
+    atilde = backend.np.array([[(x>>k)&1 for k in range(n)] for x in range(2*m)],dtype=int)
+
+    qgates = []
+    nrows = A.shape[0]
+    ncols = A.shape[1]
+    # Start with the first row (indexed as row 0)
+    for k in range(ncols):
+        # If we find a0,k = 1 for any 0 <= k <= n−1
+        if A[0,k]==1:
+            qgates.append(gates.X(n-k-1))
+            A[:,k] = (A[:,k] + 1)%2
+
+    for j in range(1,nrows):
+        flag=False
+        for k in range(log2m,ncols):
+            if A[j,k] != 0:
+                flag=True
+                break
+        
+        if flag==False:
+            # There is no element b_{j},k != 0 for k > {log2m-1}"
+            ctrls = [n-l-1 for l in range(ncols) if A[j][l] != 0]
+            qgates.append(gates.X(n-log2m-1).controlled_by(*ctrls))
+            ctrls = [l for l in range(ncols) if A[j][l] == 1]
+
+            # check whether the gate is applied on other rows 
+            for l in range(j,nrows):
+                if backend.np.array_equal(A[l,ctrls],backend.np.ones_like(A[l,ctrls])):
+                    A[l,log2m] = (A[l,log2m]+1)%2
+            
+        # There is always an element b_{j},k != 0 for k > {log2m-1}
+        for k in range(log2m,ncols):
+            if A[j,k] != 0:
+                # Element b_{j},{k} != 0, {k} > {log2m-1}"
+                for kprime in range(ell):
+                    if (k == kprime) : continue
+                    # There is a typo in the paper
+                    # b_{j},{kprime} should be different from Ã_{j},{kprime} not Ã_{j},{k}
+                    if (A[j,kprime]==atilde[j,kprime]): continue
+                    
+                    qgates.append(gates.CNOT(n-k-1,n-kprime-1))
+                    # check whether the gate is applied on other rows 
+                    for l in range(nrows):
+                        if A[l,k]==1:
+                            A[l,kprime]=(A[l,kprime]+1)%2
+
+                # Let us clean the element b_{j},{k}
+                
+                # There is another typo in the paper
+                # the control qubits for this gate correspond to the non-zero elements in row j of matrix A, not Ã
+                ctrls = [n-l-1 for l in range(k) if A[j,l] != 0]
+                qgates.append(gates.X(n-k-1).controlled_by(*ctrls))
+                ctrls = [l for l in range(k) if A[j,l] != 0]
+
+                # check whether the gate is applied on other rows 
+                for l in range(nrows):
+                    if backend.np.array_equal(A[l,ctrls],backend.np.ones_like(A[l,ctrls])):
+                        A[l,k] = (A[l,k]+1)%2
+
+    return qgates
+
+def _perm_pair_flip_ops(
+        n:int, 
+        m:int,
+        backend = None
+        ):
+    """Implement σ_{i,2} as X fan‑in + MCX + X fan‑out."""
+    backend =_check_backend(backend)
+    # let us flip the first qubit when the last {int(n-math.log2(2*m))} qubits are all in the state |0⟩
+    prefix = int(backend.np.ceil(backend.np.log2(2*m))) 
+    x_qubits = list(range(prefix, n))
+    qgates=[gates.X(n-q-1) for q in x_qubits]
+    qgates.append(gates.X(n-1).controlled_by(*range(n-int(np.ceil(math.log2(2*m)))))) # flip qubit 0
+    qgates.extend(gates.X(n-q-1) for q in x_qubits) 
+
+    return qgates
+
+def permutation_synthesis(
+        sigma:list[int],
+        m:int=2,
+        backend=None,
+):
+    """Given permutation sigma on {0,...,d-1} and a power‑of‑two budget m,
+    factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that
+        - each layer has at most m disjoint transpositions
+        - each layer moves a power‑of‑two number of indices.
+        Return a circuit synthesis of sigma. 
+
+    Args:
+        sigma (list[int]): permutation description on {0,...,d-1}.
+        m (int): power‑of‑two budget m (Default:2)
+
+    Returns:
+        :class:`qibo.models.circuit.Circuit`: Circuit that implements the permutation sigma.
+
+    References:
+        1. L. Li, J. Luo,
+        *Nearly Optimal Circuit Size for Sparse Quantum State Preparation*
+        `arXiv:2406.16142 (2024) <https://doi.org/10.48550/arXiv.2406.16142>`_.
+    """
+    backend = _check_backend(backend)
+
+    if not isinstance(sigma, list):
+        raise_error(
+                TypeError, f"Permutation sigma must be list[int]"
+            )
+        
+    n = int(backend.np.ceil(backend.np.log2(len(sigma))))
+    if sum([abs(s-i) for s,i in zip(sorted(sigma),range(2**n))]) != 0:
+        raise_error(
+                TypeError, "Permutation sigma must contain all indices {0,...,n-1}"
+            )
+        
+    if (m > 0 and (m & (m-1)) != 0):
+        raise_error(
+                TypeError, f"budget m must be a power‑of‑two"
+            )
+        
+    from qibo.quantum_info.utils import (  # pylint: disable=import-outside-toplevel
+        decompose_permutation,
+    )
+
+    # factor sigma into the fewest layers such that
+    # each layer has at most m disjoint transpositions, and
+    # each layer moves a power‑of‑two number of indices
+    layers = decompose_permutation(sigma, m)
+
+    circ_gates=[]
+    # in case we have more than one permutation to do, do it in layers
+    for layer in layers:
+        m=len(layer)
+        ell, col_gates, A = _perm_column_ops(layer, n, backend)
+        row_gates         = _perm_row_ops(A, ell, m, n, backend)
+        flip_gates        = _perm_pair_flip_ops(n, m, backend)
+
+        circ_gates += col_gates + row_gates + flip_gates + list(reversed(col_gates+row_gates))
+
+    circ = Circuit(n)
+    circ.add(circ_gates)
+    return circ

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -636,7 +636,7 @@ def _greedy_pack(matchings: List[List[Tuple[int, int]]], m: int):
     return layers
 
 
-def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
+def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int, backend=None):
     """
      Given permutation ``sigma`` on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`
     and a power‑of‑two budget ``m``, this function factors ``sigma``
@@ -652,11 +652,15 @@ def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
     Args:
         sigma (list[int] or tuple[int]): permutation description on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`.
         m (int): power‑of‑two budget.
+        backend (:class:`qibo.backends.abstract.Backend`, optional): backend to be used
+            in the execution. If ``None``, it uses the current backend. Defaults to ``None``.
 
     Returns:
         list[list[tuple[int, int]]]: :math:`t` layers of pairwise transpositions.
 
     """
+    backend = _check_backend(backend)
+
     if isinstance(sigma, tuple):
         sigma = list(sigma)
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -4,7 +4,7 @@ from functools import reduce
 from itertools import permutations
 from math import factorial
 from re import finditer
-from typing import Optional, Union
+from typing import Optional, List, Tuple, Union
 
 import numpy as np
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -540,3 +540,112 @@ def _hadamard_transform_1d(array, backend=None):
         array_copied /= 2.0
 
     return array_copied
+
+
+def _cycles_from_perm(
+        sigma: list[int]
+):
+    """ 
+    We extract the cylces from a permutation as follows:
+        - Treat the permutation as a directed graph of arrows i->sigma(i).
+        - Depth‑first walk from every unvisited vertex; each walk closes at the start -> a cycle.
+        - Disjoint cycles partition the set {0,...,n-1} and commute, so we can factorize them independently.
+    """
+    n, seen, cycles = len(sigma), [False]*len(sigma), []
+    for i in range(n):
+        # Depth‑first walk from every unvisited vertex
+        if seen[i]: continue
+        cur, cyc = i, []
+        # Disjoint cycles
+        while not seen[cur]:
+            seen[cur]=True
+            cyc.append(cur)
+            cur=sigma[cur]
+        if len(cyc)>1: cycles.append(cyc)
+    return cycles
+
+
+def _star_matchings(
+        cyc: list[int]
+):
+    """
+    Given a cycle (a_1,a_2,...,a_k) with k>=2, the star factorisation expresses it as the ordered 
+    product of (k-1) disjoint transpositions that all share the first vertex:
+
+        (a_1,a_2),(a_1,a_3),...,(a_1,a_k).
+
+    Applied right‑to‑left, this product reproduces the original cycle.
+    """
+    hub=cyc[0]
+    return [[(min(hub,v), max(hub,v))] for v in cyc[1:]]
+
+
+def _greedy_pack(
+        matchings:list[list[tuple[int, int]]], 
+        m:int
+):
+    """
+    Add a matching to the current layer if
+        - it shares no vertex with swaps already in the layer, and
+        - new layer size #swaps stays a power of two <= m.
+    Otherwise flush the layer and start a new one.
+    It works since disjointness keeps swaps commutative, and the power‑of‑two size rule 
+    aligns exactly with layer constraints.
+    """
+    layers:list[list[tuple[int, int]]]=[]
+    cur:list[tuple[int, int]] =[]
+    used=set()
+    def _flush():
+        nonlocal cur,used
+        if cur: layers.append(cur)
+        cur,used=[],set()
+
+    def _verts(layer:list[tuple[int, int]]):
+        for a,b in layer: yield a; yield b
+
+    for M in matchings:
+        x = len(cur)+len(M)
+        # is power of 2 and x<=m
+        legal=(x > 0 and (x & (x-1)) == 0) and x<=m
+        # shares no vertex with swaps already in the layer
+        if cur and (any(v in used for v in _verts(M)) or not legal): _flush()
+        cur.extend(M)
+        used.update(_verts(M))
+        if len(cur)==m: _flush()
+    _flush()
+    return layers
+
+def decompose_permutation(
+        sigma:list[int], 
+        m:int
+):
+    """
+    Given a permutation sigma on {0,...,n-1} and a power‑of‑two budget m,
+    factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that
+        - each layer has at most m disjoint transpositions
+        - each layer moves a power‑of‑two number of indices.
+
+    We do this as follows:
+        1) Cycle extraction – split sigma into disjoint cycles.
+        2) Star factorisation – a k‑cycle becomes (k-1) hub–spoke swaps.
+        3) Greedy packing – merge swaps into layers while keeping rules.
+
+    Args:
+        sigma (List[int]): permutation description on {0,...,n-1}.
+        m (int): power‑of‑two budget m
+
+    Returns:
+        (List[List[Tuple[int, int]]]): list of t layers of paiwise transposition
+
+    """
+    if not isinstance(sigma, list):
+        raise_error(
+                TypeError, f"Permutation sigma must be List[int]"
+            )
+        
+    if (m > 0 and (m & (m-1)) != 0):
+        raise_error(
+                TypeError, f"budget m must be a power‑of‑two"
+            )
+    matchings=[l for cyc in _cycles_from_perm(sigma) for l in _star_matchings(cyc)]
+    return _greedy_pack(matchings, m)

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -547,7 +547,7 @@ def _cycles_from_perm(sigma: List[int]):
     - Treat the permutation as a directed graph of arrows i->sigma(i).
     - Depth‑first walk from every unvisited vertex; each walk closes at the start -> a cycle.
     - Disjoint cycles partition the set {0,...,n-1} and commute, so we can factorize them independently.
-    
+
     Args:
         sigma (list[int] or tuple[int]): permutation description on {0,...,n-1}.
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -543,8 +543,7 @@ def _hadamard_transform_1d(array, backend=None):
 
 
 def _cycles_from_perm(sigma: List[int]):
-    """
-    We extract the cylces from a permutation as follows:
+    """Extract the cycles from a permutation as follows:
         - Treat the permutation as a directed graph of arrows i->sigma(i).
         - Depth‑first walk from every unvisited vertex; each walk closes at the start -> a cycle.
         - Disjoint cycles partition the set {0,...,n-1} and commute, so we can factorize them independently.
@@ -567,10 +566,12 @@ def _cycles_from_perm(sigma: List[int]):
 
 def _star_matchings(cyc: list[int]):
     """
-    Given a cycle (a_1,a_2,...,a_k) with k>=2, the star factorisation expresses it as the ordered
-    product of (k-1) disjoint transpositions that all share the first vertex:
+    Given a cycle :math:`(a_{1}, \\, a_{2}, \\, \\cdots, \\, a_{k})` with :math:`k \\geq 2`,
+    the star factorization expresses the cycle as the ordered product of :math:`(k-1)` 
+    disjoint transpositions that all share the first vertex:
 
-        (a_1,a_2),(a_1,a_3),...,(a_1,a_k).
+    .. math::
+        (a_{1}, \\, a_{2}), \\, (a_{1}, \\, a_{3}), \\, \\cdots, \\, (a_{1}, \\, a_{k}) \\, .
 
     Applied right‑to‑left, this product reproduces the original cycle.
     """

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -4,7 +4,7 @@ from functools import reduce
 from itertools import permutations
 from math import factorial
 from re import finditer
-from typing import Optional, Union
+from typing import Optional,  List, Tuple, Union
 
 import numpy as np
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -626,7 +626,7 @@ def _greedy_pack(matchings: List[List[Tuple[int, int]]], m: int):
         # is power of 2 and x<=m
         legal = (x > 0 and (x & (x - 1)) == 0) and x <= m
         # shares no vertex with swaps already in the layer
-        if cur and (any(v in used for v in _verts(M)) or not legal):
+        if cur and (any(v in used for v in _verts(M)) or not legal):  # pragma: no cover
             _flush()
         cur.extend(M)
         used.update(_verts(M))

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -645,5 +645,7 @@ def decompose_permutation(sigma: list[int], m: int):
 
     if m > 0 and (m & (m - 1)) != 0:
         raise_error(TypeError, f"budget m must be a power‑of‑two")
+
     matchings = [l for cyc in _cycles_from_perm(sigma) for l in _star_matchings(cyc)]
+    
     return _greedy_pack(matchings, m)

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -547,6 +547,12 @@ def _cycles_from_perm(sigma: List[int]):
     - Treat the permutation as a directed graph of arrows i->sigma(i).
     - Depth‑first walk from every unvisited vertex; each walk closes at the start -> a cycle.
     - Disjoint cycles partition the set {0,...,n-1} and commute, so we can factorize them independently.
+    
+    Args:
+        sigma (list[int] or tuple[int]): permutation description on {0,...,n-1}.
+
+    Returns:
+        list[list[tuple[int, int]]]: :math:`t` list of disjoint cycles.
     """
     n, seen, cycles = len(sigma), [False] * len(sigma), []
     for i in range(n):
@@ -574,6 +580,12 @@ def _star_matchings(cyc: list[int]):
         (a_{1}, \\, a_{2}), \\, (a_{1}, \\, a_{3}), \\, \\cdots, \\, (a_{1}, \\, a_{k}) \\, .
 
     Applied right‑to‑left, this product reproduces the original cycle.
+
+    Args:
+        cyc (list[list[tuple[int, int]]]): :math:`t` list of disjoint cycles.
+
+    Returns:
+        list[list[tuple[int, int]]]: :math:`t` list of pairwise transpositions.
     """
     hub = cyc[0]
     return [[(min(hub, v), max(hub, v))] for v in cyc[1:]]
@@ -587,6 +599,12 @@ def _greedy_pack(matchings: List[List[Tuple[int, int]]], m: int):
     Otherwise flush the layer and start a new one.
     It works since disjointness keeps swaps commutative, and the power‑of‑two size rule
     aligns exactly with layer constraints.
+
+    Args:
+        matchings (list[list[tuple[int, int]]]): :math:`t` list of pairwise transpositions.
+
+    Returns:
+        list[list[tuple[int, int]]]: :math:`t` layers of pairwise transpositions.
     """
     layers: list[list[tuple[int, int]]] = []
     cur: list[tuple[int, int]] = []

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -617,7 +617,7 @@ def _greedy_pack(matchings: list[list[tuple[int, int]]], m: int):
     return layers
 
 
-def decompose_permutation(sigma: list[int], m: int):
+def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
     """
     Given a permutation sigma on {0,...,n-1} and a power‑of‑two budget m,
     factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -645,8 +645,11 @@ def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
             TypeError, f"Permutation sigma must be ``list`` or ``tuple`` of ``int``s."
         )
 
+    if sum([abs(s - i) for s, i in zip(sorted(sigma), range(len(sigma)))]) != 0:
+        raise_error(ValueError, "Permutation sigma must contain all indices {0,...,n-1}")
+
     if m > 0 and (m & (m - 1)) != 0:
-        raise_error(TypeError, f"budget m must be a power‑of‑two")
+        raise_error(ValueError, f"budget m must be a power‑of‑two")
 
     matchings = [l for cyc in _cycles_from_perm(sigma) for l in _star_matchings(cyc)]
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -638,9 +638,10 @@ def _greedy_pack(matchings: List[List[Tuple[int, int]]], m: int):
 
 def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
     """
-    Given a permutation sigma on {0,...,n-1} and a power‑of‑two budget m,
-    factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that
-        - each layer has at most m disjoint transpositions
+     Given permutation ``sigma`` on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`
+    and a power‑of‑two budget ``m``, this function factors ``sigma``
+    into the fewest layers :math:`\\sigma_{1}, \\, \\sigma_{2}, \\, \\cdots, \\, \\sigma_{t}` such that:
+        - each layer has at most :math:`m` disjoint transpositions
         - each layer moves a power‑of‑two number of indices.
 
     We do this as follows:
@@ -649,8 +650,8 @@ def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
         3) Greedy packing – merge swaps into layers while keeping rules.
 
     Args:
-        sigma (list[int] or tuple[int]): permutation description on {0,...,n-1}.
-        m (int): power‑of‑two budget m
+        sigma (list[int] or tuple[int]): permutation description on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`.
+        m (int): power‑of‑two budget.
 
     Returns:
         list[list[tuple[int, int]]]: :math:`t` layers of pairwise transpositions.

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -634,14 +634,14 @@ def decompose_permutation(sigma: list[int], m: int):
         m (int): power‑of‑two budget m
 
     Returns:
-        (list[list[tuple[int, int]]]): list of t layers of paiwise transposition
+        list[list[tuple[int, int]]]: :math:`t` layers of pairwise transpositions.
 
     """
     if isinstance(sigma, tuple):
         sigma = list(sigma)
 
-    if not isinstance(sigma, list):
-        raise_error(TypeError, f"Permutation sigma must be List[int]")
+    if not isinstance(sigma, (list, tuple)):
+        raise_error(TypeError, f"Permutation sigma must be ``list`` or ``tuple`` of ``int``s.")
 
     if m > 0 and (m & (m - 1)) != 0:
         raise_error(TypeError, f"budget m must be a power‑of‑two")

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -641,7 +641,9 @@ def decompose_permutation(sigma: list[int], m: int):
         sigma = list(sigma)
 
     if not isinstance(sigma, (list, tuple)):
-        raise_error(TypeError, f"Permutation sigma must be ``list`` or ``tuple`` of ``int``s.")
+        raise_error(
+            TypeError, f"Permutation sigma must be ``list`` or ``tuple`` of ``int``s."
+        )
 
     if m > 0 and (m & (m - 1)) != 0:
         raise_error(TypeError, f"budget m must be a power‑of‑two")

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -4,7 +4,7 @@ from functools import reduce
 from itertools import permutations
 from math import factorial
 from re import finditer
-from typing import Optional,  List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -630,13 +630,16 @@ def decompose_permutation(sigma: list[int], m: int):
         3) Greedy packing – merge swaps into layers while keeping rules.
 
     Args:
-        sigma (List[int]): permutation description on {0,...,n-1}.
+        sigma (list[int] or tuple[int]): permutation description on {0,...,n-1}.
         m (int): power‑of‑two budget m
 
     Returns:
-        (List[List[Tuple[int, int]]]): list of t layers of paiwise transposition
+        (list[list[tuple[int, int]]]): list of t layers of paiwise transposition
 
     """
+    if isinstance(sigma, tuple):
+        sigma = list(sigma)
+
     if not isinstance(sigma, list):
         raise_error(TypeError, f"Permutation sigma must be List[int]")
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -544,9 +544,9 @@ def _hadamard_transform_1d(array, backend=None):
 
 def _cycles_from_perm(sigma: List[int]):
     """Extract the cycles from a permutation as follows:
-        - Treat the permutation as a directed graph of arrows i->sigma(i).
-        - Depth‑first walk from every unvisited vertex; each walk closes at the start -> a cycle.
-        - Disjoint cycles partition the set {0,...,n-1} and commute, so we can factorize them independently.
+    - Treat the permutation as a directed graph of arrows i->sigma(i).
+    - Depth‑first walk from every unvisited vertex; each walk closes at the start -> a cycle.
+    - Disjoint cycles partition the set {0,...,n-1} and commute, so we can factorize them independently.
     """
     n, seen, cycles = len(sigma), [False] * len(sigma), []
     for i in range(n):
@@ -567,7 +567,7 @@ def _cycles_from_perm(sigma: List[int]):
 def _star_matchings(cyc: list[int]):
     """
     Given a cycle :math:`(a_{1}, \\, a_{2}, \\, \\cdots, \\, a_{k})` with :math:`k \\geq 2`,
-    the star factorization expresses the cycle as the ordered product of :math:`(k-1)` 
+    the star factorization expresses the cycle as the ordered product of :math:`(k-1)`
     disjoint transpositions that all share the first vertex:
 
     .. math::

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -646,7 +646,9 @@ def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
         )
 
     if sum([abs(s - i) for s, i in zip(sorted(sigma), range(len(sigma)))]) != 0:
-        raise_error(ValueError, "Permutation sigma must contain all indices {0,...,n-1}")
+        raise_error(
+            ValueError, "Permutation sigma must contain all indices {0,...,n-1}"
+        )
 
     if m > 0 and (m & (m - 1)) != 0:
         raise_error(ValueError, f"budget m must be a power‑of‑two")

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -542,7 +542,7 @@ def _hadamard_transform_1d(array, backend=None):
     return array_copied
 
 
-def _cycles_from_perm(sigma: list[int]):
+def _cycles_from_perm(sigma: List[int]):
     """
     We extract the cylces from a permutation as follows:
         - Treat the permutation as a directed graph of arrows i->sigma(i).
@@ -578,7 +578,7 @@ def _star_matchings(cyc: list[int]):
     return [[(min(hub, v), max(hub, v))] for v in cyc[1:]]
 
 
-def _greedy_pack(matchings: list[list[tuple[int, int]]], m: int):
+def _greedy_pack(matchings: List[List[Tuple[int, int]]], m: int):
     """
     Add a matching to the current layer if
         - it shares no vertex with swaps already in the layer, and
@@ -617,7 +617,7 @@ def _greedy_pack(matchings: list[list[tuple[int, int]]], m: int):
     return layers
 
 
-def decompose_permutation(sigma: Union[list[int], tuple[int, ...]], m: int):
+def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
     """
     Given a permutation sigma on {0,...,n-1} and a power‑of‑two budget m,
     factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -647,5 +647,5 @@ def decompose_permutation(sigma: list[int], m: int):
         raise_error(TypeError, f"budget m must be a power‑of‑two")
 
     matchings = [l for cyc in _cycles_from_perm(sigma) for l in _star_matchings(cyc)]
-    
+
     return _greedy_pack(matchings, m)

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -4,7 +4,7 @@ from functools import reduce
 from itertools import permutations
 from math import factorial
 from re import finditer
-from typing import Optional, List, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -617,7 +617,7 @@ def _greedy_pack(matchings: list[list[tuple[int, int]]], m: int):
     return layers
 
 
-def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int):
+def decompose_permutation(sigma: Union[list[int], tuple[int, ...]], m: int):
     """
     Given a permutation sigma on {0,...,n-1} and a power‑of‑two budget m,
     factor sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that

--- a/src/qibo/quantum_info/utils.py
+++ b/src/qibo/quantum_info/utils.py
@@ -636,7 +636,9 @@ def _greedy_pack(matchings: List[List[Tuple[int, int]]], m: int):
     return layers
 
 
-def decompose_permutation(sigma: Union[List[int], Tuple[int, ...]], m: int, backend=None):
+def decompose_permutation(
+    sigma: Union[List[int], Tuple[int, ...]], m: int, backend=None
+):
     """
      Given permutation ``sigma`` on :math:`\\{0, \\, 1, \\, \\dots, \\, d-1\\}`
     and a power‑of‑two budget ``m``, this function factors ``sigma``

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -272,7 +272,8 @@ def test_hamming_weight_encoder(
 @pytest.mark.parametrize("zip_input", [False, True])
 @pytest.mark.parametrize("integers", [False, True])
 @pytest.mark.parametrize("nqubits", [4, 7])
-def test_sparse_encoder(backend, nqubits, integers, zip_input, seed):
+@pytest.mark.parametrize("method", ["li", "farias"])
+def test_sparse_encoder(backend, method, nqubits, integers, zip_input, seed):
     dims = 2**nqubits
     sparsity = nqubits
 
@@ -293,10 +294,10 @@ def test_sparse_encoder(backend, nqubits, integers, zip_input, seed):
 
     if integers and not zip_input:
         with pytest.raises(ValueError):
-            circuit = sparse_encoder(data, nqubits=None)
+            circuit = sparse_encoder(data, method, nqubits=None)
 
     _nqubits = nqubits if integers else None
-    circuit = sparse_encoder(data, _nqubits, backend=backend)
+    circuit = sparse_encoder(data, method, _nqubits, backend=backend)
     state = backend.execute_circuit(circuit).state()
 
     backend.assert_allclose(state, target)

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -294,7 +294,10 @@ def test_sparse_encoder(backend, method, nqubits, integers, zip_input, seed):
 
     if integers and not zip_input:
         with pytest.raises(ValueError):
-            circuit = sparse_encoder(data, method, nqubits=None)
+            circuit = sparse_encoder(data, method, nqubits=None, backend=backend)
+
+        with pytest.raises(ValueError):
+            circuit = sparse_encoder(data, method=True, nqubits=nqubits, backend=backend)
 
     _nqubits = nqubits if integers else None
     circuit = sparse_encoder(data, method, _nqubits, backend=backend)

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -23,6 +23,7 @@ from qibo.models.encodings import (
     graph_state,
     hamming_weight_encoder,
     phase_encoder,
+    permutation_synthesis,
     sparse_encoder,
     unary_encoder,
     unary_encoder_random_gaussian,
@@ -306,6 +307,16 @@ def test_sparse_encoder(backend, method, nqubits, integers, zip_input, seed):
     state = backend.execute_circuit(circuit).state()
 
     backend.assert_allclose(state, target)
+
+@pytest.mark.parametrize("sigma", [tuple(0,2,1,3), [0,2,1,3]])
+def test_permutation_synthesis_errors(sigma, backend):
+
+    with pytest.raises(TypeError):
+        permutation_synthesis(backend.np.array(sigma), m=2, backend=backend)
+    with pytest.raises(ValueError):
+        permutation_synthesis([0,2,1,3,10], m=2, backend=backend)
+    with pytest.raises(ValueError):
+        permutation_synthesis(sigma, m=3, backend=backend)
 
 
 def test_entangling_layer_errors():

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -297,7 +297,9 @@ def test_sparse_encoder(backend, method, nqubits, integers, zip_input, seed):
             circuit = sparse_encoder(data, method, nqubits=None, backend=backend)
 
         with pytest.raises(ValueError):
-            circuit = sparse_encoder(data, method=True, nqubits=nqubits, backend=backend)
+            circuit = sparse_encoder(
+                data, method=True, nqubits=nqubits, backend=backend
+            )
 
     _nqubits = nqubits if integers else None
     circuit = sparse_encoder(data, method, _nqubits, backend=backend)

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -22,8 +22,8 @@ from qibo.models.encodings import (
     ghz_state,
     graph_state,
     hamming_weight_encoder,
-    phase_encoder,
     permutation_synthesis,
+    phase_encoder,
     sparse_encoder,
     unary_encoder,
     unary_encoder_random_gaussian,
@@ -308,13 +308,14 @@ def test_sparse_encoder(backend, method, nqubits, integers, zip_input, seed):
 
     backend.assert_allclose(state, target)
 
-@pytest.mark.parametrize("sigma", [tuple(0,2,1,3), [0,2,1,3]])
+
+@pytest.mark.parametrize("sigma", [tuple(0, 2, 1, 3), [0, 2, 1, 3]])
 def test_permutation_synthesis_errors(sigma, backend):
 
     with pytest.raises(TypeError):
         permutation_synthesis(backend.np.array(sigma), m=2, backend=backend)
     with pytest.raises(ValueError):
-        permutation_synthesis([0,2,1,3,10], m=2, backend=backend)
+        permutation_synthesis([0, 2, 1, 3, 10], m=2, backend=backend)
     with pytest.raises(ValueError):
         permutation_synthesis(sigma, m=3, backend=backend)
 

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -309,7 +309,7 @@ def test_sparse_encoder(backend, method, nqubits, integers, zip_input, seed):
     backend.assert_allclose(state, target)
 
 
-@pytest.mark.parametrize("sigma", [tuple(0, 2, 1, 3), [0, 2, 1, 3]])
+@pytest.mark.parametrize("sigma", [(0, 2, 1, 3), [0, 2, 1, 3]])
 def test_permutation_synthesis_errors(sigma, backend):
 
     with pytest.raises(TypeError):

--- a/tests/test_quantum_info_utils.py
+++ b/tests/test_quantum_info_utils.py
@@ -301,12 +301,12 @@ def test_pqc_integral(backend):
     backend.assert_allclose(fid, 1.0, atol=PRECISION_TOL)
 
 
-@pytest.mark.parametrize("sigma", [tuple(0,2,1,3), [0,2,1,3]])
+@pytest.mark.parametrize("sigma", [tuple(0, 2, 1, 3), [0, 2, 1, 3]])
 def test_decompose_permutation_errors(sigma, backend):
 
     with pytest.raises(TypeError):
         decompose_permutation(backend.np.array(sigma), m=2, backend=backend)
     with pytest.raises(ValueError):
-        decompose_permutation([0,2,1,3,10], m=2, backend=backend)
+        decompose_permutation([0, 2, 1, 3, 10], m=2, backend=backend)
     with pytest.raises(ValueError):
         decompose_permutation(sigma, m=3, backend=backend)

--- a/tests/test_quantum_info_utils.py
+++ b/tests/test_quantum_info_utils.py
@@ -301,7 +301,7 @@ def test_pqc_integral(backend):
     backend.assert_allclose(fid, 1.0, atol=PRECISION_TOL)
 
 
-@pytest.mark.parametrize("sigma", [tuple(0, 2, 1, 3), [0, 2, 1, 3]])
+@pytest.mark.parametrize("sigma", [(0, 2, 1, 3), [0, 2, 1, 3]])
 def test_decompose_permutation_errors(sigma, backend):
 
     with pytest.raises(TypeError):

--- a/tests/test_quantum_info_utils.py
+++ b/tests/test_quantum_info_utils.py
@@ -9,6 +9,7 @@ from qibo.config import PRECISION_TOL
 from qibo.quantum_info.metrics import fidelity
 from qibo.quantum_info.random_ensembles import random_clifford
 from qibo.quantum_info.utils import (
+    decompose_permutation,
     haar_integral,
     hadamard_transform,
     hamming_distance,
@@ -298,3 +299,14 @@ def test_pqc_integral(backend):
     fid = fidelity(pqc_int, pqc_int, backend=backend)
 
     backend.assert_allclose(fid, 1.0, atol=PRECISION_TOL)
+
+
+@pytest.mark.parametrize("sigma", [tuple(0,2,1,3), [0,2,1,3]])
+def test_decompose_permutation_errors(sigma, backend):
+
+    with pytest.raises(TypeError):
+        decompose_permutation(backend.np.array(sigma), m=2, backend=backend)
+    with pytest.raises(ValueError):
+        decompose_permutation([0,2,1,3,10], m=2, backend=backend)
+    with pytest.raises(ValueError):
+        decompose_permutation(sigma, m=3, backend=backend)


### PR DESCRIPTION
Here, I have three contributions:
   - `permutation_synthesis`: as the name suggests we synthesize a quantum circuit given a permutation description following the procedure described in [[1](https://arxiv.org/abs/2406.16142)]
   - for this, I needed `decompose_permutation`, which, given a permutation sigma on {0,...,d-1} and a power‑of‑two budget `m`, decompose sigma into the fewest layers sigma_1, sigma_2, ..., sigma_t such that
        - each layer has at most m disjoint transpositions
        - each layer moves a power‑of‑two number of indices.
        - We do this as follows:
        1) Cycle extraction – split sigma into disjoint cycles.
        2) Star factorisation – a k‑cycle becomes (k-1) hub–spoke swaps.
        3) Greedy packing – merge swaps into layers while keeping rules.

With a permutation synthesis at hand, it is possible to implement a the sparse encoder in reference [[1](https://arxiv.org/abs/2406.16142)] with a better scaling.
  - The `sparse_encoder`, now, expects an extra input `method`, with the option to implement the early version of the sparse encoder (`_sparse_encoder_farias`), defaulting to Li's encoder (`_sparse_encoder_li`).

Reference:
[1] Lvzhou Li, Jingquan Luo, [Nearly Optimal Circuit Size for Sparse Quantum State Preparation](https://arxiv.org/abs/2406.16142) 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
