### PR TITLE
Add Möttönen state preparation as `binary_encoder` parametrization

### DIFF
--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -301,10 +301,9 @@ def _mottonen_alpha_y(
     )[None]
     denominator = np.sum(a[indices_denominator] ** 2, axis=-1)
 
-    with np.errstate(divide="ignore", invalid="ignore"):
-        division = np.where(denominator != 0.0, numerator / denominator, 0.0)
+    division = backend.where(denominator != 0.0, numerator / denominator, 0.0)
 
-    return 2 * np.arcsin(np.sqrt(division))
+    return 2 * backend.arcsin(backend.sqrt(division))
 
 
 def _mottonen_alpha_z(

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -269,7 +269,7 @@ def _mottonen_compute_theta(
 
     hadamard = np.array([[1, 1], [1, -1]]) / 2
     for i in range(broadcasted, num_qubits + broadcasted):
-        theta = np.tensordot(hadamard, theta, axes=[[1], [i]])
+        theta = backend.tensordot(hadamard, theta, axes=[[1], [i]])
 
     if num_qubits > 1:
         cnot = backend.reshape(backend.matrices.CNOT, (2, 2, 2, 2))

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -313,14 +313,12 @@ def _mottonen_alpha_z(
     """Rotation angles for uniformly controlled Z rotation on qubit k."""
     omega = backend.to_numpy(phases)
 
-    indices1 = (
-        np.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (k - 1)
-        + np.arange(2 ** (k - 1))[None]
-    )
-    indices2 = (
-        np.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (k - 1)
-        + np.arange(2 ** (k - 1))[None]
-    )
+    indices_1 = backend.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (k - 1)
+    indices_1 += backend.arange(2 ** (k - 1))[None]
+
+    indices_2 = backend.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (k - 1)
+    indices_2 += backend.arange(2 ** (k - 1))[None]
+
 
     return backend.sum((phases[indices_1] - phases[indices_2]) / 2 ** (k - 1), axis=-1)
 

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -235,11 +235,14 @@ def _binary_codewords_ehrlich(dims: int, backend: Optional[Backend] = None):
     # no final singleton: we've generated exactly d bitstrings (0..d-1)
 
 
-def _mottonen_gray_code(rank: int) -> np.ndarray:
+def _mottonen_gray_code(rank: int, backend: Optional[Backend] = None) -> ArrayLike:
     """Return Gray code of given rank as integer array."""
-    code = np.array([0, 1])
-    for _ in range(1, rank):
-        code = np.concatenate([code, code[::-1] + 2**_])
+    backend = _check_backend(backend)
+
+    code = backend.cast([0, 1], dtype=backend.int8)
+    for elem in range(1, rank):
+        code = backend.concatenate([code, code[::-1] + 2**elem])
+
     return code
 
 

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -282,8 +282,8 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
 
 
 def _mottonen_alpha_y(
-    amplitudes: ArrayLike, n: int, k: int, backend: Backend
-) -> np.ndarray:
+    amplitudes: ArrayLike, n: int, k: int, backend: Optional[Backend] = None
+) -> ArrayLike:
     """Rotation angles for uniformly controlled Y rotation on qubit k.
 
     See Eq. (8) in Möttönen et al. (2004).

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -374,9 +374,9 @@ def _binary_encoder_mottonen(
             alpha_z = _mottonen_alpha_z(phases, nqubits, k, backend)
             target = nqubits - k
             control = list(reversed(range(nqubits - k)))
-            theta_z = _mottonen_compute_theta(alpha_z)
+            theta_z = _mottonen_compute_theta(alpha_z, backend=backend)
             if len(control) == 0:
-                circuit.add(gates.RZ(target, theta_z[0], trainable=True))
+                circuit.add(gates.RZ(target, theta_z[0]))
                 parameters.append(theta_z[0])
             else:
                 code = _mottonen_gray_code(len(control), backend=backend)

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -315,14 +315,10 @@ def _mottonen_alpha_z(
     """Rotation angles for uniformly controlled Z rotation on qubit k."""
     backend = _check_backend(backend)
 
-    indices_1 = backend.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (
-        k - 1
-    )
+    indices_1 = backend.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (k - 1)
     indices_1 = indices_1 + backend.arange(2 ** (k - 1))[None]
 
-    indices_2 = backend.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (
-        k - 1
-    )
+    indices_2 = backend.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (k - 1)
     indices_2 = indices_2 + backend.arange(2 ** (k - 1))[None]
 
     return backend.sum((phases[indices_1] - phases[indices_2]) / 2 ** (k - 1), axis=-1)

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -307,10 +307,10 @@ def _mottonen_alpha_y(
 
 
 def _mottonen_alpha_z(
-    phases: ArrayLike, n: int, k: int, backend: Backend
-) -> np.ndarray:
+    phases: ArrayLike, n: int, k: int, backend: Optional[Backend] = None
+) -> ArrayLike:
     """Rotation angles for uniformly controlled Z rotation on qubit k."""
-    omega = backend.to_numpy(phases)
+    backend = _check_backend(backend)
 
     indices_1 = backend.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (k - 1)
     indices_1 += backend.arange(2 ** (k - 1))[None]

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -270,9 +270,7 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
         theta = np.tensordot(hadamard, theta, axes=[[1], [i]])
 
     if num_qubits > 1:
-        cnot = np.array(
-            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
-        ).reshape((2, 2, 2, 2))
+        cnot = backend.reshape(backend.matrices.CNOT, (2, 2, 2, 2))
         theta = np.tensordot(
             cnot, theta, axes=[[2, 3], [num_qubits - 1, num_qubits - 2]]
         )

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -235,6 +235,163 @@ def _binary_codewords_ehrlich(dims: int, backend: Optional[Backend] = None):
     # no final singleton: we've generated exactly d bitstrings (0..d-1)
 
 
+def _mottonen_gray_code(rank: int) -> np.ndarray:
+    """Return Gray code of given rank as integer array."""
+    code = np.array([0, 1])
+    for _ in range(1, rank):
+        code = np.concatenate([code, code[::-1] + 2**_])
+    return code
+
+
+def _mottonen_compute_theta(alpha: ArrayLike) -> np.ndarray:
+    """Map uniformly controlled rotation angles to Gray-code decomposition angles.
+
+    See Eq. (3) in Möttönen et al. (2004).
+    """
+    alpha = np.asarray(alpha, dtype=float)
+    orig_shape = alpha.shape
+    num_qubits = int(np.log2(orig_shape[-1]))
+    if num_qubits == 0:
+        return alpha
+
+    broadcasted = len(orig_shape) > 1
+    new_shape = (orig_shape[0],) + (2,) * num_qubits if broadcasted else (2,) * num_qubits
+    theta = alpha.reshape(new_shape)
+
+    hadamard = np.array([[1, 1], [1, -1]]) / 2
+    for i in range(broadcasted, num_qubits + broadcasted):
+        theta = np.tensordot(hadamard, theta, axes=[[1], [i]])
+
+    if num_qubits > 1:
+        cnot = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]).reshape(
+            (2, 2, 2, 2)
+        )
+        theta = np.tensordot(
+            cnot, theta, axes=[[2, 3], [num_qubits - 1, num_qubits - 2]]
+        )
+        for i in range(broadcasted + 1, num_qubits + broadcasted - 1):
+            theta = np.tensordot(cnot, theta, axes=[[2, 3], [1, num_qubits - 1]])
+        theta = np.moveaxis(theta, 0, 1)
+
+    return np.reshape(np.transpose(theta), orig_shape)
+
+
+def _mottonen_alpha_y(
+    amplitudes: ArrayLike, n: int, k: int, backend: Backend
+) -> np.ndarray:
+    """Rotation angles for uniformly controlled Y rotation on qubit k.
+
+    See Eq. (8) in Möttönen et al. (2004).
+    ``amplitudes`` must be non-negative (absolute values of state amplitudes).
+    """
+    a = backend.to_numpy(amplitudes)
+
+    indices_numerator = (np.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[
+        :, None
+    ] + np.arange(2 ** (k - 1))[None]
+    numerator = np.sum(a[indices_numerator] ** 2, axis=-1)
+
+    indices_denominator = (np.arange(2 ** (n - k)) * 2**k)[:, None] + np.arange(2**k)[
+        None
+    ]
+    denominator = np.sum(a[indices_denominator] ** 2, axis=-1)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        division = np.where(denominator != 0.0, numerator / denominator, 0.0)
+
+    return 2 * np.arcsin(np.sqrt(division))
+
+
+def _mottonen_alpha_z(phases: ArrayLike, n: int, k: int, backend: Backend) -> np.ndarray:
+    """Rotation angles for uniformly controlled Z rotation on qubit k."""
+    omega = backend.to_numpy(phases)
+
+    indices1 = (
+        np.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (k - 1)
+        + np.arange(2 ** (k - 1))[None]
+    )
+    indices2 = (
+        np.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (k - 1)
+        + np.arange(2 ** (k - 1))[None]
+    )
+
+    return np.sum((omega[indices1] - omega[indices2]) / 2 ** (k - 1), axis=-1)
+
+
+def _binary_encoder_mottonen(
+    data: ArrayLike,
+    nqubits: int,
+    complex_data: bool,
+    backend: Optional[Backend] = None,
+    **kwargs,
+) -> Circuit:
+    """Binary encoder circuit using Möttönen uniformly controlled rotations.
+
+    See Möttönen et al. (2004), https://arxiv.org/abs/quant-ph/0407010.
+    """
+    backend = _check_backend(backend)
+
+    dims = len(data)
+    if dims != 2**nqubits:
+        raise_error(
+            ValueError,
+            f"``data`` length must be {2**nqubits} for {nqubits} qubits, got {dims}.",
+        )
+
+    data_complex = backend.cast(data, dtype=backend.complex128)
+    amplitudes = backend.abs(data_complex)
+    phases = backend.angle(data_complex)
+
+    circuit = Circuit(nqubits, **kwargs)
+    parameters = []
+
+    for k in range(nqubits, 0, -1):
+        alpha_y = _mottonen_alpha_y(amplitudes, nqubits, k, backend)
+        target = nqubits - k
+        control = list(reversed(range(nqubits - k)))
+        theta_y = _mottonen_compute_theta(alpha_y)
+        if len(control) == 0:
+            circuit.add(gates.RY(target, theta_y[0], trainable=True))
+            parameters.append(theta_y[0])
+        else:
+            code = _mottonen_gray_code(len(control))
+            control_indices = np.log2(code ^ np.roll(code, -1)).astype(int)
+            for i, control_index in enumerate(control_indices):
+                circuit.add(gates.RY(target, theta_y[i], trainable=True))
+                circuit.add(gates.CNOT(control[control_index], target))
+                parameters.append(theta_y[i])
+
+    if complex_data or not backend.allclose(phases, 0):
+        for k in range(nqubits, 0, -1):
+            alpha_z = _mottonen_alpha_z(phases, nqubits, k, backend)
+            target = nqubits - k
+            control = list(reversed(range(nqubits - k)))
+            theta_z = _mottonen_compute_theta(alpha_z)
+            if len(control) == 0:
+                circuit.add(gates.RZ(target, theta_z[0], trainable=True))
+                parameters.append(theta_z[0])
+            else:
+                code = _mottonen_gray_code(len(control))
+                control_indices = np.log2(code ^ np.roll(code, -1)).astype(int)
+                for i, control_index in enumerate(control_indices):
+                    circuit.add(gates.RZ(target, theta_z[i], trainable=True))
+                    circuit.add(gates.CNOT(control[control_index], target))
+                    parameters.append(theta_z[i])
+
+        global_phase = -float(backend.sum(phases) / dims)
+        if abs(global_phase) > np.finfo(float).eps:
+            unitary = np.exp(-1j * global_phase) * np.eye(dims)
+            circuit.add(
+                gates.Unitary(
+                    unitary, *range(nqubits), trainable=False, check_unitary=False
+                )
+            )
+
+    circuit.set_parameters(parameters)
+
+    return circuit
+
+
 def _binary_encoder_hopf(
     data: ArrayLike,
     nqubits: int,

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -296,10 +296,10 @@ def _mottonen_alpha_y(
 
     numerator = backend.sum(amplitudes[indices_numerator] ** 2, axis=-1)
 
-    indices_denominator = (np.arange(2 ** (n - k)) * 2**k)[:, None] + np.arange(
-        2**k
-    )[None]
-    denominator = np.sum(a[indices_denominator] ** 2, axis=-1)
+    indices_denominator = (backend.arange(2 ** (n - k)) * 2**k)[:, None]
+    indices_denominator += backend.arange(2**k)[None]
+
+    denominator = backend.sum(amplitudes[indices_denominator] ** 2, axis=-1)
 
     division = backend.where(denominator != 0.0, numerator / denominator, 0.0)
 

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -291,10 +291,10 @@ def _mottonen_alpha_y(
     """
     backend = _check_backend(backend)
 
-    indices_numerator = (np.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[
-        :, None
-    ] + np.arange(2 ** (k - 1))[None]
-    numerator = np.sum(a[indices_numerator] ** 2, axis=-1)
+    indices_numerator = (backend.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[:, None]
+    indices_numerator += backend.arange(2 ** (k - 1))[None]
+
+    numerator = backend.sum(amplitudes[indices_numerator] ** 2, axis=-1)
 
     indices_denominator = (np.arange(2 ** (n - k)) * 2**k)[:, None] + np.arange(
         2**k

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -255,8 +255,8 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
 
     alpha = backend.cast(alpha, dtype=backend.float64)
     orig_shape = alpha.shape
-    num_qubits = int(np.log2(orig_shape[-1]))
-    if num_qubits == 0:
+    nqubits = int(math.log2(orig_shape[-1]))
+    if nqubits == 0:
         return alpha
 
     broadcasted = len(orig_shape) > 1

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -276,9 +276,9 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
         )
         for i in range(broadcasted + 1, num_qubits + broadcasted - 1):
             theta = backend.tensordot(cnot, theta, axes=[[2, 3], [1, num_qubits - 1]])
-        theta = np.moveaxis(theta, 0, 1)
+        theta = backend.moveaxis(theta, 0, 1)
 
-    return np.reshape(np.transpose(theta), orig_shape)
+    return backend.reshape(backend.transpose(theta), orig_shape)
 
 
 def _mottonen_alpha_y(

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -358,7 +358,7 @@ def _binary_encoder_mottonen(
         control = list(reversed(range(nqubits - k)))
         theta_y = _mottonen_compute_theta(alpha_y)
         if len(control) == 0:
-            circuit.add(gates.RY(target, theta_y[0], trainable=True))
+            circuit.add(gates.RY(target, theta_y[0]))
             parameters.append(theta_y[0])
         else:
             code = _mottonen_gray_code(len(control))

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -263,21 +263,21 @@ def _mottonen_compute_theta(
 
     broadcasted = len(orig_shape) > 1
     new_shape = (
-        (orig_shape[0],) + (2,) * num_qubits if broadcasted else (2,) * num_qubits
+        (orig_shape[0],) + (2,) * nqubits if broadcasted else (2,) * nqubits
     )
     theta = backend.reshape(alpha, new_shape)
 
     hadamard = np.array([[1, 1], [1, -1]]) / 2
-    for i in range(broadcasted, num_qubits + broadcasted):
+    for i in range(broadcasted, nqubits + broadcasted):
         theta = backend.tensordot(hadamard, theta, axes=[[1], [i]])
 
-    if num_qubits > 1:
+    if nqubits > 1:
         cnot = backend.reshape(backend.matrices.CNOT, (2, 2, 2, 2))
         theta = backend.tensordot(
-            cnot, theta, axes=[[2, 3], [num_qubits - 1, num_qubits - 2]]
+            cnot, theta, axes=[[2, 3], [nqubits - 1, nqubits - 2]]
         )
-        for i in range(broadcasted + 1, num_qubits + broadcasted - 1):
-            theta = backend.tensordot(cnot, theta, axes=[[2, 3], [1, num_qubits - 1]])
+        for i in range(broadcasted + 1, nqubits + broadcasted - 1):
+            theta = backend.tensordot(cnot, theta, axes=[[2, 3], [1, nqubits - 1]])
         theta = backend.moveaxis(theta, 0, 1)
 
     return backend.reshape(backend.transpose(theta), orig_shape)

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -246,7 +246,7 @@ def _mottonen_gray_code(rank: int, backend: Optional[Backend] = None) -> ArrayLi
     return code
 
 
-def _mottonen_compute_theta(alpha: ArrayLike) -> np.ndarray:
+def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None) -> ArrayLike:
     """Map uniformly controlled rotation angles to Gray-code decomposition angles.
 
     See Eq. (3) in Möttönen et al. (2004).

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -262,9 +262,7 @@ def _mottonen_compute_theta(
         return alpha
 
     broadcasted = len(orig_shape) > 1
-    new_shape = (
-        (orig_shape[0],) + (2,) * nqubits if broadcasted else (2,) * nqubits
-    )
+    new_shape = (orig_shape[0],) + (2,) * nqubits if broadcasted else (2,) * nqubits
     theta = backend.reshape(alpha, new_shape)
 
     hadamard = np.array([[1, 1], [1, -1]]) / 2

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -263,7 +263,7 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
     new_shape = (
         (orig_shape[0],) + (2,) * num_qubits if broadcasted else (2,) * num_qubits
     )
-    theta = alpha.reshape(new_shape)
+    theta = backend.reshape(alpha, new_shape)
 
     hadamard = np.array([[1, 1], [1, -1]]) / 2
     for i in range(broadcasted, num_qubits + broadcasted):

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -289,7 +289,7 @@ def _mottonen_alpha_y(
     See Eq. (8) in Möttönen et al. (2004).
     ``amplitudes`` must be non-negative (absolute values of state amplitudes).
     """
-    a = backend.to_numpy(amplitudes)
+    backend = _check_backend(backend)
 
     indices_numerator = (np.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[
         :, None

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -246,7 +246,9 @@ def _mottonen_gray_code(rank: int, backend: Optional[Backend] = None) -> ArrayLi
     return code
 
 
-def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None) -> ArrayLike:
+def _mottonen_compute_theta(
+    alpha: ArrayLike, backend: Optional[Backend] = None
+) -> ArrayLike:
     """Map uniformly controlled rotation angles to Gray-code decomposition angles.
 
     See Eq. (3) in Möttönen et al. (2004).
@@ -291,7 +293,9 @@ def _mottonen_alpha_y(
     """
     backend = _check_backend(backend)
 
-    indices_numerator = (backend.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[:, None]
+    indices_numerator = (backend.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[
+        :, None
+    ]
     indices_numerator += backend.arange(2 ** (k - 1))[None]
 
     numerator = backend.sum(amplitudes[indices_numerator] ** 2, axis=-1)
@@ -317,7 +321,6 @@ def _mottonen_alpha_z(
 
     indices_2 = backend.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (k - 1)
     indices_2 += backend.arange(2 ** (k - 1))[None]
-
 
     return backend.sum((phases[indices_1] - phases[indices_2]) / 2 ** (k - 1), axis=-1)
 

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -356,7 +356,7 @@ def _binary_encoder_mottonen(
         alpha_y = _mottonen_alpha_y(amplitudes, nqubits, k, backend)
         target = nqubits - k
         control = list(reversed(range(nqubits - k)))
-        theta_y = _mottonen_compute_theta(alpha_y)
+        theta_y = _mottonen_compute_theta(alpha_y, backend=backend)
         if len(control) == 0:
             circuit.add(gates.RY(target, theta_y[0]))
             parameters.append(theta_y[0])

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -275,7 +275,7 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
             cnot, theta, axes=[[2, 3], [num_qubits - 1, num_qubits - 2]]
         )
         for i in range(broadcasted + 1, num_qubits + broadcasted - 1):
-            theta = np.tensordot(cnot, theta, axes=[[2, 3], [1, num_qubits - 1]])
+            theta = backend.tensordot(cnot, theta, axes=[[2, 3], [1, num_qubits - 1]])
         theta = np.moveaxis(theta, 0, 1)
 
     return np.reshape(np.transpose(theta), orig_shape)

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -345,9 +345,14 @@ def _binary_encoder_mottonen(
             f"``data`` length must be {2**nqubits} for {nqubits} qubits, got {dims}.",
         )
 
-    data_complex = backend.cast(data, dtype=backend.complex128)
-    amplitudes = backend.abs(data_complex)
-    phases = backend.angle(data_complex)
+    dtype = backend.complex128 if complex_data else backend.float64
+    data_typed = backend.cast(data, dtype=dtype)
+    amplitudes = backend.abs(data_typed)
+    phases = (
+        backend.angle(data_typed)
+        if complex_data
+        else backend.where(data_typed < 0, np.pi, 0.0)
+    )
 
     circuit = Circuit(nqubits, **kwargs)
     parameters = []

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -271,7 +271,7 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
 
     if num_qubits > 1:
         cnot = backend.reshape(backend.matrices.CNOT, (2, 2, 2, 2))
-        theta = np.tensordot(
+        theta = backend.tensordot(
             cnot, theta, axes=[[2, 3], [num_qubits - 1, num_qubits - 2]]
         )
         for i in range(broadcasted + 1, num_qubits + broadcasted - 1):

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -324,7 +324,7 @@ def _mottonen_alpha_z(
         + np.arange(2 ** (k - 1))[None]
     )
 
-    return np.sum((omega[indices1] - omega[indices2]) / 2 ** (k - 1), axis=-1)
+    return backend.sum((phases[indices_1] - phases[indices_2]) / 2 ** (k - 1), axis=-1)
 
 
 def _binary_encoder_mottonen(

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -1,5 +1,6 @@
 """Helper functions for the `models.encodings` module."""
 
+import cmath
 import math
 from inspect import signature
 from typing import List, Optional, Set, Tuple, Union
@@ -293,13 +294,13 @@ def _mottonen_alpha_y(
 
     indices_numerator = (backend.arange(1, 2 ** (n - k + 1) + 1, 2) * 2 ** (k - 1))[
         :, None
-    ]
-    indices_numerator += backend.arange(2 ** (k - 1))[None]
+    ] + backend.arange(2 ** (k - 1))[None]
 
     numerator = backend.sum(amplitudes[indices_numerator] ** 2, axis=-1)
 
-    indices_denominator = (backend.arange(2 ** (n - k)) * 2**k)[:, None]
-    indices_denominator += backend.arange(2**k)[None]
+    indices_denominator = (backend.arange(2 ** (n - k)) * 2**k)[
+        :, None
+    ] + backend.arange(2**k)[None]
 
     denominator = backend.sum(amplitudes[indices_denominator] ** 2, axis=-1)
 
@@ -314,11 +315,15 @@ def _mottonen_alpha_z(
     """Rotation angles for uniformly controlled Z rotation on qubit k."""
     backend = _check_backend(backend)
 
-    indices_1 = backend.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (k - 1)
-    indices_1 += backend.arange(2 ** (k - 1))[None]
+    indices_1 = backend.arange(1, 2 ** (n - k + 1) + 1, 2)[:, None] * 2 ** (
+        k - 1
+    )
+    indices_1 = indices_1 + backend.arange(2 ** (k - 1))[None]
 
-    indices_2 = backend.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (k - 1)
-    indices_2 += backend.arange(2 ** (k - 1))[None]
+    indices_2 = backend.arange(0, 2 ** (n - k + 1), 2)[:, None] * 2 ** (
+        k - 1
+    )
+    indices_2 = indices_2 + backend.arange(2 ** (k - 1))[None]
 
     return backend.sum((phases[indices_1] - phases[indices_2]) / 2 ** (k - 1), axis=-1)
 
@@ -392,7 +397,7 @@ def _binary_encoder_mottonen(
 
         global_phase = -float(backend.sum(phases) / dims)
         if abs(global_phase) > np.finfo(float).eps:
-            unitary = math.exp(-1j * global_phase) * backend.identity(dims)
+            unitary = cmath.exp(-1j * global_phase) * backend.identity(dims)
             circuit.add(
                 gates.Unitary(
                     unitary, *range(nqubits), trainable=False, check_unitary=False

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -389,7 +389,7 @@ def _binary_encoder_mottonen(
 
         global_phase = -float(backend.sum(phases) / dims)
         if abs(global_phase) > np.finfo(float).eps:
-            unitary = np.exp(-1j * global_phase) * np.eye(dims)
+            unitary = math.exp(-1j * global_phase) * backend.identity(dims)
             circuit.add(
                 gates.Unitary(
                     unitary, *range(nqubits), trainable=False, check_unitary=False

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -251,7 +251,9 @@ def _mottonen_compute_theta(alpha: ArrayLike, backend: Optional[Backend] = None)
 
     See Eq. (3) in Möttönen et al. (2004).
     """
-    alpha = np.asarray(alpha, dtype=float)
+    backend = _check_backend(backend)
+
+    alpha = backend.cast(alpha, dtype=backend.float64)
     orig_shape = alpha.shape
     num_qubits = int(np.log2(orig_shape[-1]))
     if num_qubits == 0:

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -361,10 +361,11 @@ def _binary_encoder_mottonen(
             circuit.add(gates.RY(target, theta_y[0]))
             parameters.append(theta_y[0])
         else:
-            code = _mottonen_gray_code(len(control))
-            control_indices = np.log2(code ^ np.roll(code, -1)).astype(int)
+            code = _mottonen_gray_code(len(control), backend=backend)
+            control_indices = backend.log2(code ^ backend.roll(code, -1))
+            control_indices = backend.cast(control_indices, dtype=backend.int64)
             for i, control_index in enumerate(control_indices):
-                circuit.add(gates.RY(target, theta_y[i], trainable=True))
+                circuit.add(gates.RY(target, theta_y[i]))
                 circuit.add(gates.CNOT(control[control_index], target))
                 parameters.append(theta_y[i])
 

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -255,7 +255,9 @@ def _mottonen_compute_theta(alpha: ArrayLike) -> np.ndarray:
         return alpha
 
     broadcasted = len(orig_shape) > 1
-    new_shape = (orig_shape[0],) + (2,) * num_qubits if broadcasted else (2,) * num_qubits
+    new_shape = (
+        (orig_shape[0],) + (2,) * num_qubits if broadcasted else (2,) * num_qubits
+    )
     theta = alpha.reshape(new_shape)
 
     hadamard = np.array([[1, 1], [1, -1]]) / 2
@@ -263,9 +265,9 @@ def _mottonen_compute_theta(alpha: ArrayLike) -> np.ndarray:
         theta = np.tensordot(hadamard, theta, axes=[[1], [i]])
 
     if num_qubits > 1:
-        cnot = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]).reshape(
-            (2, 2, 2, 2)
-        )
+        cnot = np.array(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
+        ).reshape((2, 2, 2, 2))
         theta = np.tensordot(
             cnot, theta, axes=[[2, 3], [num_qubits - 1, num_qubits - 2]]
         )
@@ -291,9 +293,9 @@ def _mottonen_alpha_y(
     ] + np.arange(2 ** (k - 1))[None]
     numerator = np.sum(a[indices_numerator] ** 2, axis=-1)
 
-    indices_denominator = (np.arange(2 ** (n - k)) * 2**k)[:, None] + np.arange(2**k)[
-        None
-    ]
+    indices_denominator = (np.arange(2 ** (n - k)) * 2**k)[:, None] + np.arange(
+        2**k
+    )[None]
     denominator = np.sum(a[indices_denominator] ** 2, axis=-1)
 
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -302,7 +304,9 @@ def _mottonen_alpha_y(
     return 2 * np.arcsin(np.sqrt(division))
 
 
-def _mottonen_alpha_z(phases: ArrayLike, n: int, k: int, backend: Backend) -> np.ndarray:
+def _mottonen_alpha_z(
+    phases: ArrayLike, n: int, k: int, backend: Backend
+) -> np.ndarray:
     """Rotation angles for uniformly controlled Z rotation on qubit k."""
     omega = backend.to_numpy(phases)
 

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -379,10 +379,11 @@ def _binary_encoder_mottonen(
                 circuit.add(gates.RZ(target, theta_z[0], trainable=True))
                 parameters.append(theta_z[0])
             else:
-                code = _mottonen_gray_code(len(control))
-                control_indices = np.log2(code ^ np.roll(code, -1)).astype(int)
+                code = _mottonen_gray_code(len(control), backend=backend)
+                control_indices = backend.log2(code ^ backend.roll(code, -1))
+                control_indices = backend.cast(control_indices, dtype=backend.int64)
                 for i, control_index in enumerate(control_indices):
-                    circuit.add(gates.RZ(target, theta_z[i], trainable=True))
+                    circuit.add(gates.RZ(target, theta_z[i]))
                     circuit.add(gates.CNOT(control[control_index], target))
                     parameters.append(theta_z[i])
 

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -17,6 +17,7 @@ from qibo.models._encodings import (  # _up_to_k_hamming_weight_encoder_deprecat
     _angle_mod_two_pi,
     _binary_encoder_hopf,
     _binary_encoder_hyperspherical,
+    _binary_encoder_mottonen,
     _ehrlich_algorithm,
     _generate_rbs_angles,
     _generate_rbs_pairs,
@@ -57,17 +58,18 @@ def binary_encoder(
     where :math:`b_{j} \\in \\{0, \\, 1\\}^{\\otimes \\, n}` is the :math:`n`-bit representation
     of the integer :math:`j`, :math:`\\|\\cdot\\|_{F}` is the Frobenius norm.
 
-    Resulting circuit parametrizes ``data`` in either ``hyperspherical`` or ``hopf`` coordinates
-    in the :math:`(2^{n} - 1)`-unit sphere.
+    Resulting circuit parametrizes ``data`` in ``hyperspherical``, ``hopf``, or ``mottonen``
+    coordinates.
 
     Args:
         nqubits (int, optional): total number of qubits in the system.
         parametrization (str): choice of state parametrization in the :math:`(2^{n} - 1)`-unit
-            sphere. Either ``hyperspherical`` or ``hopf``. If ``data is None``, then circuit
-            returned parametrizes real-valued quantum states. To return circuits that parametrize
-            complex-valued states, options are ``hyperspherical-complex`` and ``hopf-complex``.
-            If ``data is not None``, then data type is inferred from ``data`` and the suffix
-            ``-complex`` does not need to be added. Defaults to ``hyperspherical``.
+            sphere. Either ``hyperspherical``, ``hopf``, or ``mottonen``. If ``data is None``,
+            then circuit returned parametrizes real-valued quantum states. To return circuits
+            that parametrize complex-valued states, options are ``hyperspherical-complex``,
+            ``hopf-complex``, and ``mottonen-complex``. If ``data is not None``, then data type
+            is inferred from ``data`` and the suffix ``-complex`` does not need to be added.
+            Defaults to ``hyperspherical``.
         data (ArrayLike, optional): :math:`1`-dimensional array of length :math:`d = 2^{n}`
             to be loaded in the amplitudes of a :math:`n`-qubit quantum state. If ``None``,
             circuit is returned with all phases set to :math:`0.0`. Defaults to ``None``.
@@ -95,6 +97,10 @@ def binary_encoder(
         solution of the polyharmonic equation and polyspherical addition theorems*, `Symmetry,
         Integrability and Geometry: Methods and Applications 10.3842/sigma.2013.042 (2013)
         <https://arxiv.org/abs/1209.6047>`_.
+
+        4. M. Möttönen, J. J. Vartiainen, V. Bergholm, and M. M. Salomaa,
+        *Transformation of quantum states using uniformly controlled rotations*,
+        `arXiv:quant-ph/0407010 (2004) <https://arxiv.org/abs/quant-ph/0407010>`_.
     """
 
     backend = _check_backend(backend)
@@ -122,6 +128,11 @@ def binary_encoder(
             )
 
         return _binary_encoder_hopf(
+            data, nqubits, complex_data=complex_data, backend=backend, **kwargs
+        )
+
+    if parametrization in ("mottonen", "mottonen-complex"):
+        return _binary_encoder_mottonen(
             data, nqubits, complex_data=complex_data, backend=backend, **kwargs
         )
 

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -110,7 +110,7 @@ def test_phase_encoder(backend, rotation, kind):
 @pytest.mark.parametrize("not_power_of_two", [False, True])
 @pytest.mark.parametrize("complex_data", [False, True])
 @pytest.mark.parametrize("data", [False, True])
-@pytest.mark.parametrize("parametrization", ["hopf", "hyperspherical"])
+@pytest.mark.parametrize("parametrization", ["hopf", "hyperspherical", "mottonen"])
 @pytest.mark.parametrize("nqubits", [3, 4, 5])
 def test_binary_encoder(
     backend,
@@ -148,6 +148,16 @@ def test_binary_encoder(
         if parametrization == "hyperspherical" and not_power_of_two
         else 2**nqubits
     )
+
+    if parametrization in ("mottonen", "mottonen-complex") and not_power_of_two:
+        pytest.skip("``mottonen`` parametrization requires data length to be a power of 2.")
+
+    if parametrization in ("mottonen", "mottonen-complex") and (
+        custom_codewords or keep_antictrls
+    ):
+        pytest.skip(
+            "``codewords`` and ``keep_antictrls`` are not used by the ``mottonen`` parametrization."
+        )
 
     if data:
         target = random_statevector(

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -150,7 +150,9 @@ def test_binary_encoder(
     )
 
     if parametrization in ("mottonen", "mottonen-complex") and not_power_of_two:
-        pytest.skip("``mottonen`` parametrization requires data length to be a power of 2.")
+        pytest.skip(
+            "``mottonen`` parametrization requires data length to be a power of 2."
+        )
 
     if parametrization in ("mottonen", "mottonen-complex") and (
         custom_codewords or keep_antictrls

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -150,6 +150,13 @@ def test_binary_encoder(
     )
 
     if parametrization in ("mottonen", "mottonen-complex") and not_power_of_two:
+        with pytest.raises(ValueError):
+            test = binary_encoder(
+                nqubits=nqubits,
+                data=backend.random_sample(5),
+                parametrization=parametrization,
+                backend=backend,
+            )
         pytest.skip(
             "``mottonen`` parametrization requires data length to be a power of 2."
         )


### PR DESCRIPTION
I added `Möttönen` as a third option for `binary_encoder(..., parametrization="mottonen")`, based on [arXiv:quant-ph/0407010](https://arxiv.org/abs/quant-ph/0407010). here i used same idea as paper, repare a target state from `|0⟩^n` with uniformly controlled Y rotations (amplitude magnitudes) and Z rotations (phases for complex data), using the Gray-code decomposition for the multi-controlled angles (Eq. 3).

closes #1845
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [X] Tests are passing.
- [X] Coverage does not decrease.
- [X] Documentation is updated.
