### PR TITLE
Fanout and CNOT-ladder synthesis in `log(n)` depth

### DIFF
--- a/doc/source/api-reference/qibo.rst
+++ b/doc/source/api-reference/qibo.rst
@@ -297,10 +297,22 @@ Graph state
 .. autofunction:: qibo.models.encodings.graph_state
 
 
+Fanout gate synthesis in log depth
+""""""""""""""""""""""""""""""""""
+
+.. autofunction:: qibo.models.encodings.fanout_synthesis
+
+
 Fixed Hamming-weight Encoder
 """"""""""""""""""""""""""""
 
 .. autofunction:: qibo.models.encodings.hamming_weight_encoder
+
+
+CNOT ladder synthesis in log depth
+""""""""""""""""""""""""""""""""""
+
+.. autofunction:: qibo.models.encodings.ladder_synthesis
 
 
 Permutation synthesis

--- a/src/qibo/models/__init__.py
+++ b/src/qibo/models/__init__.py
@@ -8,6 +8,7 @@ from qibo.models.encodings import (
     ghz_state,
     graph_state,
     hamming_weight_encoder,
+    ladder_synthesis,
     permutation_synthesis,
     phase_encoder,
     sparse_encoder,

--- a/src/qibo/models/__init__.py
+++ b/src/qibo/models/__init__.py
@@ -5,6 +5,7 @@ from qibo.models.encodings import (
     comp_basis_encoder,
     dicke_state,
     entangling_layer,
+    fanout_synthesis,
     ghz_state,
     graph_state,
     hamming_weight_encoder,

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -953,7 +953,7 @@ def _ladder_synthesis(qubits: int):
     if nqubits % 2 == 0:
         qubits_prime.append(qubits[-2])
 
-    return left + ladder_synth(qubits_prime) + right
+    return left + _ladder_synth(qubits_prime) + right
 
 
 def _monotonic_hw_encoder_complex(

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -933,7 +933,7 @@ def _get_phase_gate_correction_sparse(
     return gate
 
 
-def _ladder_synthesis(qubits: int):
+def _ladder_synthesis(qubits: int) -> list[Gate]:
     nqubits = len(qubits)
 
     if nqubits == 1:
@@ -953,7 +953,7 @@ def _ladder_synthesis(qubits: int):
     if nqubits % 2 == 0:
         qubits_prime.append(qubits[-2])
 
-    return left + _ladder_synth(qubits_prime) + right
+    return left + _ladder_synthesis(qubits_prime) + right
 
 
 def _monotonic_hw_encoder_complex(

--- a/src/qibo/models/_encodings.py
+++ b/src/qibo/models/_encodings.py
@@ -933,6 +933,29 @@ def _get_phase_gate_correction_sparse(
     return gate
 
 
+def _ladder_synthesis(qubits: int):
+    nqubits = len(qubits)
+
+    if nqubits == 1:
+        return []
+
+    if nqubits == 2:
+        return [gates.CNOT(qubits[0], qubits[1])]
+
+    qubits_prime = [qubits[1]]
+    left = [gates.CNOT(qubits[-2], qubits[-1])]
+    right = [gates.CNOT(qubits[0], qubits[1])]
+    for j in range(1, int(math.ceil(nqubits / 2)) - 2 + 1):
+        left.append(gates.CNOT(qubits[2 * j - 1], qubits[2 * j]))
+        right.append(gates.CNOT(qubits[2 * j], qubits[2 * j + 1]))
+        qubits_prime.append(qubits[2 * j + 1])
+
+    if nqubits % 2 == 0:
+        qubits_prime.append(qubits[-2])
+
+    return left + ladder_synth(qubits_prime) + right
+
+
 def _monotonic_hw_encoder_complex(
     codewords: List[int],
     data: ArrayLike,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -23,6 +23,7 @@ from qibo.models._encodings import (  # _up_to_k_hamming_weight_encoder_deprecat
     _generate_rbs_pairs,
     _get_gate,
     _get_phase_gate_correction,
+    _ladder_synthesis,
     _non_trivial_layers,
     _parametrized_two_qubit_gate,
     _perm_column_ops,
@@ -657,6 +658,57 @@ def hamming_weight_encoder(
 
     if complex_data and phase_correction:
         circuit.add(_get_phase_gate_correction(bitstrings[-1], phis[-1]))
+
+    return circuit
+
+
+def ladder_synthesis(
+    qubits: list[int] | tuple[int],
+    nqubits: Optional[int] = None,
+    return_circuit: bool = False,
+    **kwargs,
+):
+    """Synthesis of the CNOT ladder operator in logarithmic depth.
+
+    Implementation based on Ref. [1, Algorithm 1].
+
+    Args:
+        qubits (list[int] | tuple[int]): qubits in which the CNOT ladder acts on.
+        nqubits (int, optional): total number of qubits in the circuit. To be used when
+            `return_circuit=True` and the total number of qubits differ from `len(qubits)`.
+            Defaults to ``None``.
+        return_circuit (bool, optional): if ``True``, returns a :class:`qibo.models.circuit.Circuit`
+            class. If ``False``, returns a list with the sequence of :class:`qibo.gates.CNOT` gates
+            in parallel. Defaults to ``False``.
+
+    Returns:
+        list or :class:`qibo.models.circuit.Circuit`: List of gates or circuit containing the
+        sequence of gates.
+
+    References:
+        1. M. Remaud and V. Vanndaele, *Ancilla-free quantum adder with sublinear depth*,
+        `In: Glück, R., Kaarsgaard, R. (eds) Reversible Computation. RC 2025.
+        Lecture Notes in Computer Science, vol 15716.
+        Springer, Cham. (2025) <https://doi.org/10.1103/PhysRevApplied.23.044014>`_.
+
+    """
+    queue = _ladder_synthesis(qubits)
+
+    if not return_circuit:
+        return queue
+
+    if nqubits is None:
+        if set(qubits) != set(range(len(qubits))):
+            raise_error(
+                ValueError,
+                "`nqubits` must be specified when `return_circuit=True`"
+                + "and `set(qubits) != set(range(len(qubits)))`.",
+            )
+
+        nqubits = len(qubits)
+
+    circuit = Circuit(nqubits, **kwargs)
+    circuit.add(queue)
 
     return circuit
 

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -454,6 +454,49 @@ def entangling_layer(
     return circuit
 
 
+def fanout_synthesis(
+    qubits: list[int] | tuple[int],
+    nqubits: Optional[int] = None,
+    **kwargs,
+) -> Circuit:
+    """Synthesis of the Fanout gate in logarithmic depth.
+
+    Implementation based on applying Ref. [1, Algorithm 1] twice.
+
+    Args:
+        qubits (list[int] | tuple[int]): qubits in which the CNOT ladder acts on.
+        nqubits (int, optional): total number of qubits in the circuit. To be used when
+            the total number of qubits differ from `len(qubits)`. Defaults to ``None``.
+
+    Returns:
+        :class:`qibo.models.circuit.Circuit`: Circuit containing the sequence of gates in parallel.
+
+    References:
+        1. M. Remaud and V. Vanndaele, *Ancilla-free quantum adder with sublinear depth*,
+        `In: Glück, R., Kaarsgaard, R. (eds) Reversible Computation. RC 2025.
+        Lecture Notes in Computer Science, vol 15716.
+        Springer, Cham. (2025) <https://doi.org/10.1103/PhysRevApplied.23.044014>`_.
+
+    """
+
+    if nqubits is None:
+        if set(qubits) != set(range(len(qubits))):
+            raise_error(
+                ValueError,
+                "`nqubits` must be specified when `set(qubits) != set(range(len(qubits)))`.",
+            )
+
+        nqubits = len(qubits)
+
+    fanout = Circuit(nqubits, **kwargs)
+    queue = ladder_synthesis(qubits, return_circuit=False)
+    fanout.add(queue)
+    qeue = ladder_synthesis(qubits[1:], return_circuit=False)
+    fanout.add(queue[::-1])
+
+    return fanout
+
+
 def ghz_state(nqubits: int, **kwargs) -> Circuit:
     """Generate an :math:`n`-qubit Greenberger-Horne-Zeilinger (GHZ) state that takes the form
 
