### PR TITLE
Fix collapse_state TypeError under numpy >= 2.4

### DIFF
--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -3263,7 +3263,8 @@ class Backend:  # pylint: disable=R0904
         state = self.reshape(state, 2 * nqubits * (2,))
         state = self.transpose(state, order)
         subshape = 2 * (2 ** len(qubits),) + 2 * (nqubits - len(qubits)) * (2,)
-        state = self.reshape(state, subshape)[int(shot), int(shot)]
+        shot = int(shot[0])
+        state = self.reshape(state, subshape)[shot, shot]
         dims = 2 ** (len(state.shape) // 2)
 
         if normalize:
@@ -3292,7 +3293,7 @@ class Backend:  # pylint: disable=R0904
         ]
         state = self.transpose(state, order)
         subshape = (2 ** len(qubits),) + (nqubits - len(qubits)) * (2,)
-        state = self.reshape(state, subshape)[int(shot)]
+        state = self.reshape(state, subshape)[int(shot[0])]
 
         if normalize:
             norm = self.sqrt(self.sum(self.abs(state) ** 2))

--- a/tests/test_measurements_collapse.py
+++ b/tests/test_measurements_collapse.py
@@ -26,6 +26,31 @@ def test_measurement_collapse(backend, nqubits, targets):
 
 
 @pytest.mark.parametrize(
+    "nqubits,targets",
+    [(2, [1]), (3, [1]), (4, [1, 3]), (5, [0, 3, 4])],
+)
+def test_measurement_collapse_density_matrix_state(backend, nqubits, targets):
+    """``Backend._collapse_density_matrix`` execution, as opposed to the
+    ``target_rho`` bookkeeping covered by ``test_measurement_collapse_density_matrix``
+    below (skipped). Regression test for the ``int(shot)`` call on the
+    1-element array returned by ``sample_shots``, which numpy >= 2.4 no
+    longer converts implicitly.
+    """
+    initial_state = random_density_matrix(2**nqubits, backend=backend)
+    circuit = Circuit(nqubits, density_matrix=True)
+    r = circuit.add(gates.M(*targets, collapse=True))
+    circuit.add(gates.M(*targets))
+    outcome = backend.execute_circuit(
+        circuit,
+        backend.cast(initial_state, dtype=initial_state.dtype, copy=True),
+        nshots=1,
+    )
+    samples = r.samples()[0]
+    backend.assert_allclose(samples, outcome.samples()[0])
+    backend.assert_allclose(backend.trace(outcome.state()), 1, atol=1e-6)
+
+
+@pytest.mark.parametrize(
     "nqubits,targets", [(2, [1]), (3, [1]), (4, [1, 3]), (5, [0, 3, 4])]
 )
 def test_measurement_collapse_density_matrix(backend, nqubits, targets):


### PR DESCRIPTION
## Bug

`gates.M(..., collapse=True)` (mid-circuit measurement/collapse) crashes under numpy >= 2.4 with:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

## Cause

`MeasurementResult.add_shot` returns `backend.sample_shots(probs, 1)`, which is a 1-element array (`np.random.choice(..., size=1, ...)`), never a 0-d array or Python scalar. `Backend._collapse_statevector` and `Backend._collapse_density_matrix` then do `int(shot)` on it to use as an index.

numpy < 2.4 allowed `int()` on a size-1 non-0-d array (deprecated since numpy 1.25, `DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated...`). numpy 2.4.0 made this a hard `TypeError`, so any circuit using mid-circuit collapse measurement now fails outright on current numpy.

Reproduce on master:

```python
from qibo import Circuit, gates

qc = Circuit(2)
qc.add(gates.H(0))
qc.add(gates.CNOT(0, 1))
qc.add(gates.M(0, collapse=True))
qc.add(gates.M(0, 1))
qc(nshots=100)  # TypeError: only 0-dimensional arrays can be converted to Python scalars
```

## Fix

Extract the scalar explicitly with `shot[0]` instead of relying on the deprecated implicit conversion, in both `_collapse_statevector` and `_collapse_density_matrix`.

## Tests

- `tests/test_measurements_collapse.py::test_measurement_collapse` (existing, statevector path) already covers `_collapse_statevector` and was failing under numpy 2.4+ before this fix.
- Added `test_measurement_collapse_density_matrix_state` for `_collapse_density_matrix`, since the existing density-matrix test (`test_measurement_collapse_density_matrix`) is already skipped for an unrelated reason ("Problems with collapsing measurement and repeated execution") and nothing else in the suite exercises that path with real assertions.

Ran locally under numpy 2.4.6 (numpy's first release where the old behavior became a hard error): both new/existing collapse tests pass; full `tests/test_measurements*.py`, `tests/test_models_circuit*.py`, `tests/test_result.py`, `tests/test_backends_hamming_weight.py` (numpy backend) pass except two pre-existing, unrelated failures in `test_models_circuit_noise.py::test_probabilities_repeated_execution` (a separate numpy-2.4 issue in `quantum_info/_quantum_info.py`'s `_fill_tril`, present identically with or without this change — happy to file that separately).
