### PR TITLE
Fix state visualization when a `MeasurementOutcomes` object is passed

### DIFF
--- a/src/qibo/ui/result_visualization.py
+++ b/src/qibo/ui/result_visualization.py
@@ -71,7 +71,7 @@ def visualize_state(
         ax.bar(x, y_values, color=QIBO_DEFAULT_COLOR, edgecolor="black")
 
     elif mode == "amplitudes":
-        amplitudes = execution_outcome.backend.to_numpy(execution_outcome.amplitudes())
+        amplitudes = execution_outcome.backend.to_numpy(execution_outcome.state())
         real_parts = np.real(amplitudes)
         imag_parts = np.imag(amplitudes)
         width = 0.3


### PR DESCRIPTION
This is a simple fix, but it should allow the usage of the state visualization function in every scenario. Closes #1764.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