@@ -667,7 +710,7 @@ def ladder_synthesis(
     nqubits: Optional[int] = None,
     return_circuit: bool = False,
     **kwargs,
-):
+) -> list[Gate] | Circuit:
     """Synthesis of the CNOT ladder operator in logarithmic depth.
 
     Implementation based on Ref. [1, Algorithm 1].

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -11,6 +11,7 @@ from scipy.special import binom
 from qibo import gates
 from qibo.backends import Backend, _check_backend
 from qibo.config import log, raise_error
+from qibo.gates.abstract import Gate
 from qibo.models._encodings import (  # _up_to_k_hamming_weight_encoder_deprecated,
     _add_dicke_unitary_gate,
     _add_wbd_gate,

--- a/src/qibo/models/encodings.py
+++ b/src/qibo/models/encodings.py
@@ -492,7 +492,7 @@ def fanout_synthesis(
     fanout = Circuit(nqubits, **kwargs)
     queue = ladder_synthesis(qubits, return_circuit=False)
     fanout.add(queue)
-    qeue = ladder_synthesis(qubits[1:], return_circuit=False)
+    queue = ladder_synthesis(qubits[1:], return_circuit=False)
     fanout.add(queue[::-1])
 
     return fanout

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -26,6 +26,7 @@ from qibo.models.encodings import (
     ghz_state,
     graph_state,
     hamming_weight_encoder,
+    ladder_synthesis,
     permutation_synthesis,
     phase_encoder,
     sparse_encoder,
@@ -786,6 +787,14 @@ def test_graph_state(backend, matrix, expects_error, circuit1, circuit2):
 
 @pytest.mark.parametrize("nqubits", [6, 8, 10])
 def test_fanout_synthesis(backend, nqubits):
+    with pytest.raises(ValueError):
+        qubits = [0, 1, 3]
+        test = ladder_synthesis(qubits, return_circuit=True)
+
+    with pytest.raises(ValueError):
+        qubits = [0, 1, 3]
+        test = fanout_synthesis(qubits)
+
     qubits = list(range(nqubits))
 
     fanout = fanout_synthesis(qubits)

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -784,7 +784,7 @@ def test_graph_state(backend, matrix, expects_error, circuit1, circuit2):
         backend.assert_circuitclose(circuit, target)
 
 
-@pytest.mark.parametrize(nqubits, [6, 8, 10])
+@pytest.mark.parametrize("nqubits", [6, 8, 10])
 def test_fanout_synthesis(backend, nqubits):
     qubits = list(range(nqubits))
 

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -22,6 +22,7 @@ from qibo.models.encodings import (
     comp_basis_encoder,
     dicke_state,
     entangling_layer,
+    fanout_synthesis,
     ghz_state,
     graph_state,
     hamming_weight_encoder,
@@ -781,3 +782,14 @@ def test_graph_state(backend, matrix, expects_error, circuit1, circuit2):
 
         circuit = graph_state(matrix)
         backend.assert_circuitclose(circuit, target)
+
+
+@pytest.mark.parametrize(nqubits, [6, 8, 10])
+def test_fanout_synthesis(backend, nqubits):
+    qubits = list(range(nqubits))
+
+    fanout = fanout_synthesis(qubits)
+
+    target = gates.FanOut(*qubits).matrix(backend)
+
+    backend.assert_allclose(fanout.unitary(backend), target)

--- a/tests/test_models_encodings.py
+++ b/tests/test_models_encodings.py
@@ -786,7 +786,7 @@ def test_graph_state(backend, matrix, expects_error, circuit1, circuit2):
 
 
 @pytest.mark.parametrize("nqubits", [6, 8, 10])
-def test_fanout_synthesis(backend, nqubits):
+def test_fanout_and_ladder_synthesis(backend, nqubits):
     with pytest.raises(ValueError):
         qubits = [0, 1, 3]
         test = ladder_synthesis(qubits, return_circuit=True)
@@ -796,9 +796,12 @@ def test_fanout_synthesis(backend, nqubits):
         test = fanout_synthesis(qubits)
 
     qubits = list(range(nqubits))
-
     fanout = fanout_synthesis(qubits)
-
     target = gates.FanOut(*qubits).matrix(backend)
-
     backend.assert_allclose(fanout.unitary(backend), target)
+
+    ladder = ladder_synthesis(qubits, return_circuit=True)
+    target = Circuit(nqubits)
+    target.add(gates.CNOT(qubit, qubit + 1) for qubit in range(nqubits - 1))
+    target = target.invert()
+    backend.assert_allclose(ladder.unitary(backend), target.unitary(backend))


### PR DESCRIPTION
Gate synthesis for `fanout` gate as well as CNOT ladders in $\log(n)$ depth.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
