### PR TITLE
Fix bug in rotations.clifford property when angle is 1.0

### DIFF
--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -2872,7 +2872,9 @@ def _check_engine(array: ArrayLike):
 def _is_clifford_given_angle(angle: Union[float, int], precision_tol: float = 1e-8):
     """Helper function to update Clifford boolean condition according to
     the given angle ``angle``."""
-    return isinstance(angle, (float, int)) and bool(angle % (math.pi / 2) < precision_tol)
+    return isinstance(angle, (float, int)) and bool(
+        angle % (math.pi / 2) < precision_tol
+    )
 
 
 def _is_hamming_weight_given_angle(angle: Union[float, int], target: float = 2 * np.pi):

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -2872,7 +2872,7 @@ def _check_engine(array: ArrayLike):
 def _is_clifford_given_angle(angle: Union[float, int]):
     """Helper function to update Clifford boolean condition according to
     the given angle ``angle``."""
-    return isinstance(angle, (float, int)) and (angle % (np.pi / 2)).is_integer()
+    return isinstance(angle, (float, int)) and bool(np.isclose(angle % (np.pi / 2), 0))
 
 
 def _is_hamming_weight_given_angle(angle: Union[float, int], target: float = 2 * np.pi):

--- a/src/qibo/gates/gates.py
+++ b/src/qibo/gates/gates.py
@@ -2869,10 +2869,10 @@ def _check_engine(array: ArrayLike):
     return np
 
 
-def _is_clifford_given_angle(angle: Union[float, int]):
+def _is_clifford_given_angle(angle: Union[float, int], precision_tol: float = 1e-8):
     """Helper function to update Clifford boolean condition according to
     the given angle ``angle``."""
-    return isinstance(angle, (float, int)) and bool(np.isclose(angle % (np.pi / 2), 0))
+    return isinstance(angle, (float, int)) and bool(angle % (math.pi / 2) < precision_tol)
 
 
 def _is_hamming_weight_given_angle(angle: Union[float, int], target: float = 2 * np.pi):


### PR DESCRIPTION
Fixes #1848.

$\theta=1.0$ is pathological since its modulo with $\pi/2$ is 1.0, which is integer, and the old method was returning `gate.clifford -> True`.