### PR TITLE
Fix LaTeX subscript rendering for multi-digit qubit labels

### DIFF
--- a/src/qibo/ui/mpldrawer.py
+++ b/src/qibo/ui/mpldrawer.py
@@ -7,6 +7,7 @@
 # pylint: disable=protected-access,R0912,R0913,R0914,R0915,R0917
 
 import json
+import re
 from pathlib import Path
 from typing import Any, Iterator, Optional, Union
 
@@ -1184,7 +1185,13 @@ def _render_label(label: str) -> str:
         str: Rendered label string.
     """
 
-    return rf"$|{label}\rangle$" if label else ""
+    if not label:
+        return ""
+
+    # Fix LaTeX subscripts with multiple characters: q_10 -> q_{10}
+    label = re.sub(r"(_)(\d{2,})", r"_{\2}", label)
+
+    return rf"$|{label}\rangle$"
 
 
 def _check_list_str(substrings: list, string: str) -> bool:

--- a/tests/test_ui_mpldrawer.py
+++ b/tests/test_ui_mpldrawer.py
@@ -502,6 +502,17 @@ def test_render_label_empty():
     assert _render_label("") == ""
 
 
+def test_render_label_multi_digit():
+    """Test render labels with multi-digit subscripts"""
+    # Test that multi-digit subscripts are properly wrapped in braces for LaTeX
+    assert _render_label("q_10") == r"$|q_{10}\rangle$"
+    assert _render_label("q_11") == r"$|q_{11}\rangle$"
+    assert _render_label("q_100") == r"$|q_{100}\rangle$"
+    # Single digit should remain unchanged
+    assert _render_label("q_9") == r"$|q_9\rangle$"
+    assert _render_label("q_0") == r"$|q_0\rangle$"
+
+
 def test_cluster_gates():
     """Test clustering gates"""
     pgates = [


### PR DESCRIPTION
Fixed LaTeX subscript rendering for circuits with more than 9 qubits, fixes #1836.