### PR TITLE
checks for `random_gaussian_matrix`

### DIFF
--- a/src/qibo/quantum_info/random_ensembles.py
+++ b/src/qibo/quantum_info/random_ensembles.py
@@ -127,7 +127,7 @@ def random_gaussian_matrix(
     """
     if not isinstance(dims, int):
         raise_error(TypeError, f"dims must be an integer, but got {type(dims)}.")
-        
+
     if rank is None:
         rank = dims
     else:
@@ -137,15 +137,17 @@ def random_gaussian_matrix(
             raise_error(
                 ValueError, f"rank ({rank}) cannot be greater than dims ({dims})."
             )
-            
+
     if dims <= 0 or rank <= 0:
         raise_error(ValueError, "Dimensions must be positive integers.")
 
     backend = _check_backend(backend)
 
     if seed is not None and not isinstance(seed, (int, np.random.Generator)):
-        raise_error(TypeError, f"seed must be an integer or Generator, but got {type(seed)}.")
-        
+        raise_error(
+            TypeError, f"seed must be an integer or Generator, but got {type(seed)}."
+        )
+
     backend.set_seed(seed)
     return backend.qinfo._random_gaussian_matrix(dims, rank, mean, stddev)
 


### PR DESCRIPTION
This fixes tests failing when using qibojit with [import-AOT compilation disabled](https://github.com/qiboteam/qibojit/pull/249).