### PR TITLE
fix: handle einsum_path contraction tuple format change in numpy 2.4

### DIFF
--- a/src/qibo/quantum_info/quantum_networks.py
+++ b/src/qibo/quantum_info/quantum_networks.py
@@ -1024,9 +1024,29 @@ def link_product(
         subscripts, *tensors, optimize=False, einsum_call=True
     )
 
-    inds, idx_rm, einsum_str, _, _ = contracrtion_list[0]
+    # the einsum_path contraction tuple changed from 5 to 3 elements in
+    # numpy 2.4: numpy <= 2.3 returns
+    # (contract_inds, idx_removed, einsum_str, remaining, do_blas), while
+    # numpy >= 2.4 returns (contract_inds, einsum_str, remaining)
+    contraction = contracrtion_list[0]
+    if len(contraction) == 5:
+        inds, idx_rm, einsum_str, _, _ = contraction
+    elif len(contraction) == 3:
+        inds, einsum_str, _ = contraction
+    else:
+        raise ValueError(
+            "Unexpected einsum_path contraction tuple "
+            f"of length {len(contraction)}: {contraction}"
+        )
+
     input_str, results_index = einsum_str.split("->")
     inputs = input_str.split(",")
+
+    if len(contraction) == 3:
+        # `idx_removed` was dropped in numpy 2.4: reconstruct it as the
+        # indices appearing on the left-hand side of `einsum_str` that do not
+        # appear on the right-hand side (its exact former definition)
+        idx_rm = set(input_str.replace(",", "")) - set(results_index)
 
     # Warning if the same index connects two input or two output systems
     if not surpress_warning:


### PR DESCRIPTION
Fixes #1870

## Problem

numpy 2.4 reduced the `einsum_path` contraction tuple from **5 to 3 elements**: `(contract_inds, idx_removed, einsum_str, remaining, do_blas)` became `(contract_inds, einsum_str, remaining)`, dropping `idx_removed` and `do_blas` (numpy/einsumfunc.py, `einsum_path`). The 5-element unpack in `link_product` then raises on numpy >= 2.4:

```
ValueError: not enough values to unpack (expected 5, got 3)
```

qibo declares `numpy = "^2.0.0"`, so numpy 2.4+ is a fully allowed version — this is a regression for legal installs, not an exotic environment.

## Fix

Inspect the tuple length rather than parsing the numpy version string (robust across forks and backports), and reconstruct `idx_removed` from the remaining fields:

- numpy <= 2.3: unpack the 5-element tuple as before (`idx_removed` is provided).
- numpy >= 2.4: `idx_removed` is the set of indices appearing on the left-hand side of `einsum_str` that do not appear on the right-hand side — its exact former definition (`idx_contract - new_result` in numpy's `_find_contraction`), computable directly from `einsum_str`.

```python
contraction = contracrtion_list[0]
if len(contraction) == 5:
    inds, idx_rm, einsum_str, _, _ = contraction
elif len(contraction) == 3:
    inds, einsum_str, _ = contraction
else:
    raise ValueError(
        "Unexpected einsum_path contraction tuple "
        f"of length {len(contraction)}: {contraction}"
    )

input_str, results_index = einsum_str.split("->")
inputs = input_str.split(",")

if len(contraction) == 3:
    idx_rm = set(input_str.replace(",", "")) - set(results_index)
```

## Verification

Ran `tests/test_quantum_info_quantum_networks.py` (numpy backend) on both tuple formats:

| numpy | contraction tuple | result |
|-------|------------------|--------|
| 2.3.3 | 5 elements | 13/13 passed |
| 2.5.2 | 3 elements | 13/13 passed |

Control on the unfixed code with numpy 2.5.2: **6 failed, 7 passed** — the six `link_product`-exercising tests (`test_with_states`, `test_with_unitaries`, `test_with_comb`, `test_predefined`, ...) crash with the unpack `ValueError`, confirming the tests cover the regression.

`idx_rm` equivalence: on numpy 2.3.3 the reconstructed value matches numpy's own `idx_removed` exactly for all subscripts used in the tests (`ij, kj->ik`, `ii->i`, `ij, jj->i`, `ij, jj, jj->i`, `ij,j->i`, `ab,bc,cd->ad`), and on numpy 2.5.2 the same derived values are produced.

No behavioral change on numpy <= 2.3 (identical unpack); `idx_rm` remains a `set`, as before.