### PR TITLE
Add QuantumNaturalGradient optimizer to core qibo

### DIFF
--- a/doc/source/code-examples/advancedexamples.rst
+++ b/doc/source/code-examples/advancedexamples.rst
@@ -691,6 +691,49 @@ Here is a simple example using a custom loss function:
     circuit.set_parameters(params)
 
 
+Quantum Natural Gradient optimization
+-------------------------------------
+
+For parametrized circuits, :class:`qibo.optimizers.QuantumNaturalGradient` implements
+the update rule from Stokes et al. using
+:func:`qibo.quantum_info.quantum_fisher_information_matrix` as the metric tensor.
+
+The optimizer expects a loss function whose first two arguments are the circuit and
+backend. A Euclidean gradient function can be supplied explicitly; otherwise a
+central finite-difference gradient is used. The QFIM calculation requires a backend
+that supports automatic differentiation (for example ``qiboml`` with PyTorch, TensorFlow,
+or JAX).
+
+.. code-block:: python
+
+    import numpy as np
+
+    from qibo import Circuit, gates
+    from qibo.optimizers import QuantumNaturalGradient
+
+    circuit = Circuit(2)
+    circuit.add(gates.RY(0, theta=1.0))
+    circuit.add(gates.RY(1, theta=1.0))
+
+    def loss_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        target = np.asarray([0.0, -1.0])
+        return float(np.sum((params - target) ** 2))
+
+    def gradient_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        target = np.asarray([0.0, -1.0])
+        return 2 * (params - target)
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        gradient_fn=gradient_fn,
+        learning_rate=0.1,
+    )
+    final_loss, losses, final_params = optimizer(steps=20)
+
+
 .. _qaoa-example:
 
 How to use the QAOA?

--- a/src/qibo/optimizers.py
+++ b/src/qibo/optimizers.py
@@ -2,6 +2,15 @@ import numpy as np
 
 from qibo.config import log, raise_error
 
+__all__ = [
+    "ParallelBFGS",
+    "QuantumNaturalGradient",
+    "cmaes",
+    "newtonian",
+    "optimize",
+    "sgd",
+]
+
 
 def optimize(
     loss,
@@ -443,3 +452,263 @@ class ParallelBFGS:  # pragma: no cover
     def jac(self, x):
         self.evaluate(x)
         return self.jacobian_value
+
+
+class QuantumNaturalGradient:
+    r"""Quantum Natural Gradient optimizer for parametrized circuits.
+
+    Implements the Quantum Natural Gradient update rule
+
+    .. math::
+
+        \theta_{t + 1} = \theta_t - \eta (F(\theta_t) + \lambda I)^+ \nabla L,
+
+    where :math:`F(\theta)` is the quantum Fisher information matrix (QFIM).
+
+    Args:
+        circuit (:class:`qibo.models.circuit.Circuit`): Parametrized circuit to optimize.
+        loss_fn (Callable): Loss function. The first two arguments must be the circuit
+            and backend used for execution.
+        loss_kwargs (dict, optional): Additional keyword arguments for ``loss_fn``.
+        initial_parameters (ArrayLike, optional): Initial circuit parameters. If ``None``,
+            the parameters already stored in ``circuit`` are used.
+        gradient_fn (Callable, optional): Function returning the Euclidean gradient with
+            respect to the circuit parameters. The first two arguments must be the circuit
+            and backend. If ``None``, a central finite-difference gradient is used.
+        gradient_kwargs (dict, optional): Additional keyword arguments for
+            ``gradient_fn``.
+        learning_rate (float, optional): QNG step size. Defaults to ``0.01``.
+        regularization (float, optional): Non-negative diagonal regularization added to
+            the QFIM before solving the natural-gradient system. Defaults to ``1e-8``.
+        finite_difference_epsilon (float, optional): Shift used when ``gradient_fn`` is
+            not provided. Defaults to ``1e-6``.
+        qfim_kwargs (dict, optional): Additional keyword arguments passed to
+            :func:`qibo.quantum_info.quantum_fisher_information_matrix`, such as
+            ``initial_state`` or ``return_complex``.
+        callback (Callable, optional): Function called after every optimization step with
+            keyword arguments ``iter_num``, ``loss``, ``parameters``, and
+            ``natural_gradient``.
+        backend (:class:`qibo.backends.abstract.Backend`, optional): Execution backend.
+            If ``None``, the current qibo backend is used.
+
+    References:
+        J. Stokes, J. Izaac, N. Killoran, and G. Carleo, *Quantum Natural Gradient*,
+        `Quantum 4, 269 (2020) <https://doi.org/10.22331/q-2020-05-25-269>`_.
+    """
+
+    def __init__(
+        self,
+        circuit,
+        loss_fn,
+        loss_kwargs=None,
+        initial_parameters=None,
+        gradient_fn=None,
+        gradient_kwargs=None,
+        learning_rate=0.01,
+        regularization=1e-8,
+        finite_difference_epsilon=1e-6,
+        qfim_kwargs=None,
+        callback=None,
+        backend=None,
+    ):
+        from qibo.backends import _check_backend
+        from qibo.models.circuit import Circuit
+
+        if not isinstance(circuit, Circuit):
+            raise_error(
+                TypeError,
+                "``circuit`` must be an instance of ``qibo.models.circuit.Circuit``.",
+            )
+        if not callable(loss_fn):
+            raise_error(TypeError, "``loss_fn`` must be callable.")
+        if gradient_fn is not None and not callable(gradient_fn):
+            raise_error(TypeError, "``gradient_fn`` must be callable or ``None``.")
+        if learning_rate <= 0:
+            raise_error(ValueError, "``learning_rate`` must be positive.")
+        if regularization < 0:
+            raise_error(ValueError, "``regularization`` must be non-negative.")
+        if finite_difference_epsilon <= 0:
+            raise_error(ValueError, "``finite_difference_epsilon`` must be positive.")
+
+        self.circuit = circuit
+        self.loss_fn = loss_fn
+        self.loss_kwargs = {} if loss_kwargs is None else loss_kwargs
+        self.gradient_fn = gradient_fn
+        self.gradient_kwargs = {} if gradient_kwargs is None else gradient_kwargs
+        self.learning_rate = learning_rate
+        self.regularization = regularization
+        self.finite_difference_epsilon = finite_difference_epsilon
+        self.qfim_kwargs = {} if qfim_kwargs is None else qfim_kwargs
+        self.callback = callback
+        self.backend = _check_backend(backend)
+
+        self.n_calls_loss = 0
+        self.n_calls_gradient = 0
+        self.n_calls_qfim = 0
+
+        if initial_parameters is not None:
+            self.circuit.set_parameters(self._as_flat_array(initial_parameters))
+
+        self.parameters = self.current_parameters()
+        if len(self.parameters) == 0:
+            raise_error(
+                ValueError,
+                "``QuantumNaturalGradient`` requires a parametrized circuit.",
+            )
+
+    def _as_flat_array(self, values):
+        if hasattr(self.backend, "to_numpy"):
+            values = self.backend.to_numpy(values)
+        return np.asarray(values, dtype=float).reshape(-1)
+
+    def _as_scalar(self, value):
+        if hasattr(self.backend, "to_numpy"):
+            value = self.backend.to_numpy(value)
+        return float(np.asarray(value).reshape(()))
+
+    def current_parameters(self):
+        """Return current circuit parameters as a flat NumPy array."""
+        return self._as_flat_array(
+            self.circuit.get_parameters(output_format="flatlist")
+        )
+
+    def loss(self, circuit=None, backend=None):
+        """Evaluate the loss and increment the loss-call counter."""
+        self.n_calls_loss += 1
+        if circuit is None:
+            circuit = self.circuit
+        if backend is None:
+            backend = self.backend
+        return self._as_scalar(self.loss_fn(circuit, backend, **self.loss_kwargs))
+
+    def metric_tensor(self):
+        """Calculate the QFIM for the current circuit parameters."""
+        from qibo.quantum_info import quantum_fisher_information_matrix
+
+        parameters = self.current_parameters()
+        qfim_parameters = self.backend.cast(parameters, dtype=self.backend.float64)
+        kwargs = dict(self.qfim_kwargs)
+        self.n_calls_qfim += 1
+        try:
+            metric = quantum_fisher_information_matrix(
+                self.circuit,
+                parameters=qfim_parameters,
+                backend=self.backend,
+                **kwargs,
+            )
+        except NotImplementedError as exc:
+            raise NotImplementedError(
+                "``QuantumNaturalGradient`` requires a qibo backend whose "
+                + "``quantum_fisher_information_matrix`` supports automatic "
+                + "differentiation, or a custom compatible backend. "
+                + f"Current backend platform is {self.backend.platform!r}."
+            ) from exc
+
+        metric = self._as_flat_matrix(metric)
+        if metric.shape != (len(parameters), len(parameters)):
+            raise_error(
+                ValueError,
+                "The QFIM shape must match the number of trainable parameters. "
+                + f"Expected {(len(parameters), len(parameters))}, got {metric.shape}.",
+            )
+        return metric
+
+    def _as_flat_matrix(self, values):
+        if hasattr(self.backend, "to_numpy"):
+            values = self.backend.to_numpy(values)
+        values = np.asarray(values, dtype=float)
+        if values.ndim != 2:
+            raise_error(ValueError, "The QFIM must be a two-dimensional matrix.")
+        return values
+
+    def gradient(self):
+        """Return the Euclidean gradient of the loss."""
+        self.n_calls_gradient += 1
+        if self.gradient_fn is not None:
+            gradient = self.gradient_fn(
+                self.circuit, self.backend, **self.gradient_kwargs
+            )
+            gradient = self._as_flat_array(gradient)
+        else:
+            gradient = self._finite_difference_gradient()
+
+        if len(gradient) != len(self.current_parameters()):
+            raise_error(
+                ValueError,
+                "The gradient length must match the number of trainable parameters. "
+                + f"Expected {len(self.current_parameters())}, got {len(gradient)}.",
+            )
+        return gradient
+
+    def _finite_difference_gradient(self):
+        params = self.current_parameters()
+        gradient = np.zeros_like(params, dtype=float)
+        epsilon = self.finite_difference_epsilon
+
+        for index in range(len(params)):
+            shifted = params.copy()
+            shifted[index] += epsilon
+            self.circuit.set_parameters(shifted)
+            loss_plus = self.loss()
+
+            shifted[index] -= 2 * epsilon
+            self.circuit.set_parameters(shifted)
+            loss_minus = self.loss()
+
+            gradient[index] = (loss_plus - loss_minus) / (2 * epsilon)
+
+        self.circuit.set_parameters(params)
+        return gradient
+
+    def natural_gradient(self):
+        """Solve the regularized QNG linear system."""
+        metric = self.metric_tensor()
+        gradient = self.gradient()
+        if self.regularization:
+            metric = metric + self.regularization * np.eye(len(gradient))
+
+        try:
+            return np.linalg.solve(metric, gradient)
+        except np.linalg.LinAlgError:
+            return np.linalg.pinv(metric) @ gradient
+
+    def run(self, steps=100):
+        """Run QNG optimization for ``steps`` iterations.
+
+        Args:
+            steps (int, optional): Number of optimization iterations. Defaults to ``100``.
+
+        Returns:
+            Tuple with final loss, loss history, and final parameters.
+        """
+        if steps < 0:
+            raise_error(ValueError, "``steps`` must be non-negative.")
+
+        losses = [self.loss()]
+        for iter_num in range(steps):
+            params = self.current_parameters()
+            natural_gradient = self.natural_gradient()
+            updated_parameters = params - self.learning_rate * natural_gradient
+            self.circuit.set_parameters(updated_parameters)
+
+            loss_value = self.loss()
+            losses.append(loss_value)
+
+            if self.callback is not None:
+                self.callback(
+                    iter_num=iter_num + 1,
+                    loss=loss_value,
+                    parameters=updated_parameters,
+                    natural_gradient=natural_gradient,
+                )
+
+        self.parameters = self.current_parameters()
+        return (
+            losses[-1],
+            self.backend.cast(losses, dtype=self.backend.float64),
+            self.backend.cast(self.parameters, dtype=self.backend.float64),
+        )
+
+    def __call__(self, steps=100):
+        """Run QNG optimization for ``steps`` iterations."""
+        return self.run(steps=steps)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,172 @@
+"""Tests for qibo.optimizers."""
+
+import numpy as np
+import pytest
+
+from qibo import Circuit, gates
+from qibo.backends import NumpyBackend
+from qibo.optimizers import QuantumNaturalGradient
+
+
+def test_quantum_natural_gradient_uses_qfim(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(2)
+    circuit.add(gates.RY(0, theta=1.0))
+    circuit.add(gates.RZ(1, theta=1.0))
+    qfim_calls = []
+
+    def loss_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        target = np.asarray([0.0, -1.0])
+        return float(np.sum((params - target) ** 2))
+
+    def gradient_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        target = np.asarray([0.0, -1.0])
+        return 2 * (params - target)
+
+    def qfim(circuit, parameters=None, **kwargs):
+        qfim_calls.append(np.asarray(parameters))
+        return np.diag([2.0, 4.0])
+
+    import qibo.quantum_info as quantum_info
+
+    monkeypatch.setattr(quantum_info, "quantum_fisher_information_matrix", qfim)
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        gradient_fn=gradient_fn,
+        learning_rate=0.5,
+        regularization=0.0,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.5, 0.5])
+    assert final_loss < losses[0]
+    assert optimizer.n_calls_qfim == 1
+    np.testing.assert_allclose(qfim_calls[0], [1.0, 1.0])
+
+
+def test_quantum_natural_gradient_regularizes_singular_qfim(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(2)
+    circuit.add(gates.RY(0, theta=1.0))
+    circuit.add(gates.RZ(1, theta=1.0))
+
+    def loss_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        return float(np.sum(params**2))
+
+    def gradient_fn(circuit, backend):
+        return np.asarray([1.0, 2.0])
+
+    import qibo.quantum_info as quantum_info
+
+    monkeypatch.setattr(
+        quantum_info,
+        "quantum_fisher_information_matrix",
+        lambda *args, **kwargs: np.zeros((2, 2)),
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        gradient_fn=gradient_fn,
+        learning_rate=0.25,
+        regularization=1.0,
+        backend=backend,
+    )
+    _, _, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.75, 0.5])
+
+
+def test_quantum_natural_gradient_finite_difference_gradient(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(1)
+    circuit.add(gates.RY(0, theta=0.4))
+
+    def loss_fn(circuit, backend):
+        param = circuit.get_parameters(output_format="flatlist")[0]
+        return float(param**2)
+
+    import qibo.quantum_info as quantum_info
+
+    monkeypatch.setattr(
+        quantum_info,
+        "quantum_fisher_information_matrix",
+        lambda *args, **kwargs: np.eye(1),
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        learning_rate=0.1,
+        regularization=0.0,
+        finite_difference_epsilon=1e-7,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.32], atol=1e-6)
+    assert final_loss < losses[0]
+    assert optimizer.n_calls_gradient == 1
+
+
+def test_quantum_natural_gradient_uses_separate_gradient_kwargs(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(1)
+    circuit.add(gates.RY(0, theta=1.0))
+
+    def loss_fn(circuit, backend, offset):
+        param = circuit.get_parameters(output_format="flatlist")[0]
+        return float((param - offset) ** 2)
+
+    def gradient_fn(circuit, backend, scale):
+        param = circuit.get_parameters(output_format="flatlist")[0]
+        return np.asarray([scale * param])
+
+    import qibo.quantum_info as quantum_info
+
+    monkeypatch.setattr(
+        quantum_info,
+        "quantum_fisher_information_matrix",
+        lambda *args, **kwargs: np.eye(1),
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        loss_kwargs={"offset": 0.0},
+        gradient_fn=gradient_fn,
+        gradient_kwargs={"scale": 3.0},
+        learning_rate=0.1,
+        regularization=0.0,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.7])
+    assert final_loss < losses[0]
+
+
+def test_quantum_natural_gradient_errors():
+    backend = NumpyBackend()
+    circuit = Circuit(1)
+
+    with pytest.raises(ValueError):
+        _ = QuantumNaturalGradient(
+            circuit, loss_fn=lambda circuit, backend: 0, backend=backend
+        )
+
+    circuit.add(gates.RY(0, theta=0.1))
+
+    with pytest.raises(ValueError):
+        _ = QuantumNaturalGradient(
+            circuit,
+            loss_fn=lambda circuit, backend: 0,
+            learning_rate=0,
+            backend=backend,
+        )


### PR DESCRIPTION
## Summary
- add `QuantumNaturalGradient` to `qibo.optimizers` for parametrized circuits
- use `quantum_fisher_information_matrix` as the QNG metric tensor with diagonal regularization
- support user-provided Euclidean gradients, separate gradient kwargs, and central finite-difference fallback
- add focused optimizer tests with mocked QFIM evaluation

Addresses the unitaryHACK 2026 bounty: **Add QuantumNaturalGradient to optimizers** ([Qibo project page](https://unitaryhack.dev/projects/qibo/)).

A related implementation already exists in `qiboml`; this PR brings the optimizer into core Qibo so users can use QNG without the ML stack.

## Test plan
- [x] `pytest tests/test_optimizers.py -o addopts=''`
- [ ] maintainer review of API parity with existing `optimize()` helpers


Made with [Cursor](https://cursor.com)